### PR TITLE
Fix compilation on ARM architecture

### DIFF
--- a/src/core/algorithms/ind/faida/hashing/hashing.h
+++ b/src/core/algorithms/ind/faida/hashing/hashing.h
@@ -2,7 +2,6 @@
 
 #include <string>
 
-#include "immintrin.h"
 #include "murmur_hash_3.h"
 
 namespace algos::faida::hashing {

--- a/src/core/algorithms/ind/faida/inclusion_testing/combined_inclusion_tester.cpp
+++ b/src/core/algorithms/ind/faida/inclusion_testing/combined_inclusion_tester.cpp
@@ -1,5 +1,8 @@
 #include "combined_inclusion_tester.h"
 
+#ifdef __AVX2__
+#include "immintrin.h"
+#endif
 #include "algorithms/ind/faida/hashing/hashing.h"
 #include "util/parallel_for.h"
 


### PR DESCRIPTION
Change \#include 'immintrin.h' location and add a check of AVX2 abailability. After the fix, compilation is successful on Ubuntu ARM.