### PR TITLE
Enable CTest; allow parallel test running

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -26,6 +26,11 @@ on:
       #- pyproject.toml
       #- examples/**
   workflow_dispatch:
+    inputs:
+      parallel-tests:
+        type: boolean
+        default: true
+        description: "Run tests in parallel"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -91,9 +96,13 @@ jobs:
             ./build.sh
           fi
       - name: Test
-        working-directory: ${{github.workspace}}/build/target
+        working-directory: ${{github.workspace}}/build
         shell: bash
         run: |
           export ${{ matrix.system.runtime-env }}
 
-          ./Desbordante_test --gtest_filter='*:-*HeavyDatasets*'
+          if [[ "${{ inputs.parallel-tests }}" != "false" ]]; then
+            export CTEST_ARGS="-j ${nproc}"
+          fi
+
+          ctest --exclude-regex ".*HeavyDatasets.*" $CTEST_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,8 +78,8 @@ else()
         # Set DEBUG build options specific for build with ASAN
         set(ASAN_OPTS "-fsanitize=address")
 
-        execute_process(COMMAND grep -q "Ubuntu" /etc/ose-release RESULT_VARIABLE IS_UBUNTU)
-        if (IS_UBUNTU AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        execute_process(COMMAND grep -q "Ubuntu" /etc/os-release RESULT_VARIABLE IS_UBUNTU)
+        if (IS_UBUNTU EQUAL 0 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
             # alloc-dealloc-mismatch generates false positives on boost exceptions
             # This applies only to Ubuntu package:
             # https://github.com/llvm/llvm-project/issues/59432?ysclid=m4y0iqca2c577414782

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ endif()
 add_subdirectory("src/core")
 
 if (COMPILE_TESTS)
+    enable_testing()
     add_subdirectory("src/tests")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ cd build/target
 ./Desbordante_test --gtest_filter='*:-*HeavyDatasets*'
 ```
 
+Alternatively, you can run tests with CTest from any directory in `Desbordante` tree:
+```sh
+ctest --test-dir build --exclude-regex ".*HeavyDatasets.*" -j $JOBS
+```
+where `$JOBS` is the desired number of concurrent jobs.
+
 `desbordante.cpython-*.so` is a Python module, packaging Python bindings for the Desbordante core library. In order to use it, simply `import` it:
 ```sh
 cd build/target

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,15 +1,16 @@
 set(BINARY ${CMAKE_PROJECT_NAME}_test)
 
 # getting GTest
-enable_testing()
+include(GoogleTest)
 
 # building tests
 file(GLOB_RECURSE test_sources "*.h*" "*.cpp*")
 add_executable(${BINARY} ${test_sources})
-add_test(NAME ${BINARY} COMMAND ${BINARY})
 
 # linking with gtest and implemented classes
 target_link_libraries(${BINARY} PRIVATE ${CMAKE_PROJECT_NAME} gtest gmock Boost::graph)
+
+gtest_discover_tests(${BINARY} WORKING_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
 # copying sample csv's for testing
 add_custom_target(copy-files ALL


### PR DESCRIPTION
- Connect GoogleTest to CTest to make test execution with `ctest` command possible.
- Enable parallel test running in CI to speed up `core-tests` task significantly:
  - The whole `core-tests` task:
     Before:  ![total_before](https://github.com/user-attachments/assets/5d160913-b270-4126-87d3-e73df59288c1), after: ![total_after](https://github.com/user-attachments/assets/145af13c-3510-4291-9ac7-eec5be552f1f);
  - GCC, Debug:
    Before:
    ![gcc_debug_before](https://github.com/user-attachments/assets/1262c6a4-822b-430f-9085-6354c7f5ab61)
    After:
    ![gcc_debug_after](https://github.com/user-attachments/assets/ec7f3742-7bb2-420a-9765-c5359dbad675)
  - Apple Clang, Debug:
    Before:
    ![apple_clang_before](https://github.com/user-attachments/assets/a69fc5c9-eb55-49d9-afe5-f7263834b763)
    After:
    ![apple_clang_after](https://github.com/user-attachments/assets/7cd326e4-7c33-43a6-8816-62f9e0fb867d)
- Fix a typo in CMakeLists, in a workaround of Clang Address Sanitizer bug on Ubuntu.