### PR TITLE
Fix Boost installation, macOS-GCC guide. Set project default language to C++

### DIFF
--- a/.github/composite-actions/download-libraries/action.yml
+++ b/.github/composite-actions/download-libraries/action.yml
@@ -75,7 +75,7 @@ runs:
     - name: Install Boost
       run: |
         cd lib/boost
-        ./bootstrap.sh --prefix=/usr
+        ./bootstrap.sh --prefix=/usr --with-libraries=container,thread,graph
         sudo ./b2 install --prefix=/usr
       shell: bash
       if: inputs.install-boost != 'false'

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -84,7 +84,7 @@ jobs:
         env:
           CIBW_BEFORE_ALL: >
             cd lib/boost &&
-            ./bootstrap.sh --prefix=/usr &&
+            ./bootstrap.sh --prefix=/usr --with-libraries=container,thread,graph &&
             ./b2 install -j4 --prefix=/usr
           CIBW_TEST_COMMAND: >
             cp {project}/test_input_data/WDC_satellites.csv {project}/src/python_bindings &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if (POLICY CMP0144)
     cmake_policy(SET CMP0144 NEW)
 endif()
 
-project(Desbordante)
+project(Desbordante CXX)
 
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)
 option(COMPILE_TESTS "Build tests" ON)

--- a/README.md
+++ b/README.md
@@ -257,11 +257,10 @@ To use test datasets you will need:
 Run the following commands:
 ```sh 
 sudo apt install gcc g++ cmake libboost-all-dev git-lfs python3
-export CC=gcc
 export CXX=g++
 ```
-The last 2 lines set gcc as CMake compiler in your terminal session.
-You can also add them to the end of `~/.profile` to set this by default in all sessions.
+The last line sets GCC as CMake compiler in your terminal session.
+You can also add it to the end of `~/.profile` to set this by default in all sessions.
 
 #### MacOS dependencies installation
 
@@ -300,14 +299,10 @@ You can also add the last export with current path to `~/.zprofile` or `~/.bash_
 
 Before building the project you must set locally or in the above-mentioned dotfiles the following CMake environment variables:
 ```sh
-export CC=gcc-14
 export CXX=g++-14
-export SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/
 export DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH}
 ```
-The first two lines set GCC as the default compiler in CMake. The `SDKROOT` export is also necessary due to issues with GCC 14 and
-the last macOS 15 SDK used by CMake by default, you can read more about this [here](https://gist.github.com/scivision/d69faebbc56da9714798087b56de925a)
-and [here](https://github.com/iains/gcc-14-branch/issues/11). The last export is the solution for dynamic linking with python module.
+The first line sets GCC as the default compiler in CMake. The last export is the solution for dynamic linking with python module.
 
 ### Building the project
 #### Building the Python module using pip

--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ Then you need to install Boost library built with GCC. Please avoid using Homebr
 is built with Clang, which has a different ABI. Instead, download the latest version of Boost from the [official website](https://www.boost.org/users/download/), open terminal and run:
 ```sh
 cd ~/Downloads
-curl https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2 --output "boost_1_86_0.tar.bz2"
-tar xvjf boost_1_86_0.tar.bz2 && rm boost_1_86_0.tar.bz2
-cd boost_1_86_0
+curl https://archives.boost.io/release/1.87.0/source/boost_1_87_0.tar.bz2 --output "boost_1_87_0.tar.bz2"
+tar xvjf boost_1_87_0.tar.bz2 && rm boost_1_87_0.tar.bz2
+cd boost_1_87_0
 ```
 Navigate to the unpacked Boost directory in the terminal and run the following commands:
 ```sh
-./bootstrap.sh 
+./bootstrap.sh --with-libraries=container,thread,graph
 echo "using darwin : : g++-14 ;" > user-config.jam
 sudo ./b2 install --user-config=user-config.jam --layout=versioned
 export BOOST_ROOT=/usr/local/ # export Boost_ROOT=/usr/local/ for CMake 3.26 and below.


### PR DESCRIPTION
Fix CI and README.md Boost installing steps to install only 3 used libraries to reduce installation time.

Set CXX(C++) as default language in CMakeLists.txt.

Fix README.md due to fix of GCC & macOS SDK15 incompatibility. 
Increase Boost version to 1.87.0 in macOS dependency installation guide.
Remove C-compilers exports in dependencies installation guide.
