### PR TITLE
Add missing size_t entry to type_map in bindings

### DIFF
--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -72,6 +72,7 @@ py::tuple GetPyType(std::type_index type_index) {
             PyTypePair<int, kPyInt>,
             PyTypePair<unsigned int, kPyInt>,
             PyTypePair<double, kPyFloat>,
+            PyTypePair<size_t, kPyInt>,
             PyTypePair<long double, kPyFloat>,
             PyTypePair<algos::metric::Metric, kPyStr>,
             PyTypePair<algos::metric::MetricAlgo, kPyStr>,


### PR DESCRIPTION
CORDS algorithm has a max_amount_of_categories option which is of type
size_t. Size_t is not present in type_map which causes execution of
desbordante-cli to fail when get_option_type() is called for
max_amount_of_categories.
