### PR TITLE
Add MacOS (Apple silicon) support and dependencies installation guide (Ubuntu + MacOS) to README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
+set(CMAKE_C_COMPILER "gcc")
+set(CMAKE_CXX_COMPILER "g++")
 project(Desbordante)
 
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.10)
-set(CMAKE_C_COMPILER "gcc")
-set(CMAKE_CXX_COMPILER "g++")
 project(Desbordante)
 
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)

--- a/README.md
+++ b/README.md
@@ -219,17 +219,64 @@ However, as Desbordante core uses C++, additional requirements on the machine ar
 
 ## Build instructions
 
-### Ubuntu
-The following instructions were tested on Ubuntu 20.04+ LTS.
+### Ubuntu and MacOS
+The following instructions were tested on Ubuntu 20.04+ LTS and MacOS 14.0+ (Apple Silicon).
 ### Dependencies
 Prior to cloning the repository and attempting to build the project, ensure that you have the following software:
 
-- GNU g++ compiler, version 10+
+- GNU GCC, version 10+
 - CMake, version 3.13+
-- Boost library, version 1.74.0+
+- Boost library built with GCC, version 1.74.0+
 
 To use test datasets you will need:
 - Git Large File Storage, version 3.0.2+
+
+#### Ubuntu dependencies installation
+
+Run the following commands:
+```sh 
+sudo apt install gcc g++ cmake libboost-all-dev git-lfs
+export CC=gcc
+export CXX=g++
+```
+The last 2 lines set gcc as CMake compiler in your terminal session.
+You can also add them to the end of `~/.profile` to set this by default in all sessions.
+
+#### MacOS dependencies installation
+
+To install GCC and CMake on MacOS we recommend to use [Homebrew](https://brew.sh/) package manager. With Homebrew
+installed, run the following commands:
+```sh
+brew install gcc cmake 
+```
+After installation, check `cmake --version`. If command is not found, then you need to add to environment path to
+homebrew installed packages. To do this open `~/.zprofile` (for Zsh) or
+`~/.bash_profile` (for Bash) and add to the end of the file the output of `brew shellenv`.
+After that, restart the terminal and check the version of CMake again, now it should be displayed.
+
+Then, check the installed version of GCC:`brew info gcc`. You must see something like `==> gcc: stable X.Y.Z ...`. 
+Check that `gcc-X` and `g++-X` commands work, where X is the version from this output 
+(this designation continues to be used further).
+
+After you need to install Boost library. Please, don't use Homebrew for this, as it may not work correctly.
+Instead, download the latest version of Boost from the [official website](https://www.boost.org/users/download/).
+After downloading, unpack the archive to the `/usr/local` directory or another directory of your
+choice.
+
+Go to unpacked boost directory in the terminal and run the following commands:
+```sh
+./bootstrap.sh 
+echo "using gcc : : g++-X ;" > user-config.jam
+./b2 --user-config=user-config.jam
+export BOOST_ROOT=$(pwd)
+``` 
+You can also add last export with current path to `~/.zprofile` or `~/.bash_profile` to set this boost path by default.
+
+Before building project you must set GCC as default compiler by changing the following environment variables:
+```sh
+export CC=gcc-X
+export CXX=g++-X
+```
 
 ### Building the project
 #### Building the Python module using pip

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ if [[ $DEBUG_MODE != true ]]; then
   PREFIX="$PREFIX -D CMAKE_BUILD_TYPE=Release"
 fi
 
-if [[ -v SANITIZER ]]; then
+if [[ -n $SANITIZER ]]; then
   PREFIX="$PREFIX -D SANITIZER=${SANITIZER}"
 fi
 

--- a/src/core/algorithms/cfd/cfd_discovery.cpp
+++ b/src/core/algorithms/cfd/cfd_discovery.cpp
@@ -59,7 +59,7 @@ CFDList CFDDiscovery::GetCfds() const {
         auto& [lhs, rhs] = dep;
 
         RawCFD::RawItems cfd_lhs;
-        for (uint i = 0; i < lhs.size(); i++) {
+        for (unsigned int i = 0; i < lhs.size(); i++) {
             Item item = lhs[i];
             AttributeIndex attr = (item == 0) ? static_cast<AttributeIndex>(i)
                                               : Output::ItemToAttrIndex(item, rel);

--- a/src/core/algorithms/cfd/util/cfd_output_util.cpp
+++ b/src/core/algorithms/cfd/util/cfd_output_util.cpp
@@ -37,7 +37,7 @@ std::string Output::ItemsetToString(Itemset const& items,
     std::string answer;
     answer += '(';
     std::vector<std::string> parts;
-    for (uint i = 0; i < items.size(); i++) {
+    for (unsigned int i = 0; i < items.size(); i++) {
         Item item = items[i];
         std::string attr_name =
                 (item == 0) ? db->GetAttrName(static_cast<int>(i)) : ItemToAttrName(item, *db);

--- a/src/core/model/table/agree_set_factory.cpp
+++ b/src/core/model/table/agree_set_factory.cpp
@@ -157,7 +157,7 @@ AgreeSetFactory::SetOfAgreeSets AgreeSetFactory::GenAsUsingMapOfIdSets() const {
          *       threads_agree_sets.size() always will be not equal to actual_threads_num leading
          *       to the infinite wait on cv.
          */
-        ushort const actual_threads_num =
+        unsigned short const actual_threads_num =
                 std::min(max_representation.size(), (size_t)config_.threads_num);
         auto task = [&identifier_sets, &agree_sets, percent_per_cluster, actual_threads_num,
                      &map_init_mutex, this, &threads_agree_sets, &map_init_cv,

--- a/src/core/model/table/agree_set_factory.h
+++ b/src/core/model/table/agree_set_factory.h
@@ -115,7 +115,7 @@ public:
     struct Configuration {
         AgreeSetsGenMethod as_gen_method = AgreeSetsGenMethod::kUsingMapOfIDSets;
         MCGenMethod mc_gen_method = MCGenMethod::kUsingCalculateSupersets;
-        ushort threads_num = 1;
+        unsigned short threads_num = 1;
 
         /* Not using default keyword because of gcc bug:
          * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
@@ -123,14 +123,14 @@ public:
         Configuration() noexcept {}
 
         explicit Configuration(AgreeSetsGenMethod as_gen_m, MCGenMethod mc_gen_m,
-                               ushort threads_num) noexcept
+                               unsigned short threads_num) noexcept
             : as_gen_method(as_gen_m), mc_gen_method(mc_gen_m), threads_num(threads_num) {}
 
         explicit Configuration(AgreeSetsGenMethod as_gen_m) noexcept : as_gen_method(as_gen_m) {}
 
         explicit Configuration(MCGenMethod mc_gen_m) noexcept : mc_gen_method(mc_gen_m) {}
 
-        explicit Configuration(ushort threads_num) noexcept : threads_num(threads_num) {}
+        explicit Configuration(unsigned short threads_num) noexcept : threads_num(threads_num) {}
     };
 
     using SetOfVectors = std::unordered_set<std::vector<int>, boost::hash<std::vector<int>>>;

--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -68,7 +68,7 @@ py::tuple GetPyType(std::type_index type_index) {
     // unpredictable and can lead to errors related to garbage collection.
     static std::unordered_map<std::type_index, std::function<py::tuple()>> const type_map{
             PyTypePair<bool, kPyBool>,
-            PyTypePair<ushort, kPyInt>,
+            PyTypePair<unsigned short, kPyInt>,
             PyTypePair<int, kPyInt>,
             PyTypePair<unsigned int, kPyInt>,
             PyTypePair<double, kPyFloat>,

--- a/src/python_bindings/py_util/py_to_any.cpp
+++ b/src/python_bindings/py_util/py_to_any.cpp
@@ -115,7 +115,7 @@ std::unordered_map<std::type_index, ConvFunc> const kConverters{
         kNormalConvPair<unsigned int>,
         kNormalConvPair<long double>,
         kNormalConvPair<std::vector<unsigned int>>,
-        kNormalConvPair<ushort>,
+        kNormalConvPair<unsigned short>,
         kNormalConvPair<int>,
         kNormalConvPair<size_t>,
         kEnumConvPair<algos::metric::Metric>,

--- a/src/tests/test_data_stats.cpp
+++ b/src/tests/test_data_stats.cpp
@@ -14,14 +14,14 @@ namespace mo = model;
 
 static algos::StdParamsMap GetParamMap(CSVConfig const &csv_config,
                                        bool const is_null_equal_null = true,
-                                       ushort thread_num = 1) {
+                                       unsigned short thread_num = 1) {
     using namespace config::names;
     return {{kCsvConfig, csv_config}, {kEqualNulls, is_null_equal_null}, {kThreads, thread_num}};
 }
 
 static std::unique_ptr<algos::DataStats> MakeStatAlgorithm(CSVConfig const &csv_config,
                                                            bool const is_null_equal_null = true,
-                                                           ushort thread_num = 1) {
+                                                           unsigned short thread_num = 1) {
     return algos::CreateAndLoadAlgorithm<algos::DataStats>(
             GetParamMap(csv_config, is_null_equal_null, thread_num));
 }

--- a/src/tests/test_typo_miner.cpp
+++ b/src/tests/test_typo_miner.cpp
@@ -17,7 +17,7 @@ struct TestingParam {
     algos::StdParamsMap params;
 
     TestingParam(CSVConfig const& csv_config, bool const is_null_equal_null, unsigned const max_lhs,
-                 double const error, ushort const threads)
+                 double const error, unsigned short const threads)
         // This dictionary is only created once, so if we put the relation itself here, it
         // won't be reset between different algorithms.
         : params({{onam::kCsvConfig, csv_config},


### PR DESCRIPTION
Change platform-specific flag in build.sh script, set GCC as default compiler in CMakeLists.txt. Refactor some system-specific code to C++ standard. Add dependencies installation guide to README.md.