### PR TITLE
Fix input_format option

### DIFF
--- a/examples/basic/mining_ar.py
+++ b/examples/basic/mining_ar.py
@@ -117,7 +117,7 @@ def scenario_tabular():
 
 def scenario_singular():
     algo = desbordante.ar.algorithms.Default()
-    algo.load_data(table=(TABLE_SINGULAR, ',', True), input_format='tabular')
+    algo.load_data(table=(TABLE_SINGULAR, ',', True), input_format='singular')
     algo.execute()
     table = pandas.read_csv(TABLE_SINGULAR, header=None, index_col=0)
 
@@ -137,10 +137,8 @@ def scenario_singular():
     print(f'In order to do this, you can use {COLOR_CODES["bold_blue"]}'
           f'get_itemnames{COLOR_CODES["default"]} method:\n')
     print_itemnames(algo.get_itemnames())
-    print('\nNow you have all of the items used in this dataset, '
-          'allowing you to filter them and then print individual entries.\n')
-    print_itemnames(list(filter(lambda item: not item.isdigit(),  algo.get_itemnames())))
-   
+    print('\nNow you have all of the items used in this dataset.\n')
+
 
 if __name__ == '__main__':
     scenario_tabular()


### PR DESCRIPTION
Changed the option to the right one, but also removed the last step of the example, i. e. removing digits from the resulting list and sorting it. The reason why it was required in the first place was the typo in `input_format`.