### PR TITLE
Fix pyproject.toml metadata, disable python3.7

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -62,6 +62,7 @@ jobs:
     env:
       CIBW_ARCHS_LINUX: x86_64
       CIBW_BUILD: "*manylinux*"
+      CIBW_SKIP: "cp37-*"
       CIBW_TEST_REQUIRES: pytest
       CIBW_BUILD_VERBOSITY: 1
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Here is a list of papers about patterns, organized in the recommended reading or
 ## Installation (this is what you probably want if you are not a project maintainer)
 Desbordante is [available](https://pypi.org/project/desbordante/) at the Python Package Index (PyPI). Dependencies:
 
-* Python >=3.7 
+* Python >=3.8
 
 To install Desbordante type:
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -237,9 +237,7 @@ Here is a list of papers about patterns, organized in the recommended reading or
 
 The source code is currently hosted on GitHub at https://github.com/Desbordante/desbordante-core
 
-Wheels for the latest released version are available at the Python Package Index (PyPI).
-
-**Currently only manylinux2014 (Ubuntu 20.04+, or any other linux distribution with gcc 10+) is supported**.
+Wheels for all released version are available at the Python Package Index (PyPI) for  **manylinux2014** (Ubuntu 20.04+, or any other linux distribution with gcc 10+) and **macOS 11.0+**.
 
 ```bash
 $ pip install desbordante

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "desbordante"
-version = "2.3.0"
+version = "2.3.1"
 description = "Science-intensive high-performance data profiler"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = "README_PYPI.md"
 license = { text = "AGPL-3.0-only" }
 
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.7",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Add macOS classifier to pyproject.toml data.
Change python required version to 3.8
Skip Python3.7 in wheel-building action.
