### PR TITLE
Fix CORDS tests

### DIFF
--- a/src/core/algorithms/fd/sfd/cords.cpp
+++ b/src/core/algorithms/fd/sfd/cords.cpp
@@ -67,6 +67,8 @@ void Cords::RegisterOptions() {
     RegisterOption(
             Option{&max_amount_of_categories_, kMaxAmountOfCategories, kDMaxAmountOfCategories}
                     .SetValueCheck(check_positive));
+
+    RegisterOption(Option{&fixed_sample_, kFixedSample, kDFixedSample, false});
 }
 
 void Cords::MakeExecuteOptsAvailableFDInternal() {
@@ -190,7 +192,8 @@ unsigned long long Cords::ExecuteInternal() {
                     handler_.GetColumnCardinality(col_i), handler_.GetColumnCardinality(col_k),
                     max_false_positive_probability_, delta_);
 
-            Sample smp(sample_size, row_count, col_i, col_k, data, typed_relation_->GetSchema());
+            Sample smp(fixed_sample_, sample_size, row_count, col_i, col_k, data,
+                       typed_relation_->GetSchema());
 
             bool sfd_detected = DetectSFD(smp);
 

--- a/src/core/algorithms/fd/sfd/cords.h
+++ b/src/core/algorithms/fd/sfd/cords.h
@@ -26,6 +26,7 @@ private:
     std::unique_ptr<TypedRelation> typed_relation_;
 
     bool only_sfd_;
+    bool fixed_sample_ = false;
 
     long double minimum_cardinality_;
     long double max_diff_vals_proportion_;

--- a/src/core/algorithms/fd/sfd/sample.cpp
+++ b/src/core/algorithms/fd/sfd/sample.cpp
@@ -10,9 +10,9 @@
 #include "model/table/tuple_index.h"
 
 namespace algos {
-Sample::Sample(unsigned long long sample_size, model::TupleIndex rows, model::ColumnIndex lhs,
-               model::ColumnIndex rhs, std::vector<model::TypedColumnData> const &data,
-               RelationalSchema const *rel_schema_)
+Sample::Sample(bool fixed_sample, unsigned long long sample_size, model::TupleIndex rows,
+               model::ColumnIndex lhs, model::ColumnIndex rhs,
+               std::vector<model::TypedColumnData> const &data, RelationalSchema const *rel_schema_)
     : lhs_col_(rel_schema_, rel_schema_->GetColumn(lhs)->GetName(), lhs),
       rhs_col_(rel_schema_, rel_schema_->GetColumn(rhs)->GetName(), rhs) {
     auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
@@ -24,7 +24,8 @@ Sample::Sample(unsigned long long sample_size, model::TupleIndex rows, model::Co
     std::unordered_set<std::string> map_cardinality;
 
     for (model::ColumnIndex i = 0; i < sample_size; i++) {
-        model::TupleIndex row = distribution(gen);
+        model::TupleIndex row = (fixed_sample) ? i : distribution(gen);
+
         row_indices_.push_back(row);
         map_lhs.insert(data[lhs].GetDataAsString(row));
         map_rhs.insert(data[rhs].GetDataAsString(row));

--- a/src/core/algorithms/fd/sfd/sample.h
+++ b/src/core/algorithms/fd/sfd/sample.h
@@ -25,7 +25,7 @@ private:
     size_t concat_cardinality_;
 
 public:
-    Sample(unsigned long long sample_size, size_t rows, model::ColumnIndex lhs,
+    Sample(bool fixed_sample, unsigned long long sample_size, size_t rows, model::ColumnIndex lhs,
            model::ColumnIndex rhs, std::vector<model::TypedColumnData> const &data,
            RelationalSchema const *rel_schema_);
     void Filter(FrequencyHandler const &handler, std::vector<model::TypedColumnData> const &data,

--- a/src/core/config/descriptions.h
+++ b/src/core/config/descriptions.h
@@ -140,4 +140,7 @@ constexpr auto kDDelta =
         "greater than minimum_cardinality_.";
 constexpr auto kDMaxAmountOfCategories =
         "Max amount of categories for the chi-squared test in case the data is not skewed";
+constexpr auto kDFixedSample =
+        "Indicates that instead of random generated sample CORDS uses sample consisting of n first "
+        "rows of the given table. Intended for tests only.";
 }  // namespace config::descriptions

--- a/src/core/config/names.h
+++ b/src/core/config/names.h
@@ -71,4 +71,5 @@ constexpr auto kMinStructuralZeroesAmount = "min_structural_zeroes_amount";
 constexpr auto kMaxFalsePositiveProbability = "max_false_positive_probability";
 constexpr auto kDelta = "delta";
 constexpr auto kMaxAmountOfCategories = "max_amount_of_categories";
+constexpr auto kFixedSample = "fixed_sample";
 }  // namespace config::names

--- a/src/tests/test_sfd.cpp
+++ b/src/tests/test_sfd.cpp
@@ -118,6 +118,7 @@ public:
     struct Config {
         bool is_null_equal_null;
         bool only_sfd;
+        bool fixed_sample;
         long double min_cardinality;
         long double max_diff_vals_proportion;
         long double min_sfd_strength_measure;
@@ -145,7 +146,8 @@ public:
                 {kMaxFalsePositiveProbability, test_config.max_false_positive_probability},
                 {kDelta, test_config.delta},
                 {kMaxAmountOfCategories, test_config.max_amount_of_categories},
-                {kMaximumLhs, test_config.max_lhs}};
+                {kMaximumLhs, test_config.max_lhs},
+                {kFixedSample, test_config.fixed_sample}};
     }
 
     static std::unique_ptr<algos::Cords> CreateCordsInstance(CSVConfig const& csv_config,
@@ -158,6 +160,7 @@ using TestConfig = CordsAlgorithmTest::Config;
 TestConfig const kTestConfigDefault{
         .is_null_equal_null = true,
         .only_sfd = false,
+        .fixed_sample = true,
         .min_cardinality = 0.04L,
         .max_diff_vals_proportion = 0.4L,
         .min_sfd_strength_measure = 0.3L,


### PR DESCRIPTION
Added option fixed_sample that indicates that cords uses sample consisting of sample_size first rows of the given table, instead of random generated one, false by default. Add all related implementation fixes.