### PR TITLE
Fix compilation on ARM architecture

### DIFF
--- a/src/core/algorithms/ind/faida/hashing/hashing.h
+++ b/src/core/algorithms/ind/faida/hashing/hashing.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "immintrin.h"
 #include "murmur_hash_3.h"
 
 namespace algos::faida::hashing {


### PR DESCRIPTION
Remove unused include "immintrin.h" available only on x86. After the fix, compilation is successful on Ubuntu ARM.