### PR TITLE
[FIX] Multi-threaded implementation of HyFD algorithm

### DIFF
--- a/src/core/algorithms/fd/hyfd/hyfd.cpp
+++ b/src/core/algorithms/fd/hyfd/hyfd.cpp
@@ -25,7 +25,7 @@ HyFD::HyFD(std::optional<ColumnLayoutRelationDataManager> relation_manager)
     RegisterOption(config::kThreadNumberOpt(&threads_num_));
 }
 
-void HyFD::MakeExecuteOptsAvailable() {
+void HyFD::MakeExecuteOptsAvailableFDInternal() {
     MakeOptionsAvailable({config::names::kThreads});
 }
 

--- a/src/core/algorithms/fd/hyfd/hyfd.cpp
+++ b/src/core/algorithms/fd/hyfd/hyfd.cpp
@@ -14,7 +14,8 @@
 #include "algorithms/fd/hycommon/util/pli_util.h"
 #include "inductor.h"
 #include "sampler.h"
-#include "thread_number/option.h"
+#include "config/thread_number/option.h"
+#include "config/names.h"
 #include "validator.h"
 
 namespace algos::hyfd {
@@ -22,7 +23,10 @@ namespace algos::hyfd {
 HyFD::HyFD(std::optional<ColumnLayoutRelationDataManager> relation_manager)
     : PliBasedFDAlgorithm({}, relation_manager) {
     RegisterOption(config::kThreadNumberOpt(&threads_num_));
-    MakeOptionsAvailable({config::kThreadNumberOpt.GetName()});
+}
+
+void HyFD::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable({config::names::kThreads});
 }
 
 unsigned long long HyFD::ExecuteInternal() {

--- a/src/core/algorithms/fd/hyfd/hyfd.cpp
+++ b/src/core/algorithms/fd/hyfd/hyfd.cpp
@@ -12,10 +12,10 @@
 
 #include "algorithms/fd/hycommon/preprocessor.h"
 #include "algorithms/fd/hycommon/util/pli_util.h"
+#include "config/names.h"
+#include "config/thread_number/option.h"
 #include "inductor.h"
 #include "sampler.h"
-#include "config/thread_number/option.h"
-#include "config/names.h"
 #include "validator.h"
 
 namespace algos::hyfd {

--- a/src/core/algorithms/fd/hyfd/hyfd.h
+++ b/src/core/algorithms/fd/hyfd/hyfd.h
@@ -44,7 +44,7 @@ private:
 
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<algos::hy::ClusterId> const& og_mapping);
 
-    void MakeExecuteOptsAvailable() override;
+    void MakeExecuteOptsAvailableFDInternal() override;
 
     config::ThreadNumType threads_num_ = 1;
 

--- a/src/core/algorithms/fd/hyfd/hyfd.h
+++ b/src/core/algorithms/fd/hyfd/hyfd.h
@@ -8,8 +8,8 @@
 #include "algorithms/fd/hycommon/types.h"
 #include "algorithms/fd/pli_based_fd_algorithm.h"
 #include "algorithms/fd/raw_fd.h"
-#include "model/table/position_list_index.h"
 #include "config/thread_number/type.h"
+#include "model/table/position_list_index.h"
 
 namespace algos::hyfd {
 

--- a/src/core/algorithms/fd/hyfd/hyfd.h
+++ b/src/core/algorithms/fd/hyfd/hyfd.h
@@ -9,7 +9,7 @@
 #include "algorithms/fd/pli_based_fd_algorithm.h"
 #include "algorithms/fd/raw_fd.h"
 #include "model/table/position_list_index.h"
-#include "thread_number/type.h"
+#include "config/thread_number/type.h"
 
 namespace algos::hyfd {
 
@@ -43,6 +43,8 @@ private:
     unsigned long long ExecuteInternal() override;
 
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<algos::hy::ClusterId> const& og_mapping);
+
+    void MakeExecuteOptsAvailable() override;
 
     config::ThreadNumType threads_num_ = 1;
 

--- a/src/core/algorithms/fd/hyfd/hyfd.h
+++ b/src/core/algorithms/fd/hyfd/hyfd.h
@@ -9,6 +9,7 @@
 #include "algorithms/fd/pli_based_fd_algorithm.h"
 #include "algorithms/fd/raw_fd.h"
 #include "model/table/position_list_index.h"
+#include "thread_number/type.h"
 
 namespace algos::hyfd {
 
@@ -42,6 +43,8 @@ private:
     unsigned long long ExecuteInternal() override;
 
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<algos::hy::ClusterId> const& og_mapping);
+
+    config::ThreadNumType threads_num_ = 1;
 
 public:
     HyFD(std::optional<ColumnLayoutRelationDataManager> relation_manager = std::nullopt);

--- a/src/core/algorithms/fd/hyfd/sampler.h
+++ b/src/core/algorithms/fd/hyfd/sampler.h
@@ -9,8 +9,8 @@ private:
     hy::Sampler sampler_;
 
 public:
-    Sampler(hy::PLIsPtr plis, hy::RowsPtr pli_records)
-        : sampler_(std::move(plis), std::move(pli_records)) {}
+    Sampler(hy::PLIsPtr plis, hy::RowsPtr pli_records, config::ThreadNumType threads_num = 1)
+        : sampler_(std::move(plis), std::move(pli_records), threads_num) {}
 
     NonFDList GetNonFDs(hy::IdPairs const& comparison_suggestions) {
         return sampler_.GetAgreeSets(comparison_suggestions);

--- a/src/core/algorithms/fd/hyfd/validator.cpp
+++ b/src/core/algorithms/fd/hyfd/validator.cpp
@@ -264,7 +264,6 @@ Validator::FDValidations Validator::ValidateAndExtendPar(std::vector<LhsPair> co
     }
 
     pool.join();
-    pool.wait();
 
     for (auto&& future : validation_futures) {
         assert(future.valid());

--- a/src/core/algorithms/fd/hyfd/validator.h
+++ b/src/core/algorithms/fd/hyfd/validator.h
@@ -7,6 +7,7 @@
 #include "algorithms/fd/hycommon/primitive_validations.h"
 #include "algorithms/fd/hyfd/model/fd_tree.h"
 #include "algorithms/fd/raw_fd.h"
+#include "config/thread_number/type.h"
 #include "model/table/position_list_index.h"
 #include "types.h"
 
@@ -33,16 +34,21 @@ private:
 
     FDValidations ValidateAndExtendSeq(std::vector<LhsPair> const& vertices);
 
+    FDValidations ValidateAndExtendPar(std::vector<LhsPair> const& vertices);
+
     [[nodiscard]] unsigned GetLevelNum() const {
         return current_level_number_;
     }
 
+    config::ThreadNumType threads_num_ = 1;
+
 public:
     Validator(std::shared_ptr<fd_tree::FDTree> fds, hy::PLIsPtr plis,
-              hy::RowsPtr compressed_records) noexcept
+              hy::RowsPtr compressed_records, config::ThreadNumType threads_num) noexcept
         : fds_(std::move(fds)),
           plis_(std::move(plis)),
-          compressed_records_(std::move(compressed_records)) {}
+          compressed_records_(std::move(compressed_records)),
+          threads_num_(threads_num) {}
 
     hy::IdPairs ValidateAndExtendCandidates();
 };


### PR DESCRIPTION
The HyFD algorithm was originally single-threaded,
which goes against its intended implementation.
If ThreadNumber option is specified in the algorithm configuration step,
the algorithm will utilize the specified number of threads.

This implementation was benchmarked on several large datasets such as:
- iowa1kk
- EpicMeds
- flight

The general trend is displayed in the following graph:
![hyfd_bench_threads_iowa1kk](https://github.com/Desbordante/desbordante-core/assets/73912760/f451c402-ed9f-4d56-a350-99da70b0cb94)
(data for iowa1kk dataset on i9-13905h)

Alternative implementations showing worse performance:
- Desbordante's utils::ParallelForEach
- std::future + std::async
- std::execution::par
- OpenMP parallel for macro
- TBB parallel for function

The final implementation showed high time consumption by memory allocation/deallocation.
In attempt of optimizing them the following allocators were benchmarked:
- tbb::scalable_allocator
- tcmalloc
- jemalloc
- mimalloc
All of which showed similar/worse performance,
therefore implementing custom allocator is probably useless.