### PR TITLE
Fix python basic example README

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -3,10 +3,10 @@
 
 These scenarios showcase a single pattern by discussing its definition and providing a brief introduction through simple examples. Furthermore, they briefly describe how to use it — how to discover or validate it in Python code. It's usually a good idea to first skim through the corresponding paper, which is listed in the main readme file.
 
-+ [algebraic_constraints.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/algebraic_constraints.py) — a scenario showing the discovery of algebraic constraints.
 + [data_stats.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/data_stats.py) — a scenario showing how to compute simple statistics (e.g. min, max over a column, etc) over a table with Desbordante.
 + [dynamic_verifying_afd.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/dynamic_verifying_afd.py) — a scenario showing how to set up dynamic verification of approximate functional dependencies.
 + [dynamic_verifying_fd.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/dynamic_verifying_fd.py) — a scenario showing how to set up dynamic verification of exact functional dependencies.
++ [mining_ac.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/mining_ac.py) — a scenario showing the discovery of algebraic constraints.
 + [mining_afd.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/mining_afd.py) — a scenario showing how to discover approximate functional dependencies.
 + [mining_ar.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/mining_ar.py) — a scenario showing how to discover association rules.
 + [mining_cfd.py](https://github.com/Desbordante/desbordante-core/tree/main/examples/basic/mining_cfd.py) — a scenario showing how to discover conditional functional dependencies.


### PR DESCRIPTION
algebraic_constraints.py link doesn't refer to any file