### PR TITLE
Remove parser trimming space symbols at string end

### DIFF
--- a/src/core/parser/csv_parser/csv_parser.cpp
+++ b/src/core/parser/csv_parser/csv_parser.cpp
@@ -12,7 +12,7 @@
 #include <boost/tokenizer.hpp>
 
 inline std::string& CSVParser::Rtrim(std::string& s) {
-    boost::trim_right(s);
+    if (!s.empty() && s.back() == '\n') s.pop_back();
     return s;
 }
 


### PR DESCRIPTION
The current approach does not work for TSVs with empty fields at line ends.