### PR TITLE
Explicitly use CMake 3.31, ad-hoc related to #549

### DIFF
--- a/.github/composite-actions/install-dependencies/action.yml
+++ b/.github/composite-actions/install-dependencies/action.yml
@@ -53,6 +53,18 @@ runs:
 
         echo "OS=$(get_short_os_name ${{ inputs.os }})" >> $GITHUB_ENV
 
+    - name: Create python virtual environment
+      run: | 
+          python3 -m venv .venv
+      shell: bash
+
+    # Add-hoc for https://github.com/Desbordante/desbordante-core/issues/549
+    - name: Install cmake 3.31.6 in python venv
+      run: |
+        source .venv/bin/activate
+        python3 -m pip install cmake==3.31.6 # ad-hoc
+      shell: bash
+
     - name: Install build tools using apt
       run: |
         sudo apt-get update -y

--- a/.github/workflows/bindings-tests.yml
+++ b/.github/workflows/bindings-tests.yml
@@ -82,15 +82,14 @@ jobs:
         run: |
           export ${{ matrix.env }}
 
-          python3 -m venv venv
-          source venv/bin/activate
+          source .venv/bin/activate
           python3 -m pip install .
       - name: Test pip package
         shell: bash
         run: |
           export ${{ matrix.runtime-env }}
 
-          source venv/bin/activate
+          source .venv/bin/activate
 
           cp test_input_data/WDC_satellites.csv src/python_bindings/
           cp test_input_data/TestLong.csv src/python_bindings/
@@ -105,7 +104,7 @@ jobs:
         run: |
           export ${{ matrix.runtime-env }}
 
-          source venv/bin/activate
+          source .venv/bin/activate
 
           cp test_input_data/TestDataStats.csv src/python_bindings
           cd src/python_bindings

--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -64,6 +64,7 @@ jobs:
           download-pybind: true
       - name: Generate compile_commands.json
         run: |
+          source .venv/bin/activate
           cmake -DCMAKE_CXX_COMPILER=g++-10 \
             -DCMAKE_BUILD_TYPE=Debug \
             -Dgtest_disable_pthreads=OFF \

--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -84,6 +84,7 @@ jobs:
         shell: bash
         run: |
           export ${{ matrix.system.env }}
+          source .venv/bin/activate
 
           if [[ "${{matrix.cfg.BUILD_TYPE}}" == "Debug" ]]; then
             ./build.sh --debug --sanitizer=${{ matrix.cfg.SANITIZER }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.25...3.31)
+
+# https://github.com/Desbordante/desbordante-core/issues/549
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0)
+    message(FATAL_ERROR "The project does not currently support versions 4.0 or higher.")
+endif()
+
 if (POLICY CMP0167)
     # deprecated by definition, but we use old behaviour for find_package(Boost) to load CMake's FindBoost module
     # TODO: port project to "Modern CMake" https://gist.github.com/mbinna/c61dbb39bca0e4fb7d1f73b0d66a4fd1

--- a/datasets/CMakeLists.txt
+++ b/datasets/CMakeLists.txt
@@ -1,13 +1,9 @@
-add_custom_target(make-input-data-dir ALL)
-add_custom_command(
-	TARGET make-input-data-dir
+add_custom_target(make-input-data-dir ALL
 	COMMAND ${CMAKE_COMMAND} -E make_directory
 		${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/input_data/
 )
 
-add_custom_target( unZip ALL )
-add_custom_command(
-	TARGET unZip
+add_custom_target(unZip ALL 
 	COMMAND ${CMAKE_COMMAND} -E tar xzf
 		${CMAKE_SOURCE_DIR}/datasets/datasets.zip
 	DEPENDS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core", "pybind11", "cmake>=3.25,<4.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -45,5 +45,5 @@ exclude = [
     "build.bat",
     "test_input_data/",
     "src/tests/*",
-    "examples/*"
+    "examples/*",
 ]


### PR DESCRIPTION
Set CMake 4.x as unsupported for project.
Use CMake 3.31 in CI explicitly with python venv and CMake from PyPi. 
Fix undocumented commands in datasets/CMakeLists.txt.

Related to #549 