### PR TITLE
Fix directory check for `pybind11` before `git clone`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ fi
 if [[ ! -d "better-enums" ]] ; then
   git clone https://github.com/aantron/better-enums.git --branch 0.11.3 --depth 1
 fi
-if [[ ! -d "pybind" ]] ; then
+if [[ ! -d "pybind11" ]] ; then
   git clone https://github.com/pybind/pybind11.git --branch v2.13.4 --depth 1
 fi
 if [[ ! -d "emhash" ]] ; then


### PR DESCRIPTION
Fix check in the build script to remove the following warning during build:
``` text
fatal: destination path 'pybind11' already exists and is not an empty directory.
```

This bug was introduced in commit d29d0d3