### PR TITLE
Performance testing baseline bug

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
           gh run list --repo "${{ github.repository }}" --limit ${{ env.num-runs }} \
             --workflow "${{ github.workflow }}" --json 'databaseId' --jq '[.[].databaseId]' \
-            >ids.json
+            --branch "${{ github.ref_name }}" >ids.json
 
           mkdir -p old-results
           for (( i = 0; i < ${{ env.num-runs }}; i = $i + 1 )); do
@@ -76,7 +76,7 @@ jobs:
             echo 'LastSuccID<<EOF'
             gh run list --repo "${{ github.repository }}" --limit 1 \
               --status success --workflow "${{ github.workflow }}" --json 'databaseId' \
-              --jq '.[].databaseId'
+              --jq '.[].databaseId' --branch "${{ github.ref_name }}"
             echo 'EOF'
           } >>"$GITHUB_ENV"
       - name: Get baseline results

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -87,6 +87,7 @@ jobs:
           pattern: baseline-v1.json
           run-id: ${{ env.LastSuccID }}
           github-token: ${{ secrets.PERFORMANCEREGRESSIONTESTING }}
+        if: ${{ env.LastSuccID != '' }}
       - name: Check baseline results
         # Each successful run must have a "baseline" attached.
         # If not, there's no baseline at all; use latest instead.

--- a/src/tests/benchmark/fd_benchmark.h
+++ b/src/tests/benchmark/fd_benchmark.h
@@ -42,7 +42,7 @@ inline void FDBenchmark(BenchmarkRunner& runner, BenchmarkComparer& comparer) {
                 dataset,
                 {{kError, static_cast<config::ErrorType>(0.95)}, {kAfdErrorMeasure, measure}},
                 measure._to_string());
-        comparer.SetThreshold(tane_name, 15);
+        comparer.SetThreshold(tane_name, 20);
     }
 
 // EulerFD tests are currently disabled, since test below runs less than a second, and


### PR DESCRIPTION
* Fix bug when performance testing crashed on first run becuase of missing baseline;
* Add branch filter in previous results downloads to allow several branches with performance testing in a single fork;
* Raise Tane threshold to 20%, because 15% was not enough for some metrics.