### PR TITLE
Fix CMakeLists.txt, macOS guide and refactor .gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,15 @@
-cmake-build-debug/
+# Build directories, libraries and binary files
+**/myeasylog.log
 build/
-Build/
-BUILD/
-bUILD/
-Datasets/
-.sconsign.dblite
+cmake-build-debug/
+dist/
 lib/
-.csv
+venv/
+
+# IDE and related files
+.cache/
 .idea/
 .vscode/
-**/myeasylog.log
-dist
-venv
+
+# OS Generated file
+**/.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
-cmake_minimum_required(VERSION 3.13)
-cmake_policy(SET CMP0144 NEW)
+cmake_minimum_required(VERSION 3.15)
+if (POLICY CMP0167)
+    # deprecated by definition, but we use old behaviour for find_package(Boost) to load CMake's FindBoost module
+    # TODO: port project to "Modern CMake" https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1
+    cmake_policy(SET CMP0167 OLD)
+endif()
+if (POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW)
+endif()
+
 project(Desbordante)
 
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)
@@ -103,9 +111,16 @@ endif()
 
 # configuring boost
 set(Boost_USE_STATIC_LIBS OFF)
-find_package(Boost 1.81.0 REQUIRED COMPONENTS container thread graph CONFIG)
-include_directories(${Boost_INCLUDE_DIRS})
-message(${Boost_INCLUDE_DIRS})
+
+find_package(Boost 1.81.0 REQUIRED COMPONENTS container thread graph)
+if (Boost_FOUND)
+    message(STATUS "Found Boost include dirs: ${Boost_INCLUDE_DIRS}")
+    include_directories( ${Boost_INCLUDE_DIRS})
+    message(STATUS "Found Boost library dirs: ${Boost_LIBRARY_DIRS}")
+else ()
+    message(FATAL_ERROR "Boost not found. If boost is installed specify environment"
+        "variables like \"BOOST_ROOT\" for hint to CMake where to search")
+endif()
 
 # providing subdirectories for header inclusion
 include_directories(

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The following instructions were tested on Ubuntu 20.04+ LTS and macOS Sonoma 14.
 Prior to cloning the repository and attempting to build the project, ensure that you have the following software:
 
 - GNU GCC, version 10+
-- CMake, version 3.13+
+- CMake, version 3.15+
 - Boost library built with GCC, version 1.81.0+
 
 To use test datasets you will need:

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ To use test datasets you will need:
 
 Run the following commands:
 ```sh 
-sudo apt install gcc g++ cmake libboost-all-dev git-lfs
+sudo apt install gcc g++ cmake libboost-all-dev git-lfs python3
 export CC=gcc
 export CXX=g++
 ```
@@ -271,10 +271,10 @@ xcode-select --install
 ```
 Follow the prompts to continue.
 
-To install GCC and CMake on macOS we recommend to use [Homebrew](https://brew.sh/) package manager. With Homebrew
+To install GCC, CMake and python on macOS we recommend to use [Homebrew](https://brew.sh/) package manager. With Homebrew
 installed, run the following commands:
 ```sh
-brew install gcc@14 cmake
+brew install gcc@14 cmake python3
 ```
 After installation, check `cmake --version`. If command is not found, then you need to add to environment path to
 homebrew installed packages. To do this open `~/.zprofile` (for Zsh) or
@@ -282,20 +282,19 @@ homebrew installed packages. To do this open `~/.zprofile` (for Zsh) or
 After that, restart the terminal and check the version of CMake again, now it should be displayed.
 
 Then you need to install Boost library built with GCC. Please avoid using Homebrew for this, as the Boost version provided by Homebrew
-is built with Clang, which has a different ABI. Instead, download the latest version of Boost from the [official website](https://www.boost.org/users/download/) and unpack the archive to the `/usr/local/` directory or another directory of your choice:
+is built with Clang, which has a different ABI. Instead, download the latest version of Boost from the [official website](https://www.boost.org/users/download/), open terminal and run:
 ```sh
-cd /usr/local/
+cd ~/Downloads
 curl https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 --output "boost_1_86_0.tar.bz2"
-tar xvjf boost_1_86_0.tar.bz2
-rm boost_1_86_0.tar.bz2
+tar xvjf boost_1_86_0.tar.bz2 && rm boost_1_86_0.tar.bz2
 cd boost_1_86_0
 ```
 Navigate to the unpacked Boost directory in the terminal and run the following commands:
 ```sh
 ./bootstrap.sh 
 echo "using darwin : : g++-14 ;" > user-config.jam
-./b2 install --user-config=user-config.jam --layout=versioned
-export BOOST_ROOT=$(pwd) # export Boost_ROOT=$(pwd) for CMake 3.26 and below.
+sudo ./b2 install --user-config=user-config.jam --layout=versioned
+export BOOST_ROOT=/usr/local/ # export Boost_ROOT=/usr/local/ for CMake 3.26 and below.
 ``` 
 You can also add the last export with current path to `~/.zprofile` or `~/.bash_profile` to set this boost path by default.
 
@@ -304,10 +303,11 @@ Before building the project you must set locally or in the above-mentioned dotfi
 export CC=gcc-14
 export CXX=g++-14
 export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
+export DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH}
 ```
-The first two lines set GCC as the default compiler in CMake. The last export is also necessary due to issues with GCC 14 and
-the last MacOSX15.0.sdk used by CMake by default, you can read more about this [here](https://gist.github.com/scivision/d69faebbc56da9714798087b56de925a)
-and [here](https://github.com/iains/gcc-14-branch/issues/11).
+The first two lines set GCC as the default compiler in CMake. The `SDKROOT` export is also necessary due to issues with GCC 14 and
+the last macOS 15 SDK used by CMake by default, you can read more about this [here](https://gist.github.com/scivision/d69faebbc56da9714798087b56de925a)
+and [here](https://github.com/iains/gcc-14-branch/issues/11). The last export is the solution for dynamic linking with python module.
 
 ### Building the project
 #### Building the Python module using pip


### PR DESCRIPTION
Increase CMake minimum required version to 3.15 due to [incompatibilities
with scikit-build-core](https://github.com/scikit-build/scikit-build-core/blob/acc69a86cd1995b8baff4e631e453906226801dd/README.md?plain=1#L72). Update README.md.

Add POLICY checks to avoid errors on policy-unsupported versions.

Change CMP0167 policy of boost searching to OLD due to non-compliance
with "[Modern CMake](https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1)" development patterns. Add "TODO" to fix this later.
Add useful logs to understand what Boost libraries were found by CMake.

Apply sort to .gitignore to improve readability.
Add .DS_Store, which is generated in macOS directories.
Add .cache, which is generated by clangd.

Add python3 to installation guide.
Fix macOS Boost installation guide to work with python module.
Fix default installation directories as root permissions were required.
Change macOS SDK version to compatibility with [new version](https://developer.apple.com/documentation/macos-release-notes/macos-15_1-release-notes).