### PR TITLE
Fix return value policies for IND and SFD bindings

### DIFF
--- a/src/python_bindings/ind/bind_ind.cpp
+++ b/src/python_bindings/ind/bind_ind.cpp
@@ -27,9 +27,9 @@ void BindInd(py::module_& main_module) {
     static constexpr auto kSpiderName = "Spider";
     static constexpr auto kMindName = "Mind";
 
-    auto ind_algos_module =
-            BindPrimitive<Spider, Faida, Mind>(ind_module, &INDAlgorithm::INDList, "IndAlgorithm",
-                                               "get_inds", {kSpiderName, "Faida", kMindName});
+    auto ind_algos_module = BindPrimitive<Spider, Faida, Mind>(
+            ind_module, &INDAlgorithm::INDList, "IndAlgorithm", "get_inds",
+            {kSpiderName, "Faida", kMindName}, pybind11::return_value_policy::copy);
     auto define_submodule = [&ind_algos_module, &main_module](char const* name,
                                                               std::vector<char const*> algorithms) {
         auto algos_module = main_module.def_submodule(name).def_submodule("algorithms");

--- a/src/python_bindings/sfd/bind_sfd.cpp
+++ b/src/python_bindings/sfd/bind_sfd.cpp
@@ -18,6 +18,9 @@ namespace python_bindings {
 void BindSFD(py::module_& main_module) {
     using namespace algos;
     auto sfd_module = main_module.def_submodule("sfd");
+
+    // NOTE: technically `Correlation` will contain an invalid pointer to the schema if the
+    // algorithm object is destroyed, but we do not use the schema anywhere.
     py::class_<Correlation>(sfd_module, "Correlation")
             .def("__str__", &Correlation::ToString)
             .def("to_string", &Correlation::ToString)
@@ -30,7 +33,7 @@ void BindSFD(py::module_& main_module) {
     auto cls = py::class_<Cords, FDAlgorithm>(sfd_algorithms_module, "SFDAlgorithm")
                        .def(py::init<>())
                        .def("get_correlations", &Cords::GetCorrelations,
-                            py::return_value_policy::reference_internal);
+                            py::return_value_policy::copy);
     sfd_algorithms_module.attr("Default") = cls;
 }
 }  // namespace python_bindings


### PR DESCRIPTION
With current return value policies the second execution of algorithms for IND, AIND and SFD mining breaks the results obtained after the first execution resulting in an error while trying to access the results.
Here are the examples of code that result in an error.
For INDs:

```python
import desbordante

TABLES = [(f'examples/datasets/ind_datasets/{table_name}.csv', ',', True) for table_name in
          ['course', 'department', 'instructor', 'student', 'teaches']]
algo = desbordante.ind.algorithms.Default()
algo.load_data(tables=TABLES)
algo.execute()
inds = algo.get_inds()
algo.execute()
print('Found inclusion dependencies (-> means "is included in"):\n')
for ind in inds:
    print(ind)
```
For AINDs:
```python
import desbordante

def get_table_path(dataset):
    return f"examples/datasets/ind_datasets/{dataset}.csv"

TABLE_NAMES = ['employee', 'project_assignments']
TABLES = [(get_table_path(name), ',', True) for name in TABLE_NAMES]

algo = desbordante.aind.algorithms.Mind()
algo.load_data(tables=TABLES)
algo.execute(error=0.3)

print()
print('Found inclusion dependencies (-> means "is included in"):')
inds=algo.get_inds()
algo.execute(error=0.2)
for ind in inds:
    print("IND:", ind)
```
For SFDs:
```python
import desbordante
import pandas as pd
import numpy as np

n_rows = 10000  # Number of rows in the dataset
np.random.seed(65)  # Set the random seed for reproducibility

# Generate attributes
A = np.random.randint(1, 100, n_rows)  # Initial column
B = 2 * A + np.random.choice([0, 1], n_rows, p=[0.95, 0.05])
C = A + B + np.random.choice([0, 27], n_rows, p=[0.85, 0.15])
D = 3 * C + np.random.choice([0, 5, 17, 34], n_rows,
                             p=[0.6, 0.1, 0.1, 0.2])
E = np.random.randint(1, 3, n_rows)  # Independent column
# Create a DataFrame
df = pd.DataFrame({
    'A': A,
    'B': B,
    'C': C,
    'D': D,
    'E': E
})

ONLY_SFD = False
MIN_CARDINALITY = 0.1
MAX_DIFF_VALS_PROPORTION = 0.99
MIN_SFD_STRENGTH_MEASURE = 0.1
MIN_SKEW_THRESHOLD = 0.5
MIN_STRUCTURAL_ZEROES_AMOUNT = 3e-01
MAX_FALSE_POSITIVE_PROBABILITY = 1e-06
DELTA = 0.11
MAX_AMOUNT_OF_CATEGORIES = 100

for i in range(15):
  algo = desbordante.sfd.algorithms.Default()
  algo.load_data(table=df)
  algo.execute(min_sfd_strength=MIN_SFD_STRENGTH_MEASURE,
               delta=DELTA,
               max_false_positive_probability=MAX_FALSE_POSITIVE_PROBABILITY,
               only_sfd=ONLY_SFD,
               min_cardinality=MIN_CARDINALITY,
               max_amount_of_categories=MAX_AMOUNT_OF_CATEGORIES,
               min_skew_threshold=MIN_SKEW_THRESHOLD,
               min_structural_zeroes_amount=MIN_STRUCTURAL_ZEROES_AMOUNT,
               max_different_values_proportion=MAX_DIFF_VALS_PROPORTION)
  fds = algo.get_fds()
  cors = algo.get_correlations()
  algo.execute(min_sfd_strength=MIN_SFD_STRENGTH_MEASURE,
               delta=DELTA,
               max_false_positive_probability=MAX_FALSE_POSITIVE_PROBABILITY,
               only_sfd=ONLY_SFD,
               min_cardinality=MIN_CARDINALITY,
               max_amount_of_categories=MAX_AMOUNT_OF_CATEGORIES,
               min_skew_threshold=MIN_SKEW_THRESHOLD,
               min_structural_zeroes_amount=MIN_STRUCTURAL_ZEROES_AMOUNT,
               max_different_values_proportion=MAX_DIFF_VALS_PROPORTION)
  print("Soft functional dependencies:")
  for fd in fds:
      print(fd)
  print("Correlations:")
  for cor in cors:
      print(cor)
```