### PR TITLE
Fix main compilation by adding the missing include 

### DIFF
--- a/src/tests/test_ind_util.h
+++ b/src/tests/test_ind_util.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <list>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
Compilation failed due to missing #include\<set\> in src/tests/test_ind_util.h. GCC 13.2.0