### PR TITLE
Fix DC bindings

### DIFF
--- a/src/core/algorithms/dc/FastADC/fastadc.cpp
+++ b/src/core/algorithms/dc/FastADC/fastadc.cpp
@@ -19,6 +19,7 @@
 namespace algos::dc {
 
 FastADC::FastADC() : Algorithm({}) {
+    pred_index_provider_ = std::make_shared<PredicateIndexProvider>();
     RegisterOptions();
     MakeOptionsAvailable({config::kTableOpt.GetName()});
 }
@@ -105,7 +106,7 @@ unsigned long long FastADC::ExecuteInternal() {
     SetLimits();
     CheckTypes();
 
-    PredicateBuilder predicate_builder(&pred_provider_, &pred_index_provider_, allow_cross_columns_,
+    PredicateBuilder predicate_builder(&pred_provider_, pred_index_provider_, allow_cross_columns_,
                                        minimum_shared_value_, comparable_threshold_);
     predicate_builder.BuildPredicateSpace(typed_relation_->GetColumnData());
 
@@ -126,7 +127,8 @@ unsigned long long FastADC::ExecuteInternal() {
     LOG(DEBUG) << "Current time: " << elapsed_milliseconds.count();
 
     ApproxEvidenceInverter dcbuilder(predicate_builder, evidence_threshold_,
-                                     std::move(evidence_set_builder.evidence_set));
+                                     std::move(evidence_set_builder.evidence_set),
+                                     typed_relation_->GetSharedPtrSchema());
 
     dcs_ = dcbuilder.BuildDenialConstraints();
 

--- a/src/core/algorithms/dc/FastADC/fastadc.h
+++ b/src/core/algorithms/dc/FastADC/fastadc.h
@@ -25,7 +25,7 @@ private:
     config::InputTable input_table_;
     std::unique_ptr<model::ColumnLayoutTypedRelationData> typed_relation_;
 
-    PredicateIndexProvider pred_index_provider_;
+    std::shared_ptr<PredicateIndexProvider> pred_index_provider_;
     PredicateProvider pred_provider_;
     IntIndexProvider int_prov_;
     DoubleIndexProvider double_prov_;
@@ -40,7 +40,7 @@ private:
     void PrintResults();
 
     void ResetState() final {
-        pred_index_provider_.Clear();
+        pred_index_provider_->Clear();
         pred_provider_.Clear();
         int_prov_.Clear();
         double_prov_.Clear();

--- a/src/core/algorithms/dc/FastADC/model/denial_constraint.h
+++ b/src/core/algorithms/dc/FastADC/model/denial_constraint.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <sstream>
 #include <string>
 
@@ -15,16 +16,20 @@ namespace algos::fastadc {
 class DenialConstraint {
 private:
     PredicateSet predicate_set_;
+    std::shared_ptr<RelationalSchema const> schema_;
 
 public:
-    explicit DenialConstraint(PredicateSet const& predicateSet) : predicate_set_(predicateSet) {}
+    explicit DenialConstraint(PredicateSet const& predicateSet,
+                              std::shared_ptr<RelationalSchema const> schema)
+        : predicate_set_(predicateSet), schema_(schema) {}
 
     DenialConstraint(boost::dynamic_bitset<> const& predicates,
-                     PredicateIndexProvider* predicate_index_provider)
-        : predicate_set_(predicates, predicate_index_provider) {}
+                     std::shared_ptr<PredicateIndexProvider> predicate_index_provider,
+                     std::shared_ptr<RelationalSchema const> schema)
+        : predicate_set_(predicates, predicate_index_provider), schema_(schema) {}
 
     DenialConstraint GetInvT1T2DC(PredicateProvider* predicate_provider) const {
-        return DenialConstraint(predicate_set_.GetInvTS(predicate_provider));
+        return DenialConstraint(predicate_set_.GetInvTS(predicate_provider), schema_);
     }
 
     PredicateSet const& GetPredicateSet() const noexcept {

--- a/src/core/algorithms/dc/FastADC/model/predicate_set.h
+++ b/src/core/algorithms/dc/FastADC/model/predicate_set.h
@@ -20,13 +20,13 @@ private:
     mutable std::unique_ptr<PredicateSet> inv_set_TS_;  // Cached inverse set
 
 public:
-    PredicateIndexProvider* provider = nullptr;
+    std::shared_ptr<PredicateIndexProvider> provider;
 
-    explicit PredicateSet(PredicateIndexProvider* predicate_index_provider)
+    explicit PredicateSet(std::shared_ptr<PredicateIndexProvider> predicate_index_provider)
         : bitset_(0), provider(predicate_index_provider) {}
 
     explicit PredicateSet(boost::dynamic_bitset<> const& bitset,
-                          PredicateIndexProvider* predicate_index_provider)
+                          std::shared_ptr<PredicateIndexProvider> predicate_index_provider)
         : bitset_(bitset), provider(predicate_index_provider) {}
 
     PredicateSet(PredicateSet const& other) : bitset_(other.bitset_), provider(other.provider) {

--- a/src/core/algorithms/dc/FastADC/util/evidence_aux_structures_builder.h
+++ b/src/core/algorithms/dc/FastADC/util/evidence_aux_structures_builder.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <span>
 #include <stdexcept>
 #include <vector>
@@ -185,7 +186,7 @@ private:
     PredicatesVector const& num_cross_;
     PredicatesVector const& str_single_;
     PredicatesVector const& str_cross_;
-    PredicateIndexProvider* provider_;
+    std::shared_ptr<PredicateIndexProvider> provider_;
 };
 
 }  // namespace algos::fastadc

--- a/src/core/algorithms/dc/FastADC/util/predicate_builder.cpp
+++ b/src/core/algorithms/dc/FastADC/util/predicate_builder.cpp
@@ -18,7 +18,7 @@
 namespace algos::fastadc {
 
 PredicateBuilder::PredicateBuilder(PredicateProvider* predicate_provider,
-                                   PredicateIndexProvider* predicate_index_provider,
+                                   std::shared_ptr<PredicateIndexProvider> predicate_index_provider,
                                    bool allow_cross_columns, double minimum_shared_value,
                                    double comparable_threshold)
     : allow_cross_columns_(allow_cross_columns),

--- a/src/core/algorithms/dc/FastADC/util/predicate_builder.h
+++ b/src/core/algorithms/dc/FastADC/util/predicate_builder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <stddef.h>
 #include <utility>
 #include <vector>
@@ -56,7 +57,7 @@ private:
     std::vector<size_t> inverse_map_;
 
 public:
-    PredicateIndexProvider* predicate_index_provider;
+    std::shared_ptr<PredicateIndexProvider> predicate_index_provider;
     PredicateProvider* predicate_provider;
 
     PredicateBuilder(PredicateBuilder const& other) = delete;
@@ -84,8 +85,9 @@ public:
      * It's expressed as a fraction between 0 and 1.
      */
     PredicateBuilder(PredicateProvider* predicate_provider,
-                     PredicateIndexProvider* predicate_index_provider, bool allow_cross_columns,
-                     double minimum_shared_value = 0.3, double comparable_threshold = 0.1);
+                     std::shared_ptr<PredicateIndexProvider> predicate_index_provider,
+                     bool allow_cross_columns, double minimum_shared_value = 0.3,
+                     double comparable_threshold = 0.1);
 
     // TODO: can we pass just a vector of TypedColumnData, or there should be another table
     // representation?

--- a/src/python_bindings/dc/bind_fastadc.cpp
+++ b/src/python_bindings/dc/bind_fastadc.cpp
@@ -16,6 +16,7 @@ void BindFastADC(py::module_& main_module) {
     auto dc_module = main_module.def_submodule("dc");
     py::class_<DC>(dc_module, "DC").def("__str__", &DC::ToString).def("__repr__", &DC::ToString);
 
-    BindPrimitiveNoBase<dc::FastADC>(dc_module, "FastADC").def("get_dcs", &dc::FastADC::GetDCs);
+    BindPrimitiveNoBase<dc::FastADC>(dc_module, "FastADC")
+            .def("get_dcs", &dc::FastADC::GetDCs, py::return_value_policy::copy);
 }
 }  // namespace python_bindings

--- a/src/tests/test_dc_structures.cpp
+++ b/src/tests/test_dc_structures.cpp
@@ -251,7 +251,8 @@ protected:
     std::unique_ptr<model::ColumnLayoutTypedRelationData> table_;
     std::vector<model::TypedColumnData> col_data_;
 
-    PredicateIndexProvider pred_index_provider_;
+    std::shared_ptr<PredicateIndexProvider> pred_index_provider_ =
+            std::make_shared<PredicateIndexProvider>();
     PredicateProvider pred_provider_;
     IntIndexProvider int_prov_;
     DoubleIndexProvider double_prov_;
@@ -281,7 +282,7 @@ protected:
 
     void CreatePredicateBuilder() {
         predicate_builder_ =
-                new PredicateBuilder(&pred_provider_, &pred_index_provider_, allow_cross_columns_);
+                new PredicateBuilder(&pred_provider_, pred_index_provider_, allow_cross_columns_);
     }
 
     void CreatePliShardBuilder() {
@@ -545,7 +546,8 @@ TEST_F(FastADC, DenialConstraints) {
 
     auto&& evidence_set = std::move(evidence_set_builder_->evidence_set);
 
-    ApproxEvidenceInverter dcbuilder(*predicate_builder_, 0.01, std::move(evidence_set));
+    ApproxEvidenceInverter dcbuilder(*predicate_builder_, 0.01, std::move(evidence_set),
+                                     table_->GetSharedPtrSchema());
     auto dcs = dcbuilder.BuildDenialConstraints();
 
     std::vector<DenialConstraint> result = std::move(dcs.ObtainResult());


### PR DESCRIPTION
Currently, DC objects are depending on the algorithm object: if the algorithm object is destroyed, DC objects become invalidated. For example, the following code results in an error:
```python
import desbordante

TABLE_1 = "examples/datasets/taxes.csv"

def execute():
    algo = desbordante.dc.algorithms.Default()
    algo.load_data(table=(TABLE_1, ',', True))
    algo.execute(evidence_threshold=0, shard_length=0)
    dcs = algo.get_dcs()
    return dcs

dcs = execute()
print("Discovered DCs:")
for dc in dcs:
    print(dc)
```
My solution is similar to the one in #496: add shared pointers so that necessary fields used by DC objects are not destroyed when the algorithm object is destroyed.