### PR TITLE
Add macOS pip-packages. Add GCC-macOS configuration to CI.

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -60,16 +60,16 @@ runs:
       shell: bash
       if: env.OS == 'ubuntu'
     - name: Install build tools using brew
-      run: brew install make cmake
+      run: brew install make cmake --formula
       shell: bash
       if: env.OS == 'macos'
 
-    - name: Install GCC toolset
+    - name: Install GCC toolset (on Ubuntu)
       run: |
         sudo apt-get install gcc-10 g++-10 -y
       shell: bash
-      if: inputs.install-toolset == 'true' && inputs.toolset == 'gcc'
-    - name: Install Clang toolset (on Linux)
+      if: inputs.install-toolset == 'true' && inputs.toolset == 'gcc' && env.OS == 'ubuntu'
+    - name: Install Clang toolset (on Ubuntu)
       # "all" option is needed to install libc++ and libc++abi
       # apt is hardcoded in llvm.sh, so we can't use it everywhere
       run: |
@@ -78,6 +78,11 @@ runs:
         sudo ./llvm.sh 17 all
       shell: bash
       if: inputs.install-toolset == 'true' && inputs.toolset == 'llvm-clang' && env.OS == 'ubuntu'
+    - name: Install GCC toolset (on macOS)
+      run: |
+        brew install gcc@14
+      shell: bash
+      if: inputs.install-toolset == 'true' && inputs.toolset == 'gcc' && env.OS == 'macos'
     - name: Install LLVM Clang toolset (on macOS)
       run: brew install llvm@17
       shell: bash
@@ -139,19 +144,27 @@ runs:
         ./bootstrap.sh --with-libraries=container,thread,graph
         sudo ./b2 install --prefix=/usr
       shell: bash
-      if: inputs.install-boost == 'true' && inputs.toolset == 'gcc'
-    - name: Install Boost built with Clang (on Linux)
+      if: inputs.install-boost == 'true' && inputs.toolset == 'gcc' && env.OS == 'ubuntu'
+    - name: Install Boost built with Clang (on Ubuntu)
       run: |
         cd lib/boost
-        ./bootstrap.sh
+        ./bootstrap.sh --with-libraries=container,thread,graph
         sudo ./b2 install -a --prefix=/usr toolset=clang cxxflags="-stdlib=libc++" \
          linkflags="-stdlib=libc++"
       shell: bash
       if: inputs.install-boost == 'true' && inputs.toolset == 'llvm-clang' && env.OS == 'ubuntu'
+    - name: Install Boost built with GCC (on macOS)
+      run: | 
+        cd lib/boost
+        ./bootstrap.sh --with-libraries=container,thread,graph 
+        echo "using darwin : : g++-14 ;" > user-config.jam
+        sudo ./b2 install -a --user-config=user-config.jam --prefix=/usr/local
+      shell: bash
+      if: inputs.install-boost == 'true' && inputs.toolset == 'gcc' && env.OS == 'macos'
     - name: Install Boost built with LLVM Clang (on macOS)
       run: |
         cd lib/boost
-        ./bootstrap.sh
+        ./bootstrap.sh --with-libraries=container,thread,graph
         echo "using darwin : : $(brew --prefix llvm@17)/bin/clang++ ;" > user-config.jam
         sudo ./b2 install -a --user-config=user-config.jam --prefix=/usr/local \
          cxxflags="-std=c++11 -I$(brew --prefix llvm@17)/include" \

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -57,8 +57,7 @@ jobs:
           download-pybind: true
       - name: Generate compile_commands.json
         run: |
-          cmake -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+          cmake -DCMAKE_CXX_COMPILER=g++-10 \
             -DCMAKE_BUILD_TYPE=Debug \
             -Dgtest_disable_pthreads=OFF \
             -DASAN=OFF \

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -32,40 +32,92 @@ on:
     types:
       - published
 jobs:
-  generate-wheels-matrix:
-    # https://iscinumpy.dev/post/cibuildwheel-2-10-0/
-    name: Generate wheels matrix
+  generate-linux-wheels-matrix:
+    name: Generate Linux wheel matrix
     runs-on: ubuntu-latest
     outputs:
       include: ${{ steps.set-matrix.outputs.include }}
     steps:
       - uses: actions/checkout@v4
       - name: Install cibuildwheel
-        run: pipx install cibuildwheel==2.16.2
+        run: pipx install cibuildwheel==2.22.0
       - id: set-matrix
         run: |
           MATRIX=$(
             {
               cibuildwheel --print-build-identifiers --platform linux \
-              | jq -nRc '{"only": inputs, "os": "ubuntu-latest"}'
+              | jq -nRc '{"only": inputs, "os": "ubuntu-latest", "toolset": "gcc"}' 
             } | jq -sc
           )
           echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
+      - name: Check matrix
+        run: echo "${{ steps.set-matrix.outputs.include }}"
     env:
       CIBW_ARCHS_LINUX: x86_64
-      # Builds wheels for PyPy & CPython on manylinux
       CIBW_BUILD: "*manylinux*"
       CIBW_TEST_REQUIRES: pytest
       CIBW_BUILD_VERBOSITY: 1
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
 
+  generate-macos-wheels-matrix:
+    name: Generate macOS wheel matrix
+    runs-on: macos-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cibuildwheel
+        run: pipx install cibuildwheel==2.22.0
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            cibuildwheel --print-build-identifiers --platform macos \
+            | jq -sR 'split("\n") | map(select(length > 0)) | map(
+              {
+                "only": ., 
+                "os": (if contains("x86_64") then "macos-13" else "macos-latest" end), 
+                "toolset": "apple-clang",
+              })' \
+            | jq -c
+          )
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
+      - name: Check matrix
+        run: echo "${{ steps.set-matrix.outputs.include }}"
+    env:
+      CIBW_ARCHS_MACOS: arm64 x86_64
+      CIBW_BUILD: "*macos*"
+      # https://github.com/pypa/cibuildwheel/issues/2126
+      CIBW_SKIP: "cp37-*"
+      CIBW_TEST_REQUIRES: pytest
+      CIBW_BUILD_VERBOSITY: 1
+
+  merge-matrices:
+    name: Merge wheel matrices
+    needs: [generate-linux-wheels-matrix, generate-macos-wheels-matrix]
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.merge.outputs.include }}
+    steps:
+        - name: Merge JSON matrices
+          id: merge
+          run: |
+            LINUX_MATRIX='${{ needs.generate-linux-wheels-matrix.outputs.include }}'
+            MACOS_MATRIX='${{ needs.generate-macos-wheels-matrix.outputs.include }}'
+            
+            MERGED_MATRIX=$(jq -c -n --argjson var1 "$LINUX_MATRIX" --argjson var2 "$MACOS_MATRIX" '$var1 + $var2')
+            echo "include=$MERGED_MATRIX" >> $GITHUB_OUTPUT
+        - name: Check merged matrix
+          run: echo "${{ steps.merge.outputs.include }}"
+
   build-wheels:
     name: Build ${{ matrix.only }}
-    needs: generate-wheels-matrix
+    needs: [merge-matrices]
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.generate-wheels-matrix.outputs.include) }}
+        include: ${{ fromJson(needs.merge-matrices.outputs.include) }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -73,21 +125,31 @@ jobs:
       - name: Install dependencies
         uses: ./.github/composite-actions/install-dependencies
         with:
-          os: ubuntu
-          toolset: gcc
+          os: ${{ matrix.os }}
+          toolset: ${{ matrix.toolset }}
           install-boost: false
-          download-pybind: true
           download-googletest: false
+          download-pybind: true
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.22.0
         with:
           only: ${{ matrix.only }}
         env:
-          CIBW_BEFORE_ALL: >
+          MACOSX_DEPLOYMENT_TARGET: 11.0
+          CIBW_BEFORE_ALL_LINUX: >
             cd lib/boost &&
-            ./bootstrap.sh --prefix=/usr &&
-            ./b2 install -j4 --prefix=/usr
+            ./bootstrap.sh --with-libraries=container,thread,graph &&
+            ./b2 install -j4 --prefix=/usr &&
+            export BOOST_ROOT=/usr &&
+            export CXX=g++-10 
+          CIBW_BEFORE_ALL_MACOS: >
+            cd lib/boost &&
+            ./bootstrap.sh --with-libraries=container,thread,graph &&
+            sudo ./b2 install -j3 --prefix=/usr/local cxxflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET} -std=c++20" linkflags="-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET}" &&
+            export BOOST_ROOT=/usr/local &&
+            export CXX=clang++ &&
+            export DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH} 
           CIBW_TEST_COMMAND: >
             cp {project}/test_input_data/WDC_satellites.csv {project}/src/python_bindings &&
             cp {project}/test_input_data/transactional_data/rules-kaggle-rows.csv {project}/src/python_bindings &&
@@ -95,6 +157,8 @@ jobs:
             cp {project}/test_input_data/TestWide.csv {project}/src/python_bindings &&
             cd {project}/src/python_bindings &&
             python3 {project}/src/python_bindings/test_bindings.py
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            DYLD_LIBRARY_PATH=/usr/local/lib:${DYLD_LIBRARY_PATH} delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if (POLICY CMP0144)
     cmake_policy(SET CMP0144 NEW)
 endif()
 
-project(Desbordante)
+project(Desbordante CXX)
 
 option(COPY_PYTHON_EXAMPLES "Copy Python examples" OFF)
 option(COMPILE_TESTS "Build tests" ON)

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ To install Desbordante type:
 $ pip install desbordante
 ```
 
-However, as Desbordante core uses C++, additional requirements on the machine are imposed. Therefore this installation option may not work for everyone. Currently, only manylinux2014 (Ubuntu 20.04+, or any other linux distribution with gcc 10+) is supported. If the above does not work for you consider building from sources.
+However, as Desbordante core uses C++, additional requirements on the machine are imposed. Therefore this installation option may not work for everyone. Currently, only manylinux2014 (Ubuntu 20.04+, or any other linux distribution with gcc 10+) and macOS 11.0+ (arm64, x86_64) is supported. If the above does not work for you consider building from sources.
 
 ## Build instructions
 
@@ -265,11 +265,10 @@ Instructions for other supported compilers can be found in [Desbordante wiki](ht
 
 Run the following commands:
 ```sh 
-sudo apt install gcc g++ cmake libboost-all-dev git-lfs python3
-export CC=gcc
+sudo apt install g++ cmake libboost-all-dev git-lfs python3
 export CXX=g++
 ```
-The last 2 lines set gcc as CMake compiler in your terminal session.
+The last line sets g++ as CMake compiler in your terminal session.
 You can also add them to the end of `~/.profile` to set this by default in all sessions.
 
 #### macOS dependencies installation (Apple Clang)
@@ -292,11 +291,10 @@ After that, restart the terminal and check the version of CMake again, now it sh
 
 Run the following commands:
 ```sh
-export CC=clang
 export CXX=clang++
 export BOOST_ROOT=$(brew --prefix boost)
 ```
-These commands set Apple Clang as CMake compiler in your terminal session.
+These commands set Apple Clang and Homebrew Boost as default in CMake in your terminal session.
 You can also add them to the end of `~/.profile` to set this by default in all sessions.
 
 ### Building the project

--- a/src/python_bindings/py_util/bind_primitive.h
+++ b/src/python_bindings/py_util/bind_primitive.h
@@ -2,6 +2,8 @@
 
 #include <array>
 #include <cstddef>
+#include <sstream>
+#include <string>
 #include <type_traits>
 
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
Add macOS wheels to cibuildwheel workflow:
1. Create a separate job for macOS wheel matrix generation due to wheels autoskipping on x86_64 ubuntu runner.
3. Create matrix merge job to merge all matrices into a single.
4. Add macOS support to the wheel build job.

Add macOS-GCC CI configuration:
1. Add missing steps in install-dependencies action.
2. Add configruation to core-tests and bindings-tests workflows.
3. Add --formula flag to brew install cmake to disable warning.

Refactor CI:
1. Set libraries download in alphabetical order.
2. Bump actions/checkout to v4.
3. Change run_tests matrix to more readable. resolves #512 
4. Add env field to avoid code duplications inside job.

Also set C++ as default CMake project language, remove C-compilers exports.
Fix boost libraries building to build only used libraries.
