### PR TITLE
Make HPIValid default UCC mining algorithm

### DIFF
--- a/src/python_bindings/ucc/bind_ucc.cpp
+++ b/src/python_bindings/ucc/bind_ucc.cpp
@@ -39,8 +39,8 @@ void BindUcc(py::module_& main_module) {
             .def_property_readonly("indices", &UCC::GetColumnIndicesAsVector)
             .def("__eq__", [](UCC const& a, UCC const& b) { return a == b; })
             .def("__hash__", [](UCC const& ucc) { return py::hash(MakeUCCNameTuple(ucc)); });
-    BindPrimitive<HyUCC, PyroUCC, HPIValid>(
+    BindPrimitive<HPIValid, HyUCC, PyroUCC>(
             ucc_module, py::overload_cast<>(&UCCAlgorithm::UCCList, py::const_), "UccAlgorithm",
-            "get_uccs", {"HyUCC", "PyroUCC", "HPIValid"}, pybind11::return_value_policy::copy);
+            "get_uccs", {"HPIValid", "HyUCC", "PyroUCC"}, pybind11::return_value_policy::copy);
 }
 }  // namespace python_bindings


### PR DESCRIPTION
Change Python bindings to make HPIValid default UCC mining algorithm in Python