### PR TITLE
Remove bitset boilerplate

### DIFF
--- a/src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h
+++ b/src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h
@@ -14,6 +14,7 @@
 #include "dc/FastADC/util/denial_constraint_set.h"
 #include "dc/FastADC/util/predicate_builder.h"
 #include "dc/FastADC/util/predicate_organizer.h"
+#include "util/set_bits_view.h"
 
 namespace algos::fastadc {
 
@@ -197,8 +198,7 @@ private:
         dc_candidates.ForEach([this](DCCandidate const& dc) { approx_covers_.Add(dc); });
         for (auto const& invalid_dc : invalid_dcs) {
             boost::dynamic_bitset<> can_add = invalid_dc.cand & (~evi);
-            for (size_t i = can_add.find_first(); i != boost::dynamic_bitset<>::npos;
-                 i = can_add.find_next(i)) {
+            for (size_t i : util::SetBits(can_add)) {
                 DCCandidate valid_dc{.bitset = invalid_dc.bitset};
                 valid_dc.bitset.set(i);
                 if (!approx_covers_.ContainsSubset(valid_dc)) approx_covers_.Add(valid_dc);
@@ -211,8 +211,7 @@ private:
                                   PredicateBitset const& evi, size_t e, int64_t target) {
         for (auto const& invalid_dc : invalid_dcs) {
             boost::dynamic_bitset<> can_add = invalid_dc.cand & (~evi);
-            for (size_t i = can_add.find_first(); i != boost::dynamic_bitset<>::npos;
-                 i = can_add.find_next(i)) {
+            for (size_t i : util::SetBits(can_add)) {
                 DCCandidate valid_dc = invalid_dc;
                 valid_dc.bitset.set(i);
                 valid_dc.cand &= (~mutex_map_[i]);

--- a/src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp
+++ b/src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp
@@ -2,6 +2,7 @@
 
 #include "dc/FastADC/model/predicate.h"
 #include "dc/FastADC/util/dc_candidate.h"
+#include "util/set_bits_view.h"
 
 namespace algos::fastadc {
 
@@ -13,8 +14,7 @@ bool DCCandidateTrie::Add(DCCandidate const& add_dc) {
     boost::dynamic_bitset<> const& bitset = add_dc.bitset;
     DCCandidateTrie* tree_node = this;
 
-    for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
-         i = bitset.find_next(i)) {
+    for (size_t i : util::SetBits(bitset)) {
         auto& subtree = tree_node->subtrees_[i];
         if (!subtree) {
             subtree = std::make_unique<DCCandidateTrie>(max_subtrees_);
@@ -48,8 +48,7 @@ void DCCandidateTrie::GetAndRemoveGeneralizationsAux(boost::dynamic_bitset<> con
         dc_.reset();
     }
 
-    for (size_t i = superset.find_first(); i != boost::dynamic_bitset<>::npos;
-         i = superset.find_next(i)) {
+    for (size_t i : util::SetBits(superset)) {
         auto& subtree = subtrees_[i];
         if (subtree) {
             subtree->GetAndRemoveGeneralizationsAux(superset, removed);
@@ -83,8 +82,7 @@ DCCandidate* DCCandidateTrie::GetSubsetAux(DCCandidate const& add) {
 
     boost::dynamic_bitset<> const& bitset = add.bitset;
 
-    for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
-         i = bitset.find_next(i)) {
+    for (size_t i : util::SetBits(bitset)) {
         auto& subtree = subtrees_[i];
         if (subtree) {
             DCCandidate* res = subtree->GetSubsetAux(add);

--- a/src/core/algorithms/dc/FastADC/util/predicate_organizer.h
+++ b/src/core/algorithms/dc/FastADC/util/predicate_organizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dc/FastADC/model/evidence_set.h"
+#include "util/set_bits_view.h"
 
 namespace algos::fastadc {
 
@@ -56,8 +57,7 @@ public:
     boost::dynamic_bitset<> Retransform(boost::dynamic_bitset<> const& bitset) const {
         boost::dynamic_bitset<> valid{kPredicateBits};
 
-        for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
-             i = bitset.find_next(i)) {
+        for (size_t i : util::SetBits(bitset)) {
             valid.set(indexes_[i]);  // indexes_[i] is <= than number of predicates
         }
 
@@ -76,7 +76,7 @@ private:
 
         for (auto const& evidence : evidence_set_) {
             PredicateBitset bitset = evidence.evidence;
-            for (size_t i = bitset._Find_first(); i != bitset.size(); i = bitset._Find_next(i)) {
+            for (size_t i : util::SetBits(bitset)) {
                 counts[i]++;
             }
         }

--- a/src/core/algorithms/fd/aidfd/aid.cpp
+++ b/src/core/algorithms/fd/aidfd/aid.cpp
@@ -1,6 +1,7 @@
 #include "aid.h"
 
 #include "config/tabular_data/input_table/option.h"
+#include "util/set_bits_view.h"
 
 namespace algos {
 
@@ -156,9 +157,7 @@ boost::dynamic_bitset<> Aid::BuildAgreeSet(size_t t1, size_t t2) {
 void Aid::HandleConstantColumns(boost::dynamic_bitset<>& attributes) {
     boost::dynamic_bitset<> empty_set(number_of_attributes_);
     Vertical lhs = *schema_->empty_vertical_;
-    for (size_t attr_num = constant_columns_.find_first();
-         attr_num != boost::dynamic_bitset<>::npos;
-         attr_num = constant_columns_.find_next(attr_num)) {
+    for (size_t attr_num : util::SetBits(constant_columns_)) {
         attributes[attr_num] = false;
         Column rhs = *schema_->GetColumn(attr_num);
         RegisterFd(lhs, rhs, schema_);

--- a/src/core/algorithms/fd/aidfd/search_tree.cpp
+++ b/src/core/algorithms/fd/aidfd/search_tree.cpp
@@ -1,5 +1,7 @@
 #include "search_tree.h"
 
+#include "util/set_bits_view.h"
+
 SearchTree::Node::Node(size_t bit, SearchTree::Bitset set, SearchTree::Bitset sets_union,
                        SearchTree::Bitset sets_inter, std::shared_ptr<Node> const& parent,
                        std::shared_ptr<Node> left, std::shared_ptr<Node> right)
@@ -44,7 +46,7 @@ SearchTree::SearchTree(Bitset const& set) : number_of_attributes_(set.size()) {
 }
 
 void SearchTree::CreateSingleElementSets(Bitset const& set) {
-    for (size_t bit = set.find_first(); bit != Bitset::npos; bit = set.find_next(bit)) {
+    for (size_t bit : util::SetBits(set)) {
         Bitset bitset_to_add(number_of_attributes_);
         bitset_to_add.set(bit);
         Add(bitset_to_add);

--- a/src/core/algorithms/fd/eulerfd/search_tree.cpp
+++ b/src/core/algorithms/fd/eulerfd/search_tree.cpp
@@ -1,5 +1,7 @@
 #include "search_tree.h"
 
+#include "util/set_bits_view.h"
+
 namespace algos {
 
 SearchTreeEulerFD::Node::Node(size_t bit, SearchTreeEulerFD::Bitset set,
@@ -51,7 +53,7 @@ SearchTreeEulerFD::SearchTreeEulerFD(Bitset const& set) : number_of_attributes_(
 }
 
 void SearchTreeEulerFD::CreateSingleElementSets(Bitset const& set) {
-    for (size_t bit = set.find_first(); bit != Bitset::npos; bit = set.find_next(bit)) {
+    for (size_t bit : util::SetBits(set)) {
         Bitset bitset_to_add(number_of_attributes_);
         bitset_to_add.set(bit);
         Add(bitset_to_add);

--- a/src/core/algorithms/fd/fdep/fd_tree_element.cpp
+++ b/src/core/algorithms/fd/fdep/fd_tree_element.cpp
@@ -1,6 +1,7 @@
 #include "fd_tree_element.h"
 
 #include "model/types/bitset.h"
+#include "set_bits_view.h"
 
 FDTreeElement::FDTreeElement(size_t max_attribute_number)
     : max_attribute_number_(max_attribute_number) {
@@ -154,7 +155,7 @@ void FDTreeElement::AddFunctionalDependency(model::Bitset<FDTreeElement::kMaxAtt
     FDTreeElement* current_node = this;
     this->AddRhsAttribute(attr_num);
 
-    for (size_t i = lhs._Find_first(); i != kMaxAttrNum; i = lhs._Find_next(i)) {
+    for (size_t i : util::SetBits(lhs)) {
         if (current_node->children_[i - 1] == nullptr) {
             current_node->children_[i - 1] =
                     std::make_unique<FDTreeElement>(this->max_attribute_number_);
@@ -217,8 +218,7 @@ void FDTreeElement::PrintDependencies(model::Bitset<FDTreeElement::kMaxAttrNum>&
         if (this->is_fd_[attr - 1]) {
             out = "{";
 
-            for (size_t i = active_path._Find_first(); i != kMaxAttrNum;
-                 i = active_path._Find_next(i)) {
+            for (size_t i : util::SetBits(active_path)) {
                 if (!column_id.empty())
                     out += column_id + std::to_string(std::stoi(column_names[i - 1]) + 1) + ",";
                 else
@@ -259,8 +259,7 @@ void FDTreeElement::TransformTreeFdCollection(
     for (size_t attr = 1; attr <= this->max_attribute_number_; ++attr) {
         if (this->is_fd_[attr - 1]) {
             boost::dynamic_bitset<> lhs_bitset(kMaxAttrNum);
-            for (size_t i = active_path._Find_first(); i != kMaxAttrNum;
-                 i = active_path._Find_next(i)) {
+            for (size_t i : util::SetBits(active_path)) {
                 if (i > 0) {
                     lhs_bitset.set(i - 1);
                 }

--- a/src/core/algorithms/fd/fdep/fdep.cpp
+++ b/src/core/algorithms/fd/fdep/fdep.cpp
@@ -97,8 +97,7 @@ void FDep::AddViolatedFDs(std::vector<size_t> const& t1, std::vector<size_t> con
     }
 
     equal_attr &= (~diff_attr);
-    for (size_t attr = diff_attr._Find_first(); attr != FDTreeElement::kMaxAttrNum;
-         attr = diff_attr._Find_next(attr)) {
+    for (size_t attr : util::SetBits(diff_attr)) {
         this->neg_cover_tree_->AddFunctionalDependency(equal_attr, attr);
     }
 }

--- a/src/core/algorithms/fd/hycommon/preprocessor.cpp
+++ b/src/core/algorithms/fd/hycommon/preprocessor.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "algorithms/fd/hycommon/util/pli_util.h"
+#include "util/set_bits_view.h"
 
 namespace algos::hy::util {
 
@@ -87,7 +88,7 @@ std::tuple<PLIs, Rows, std::vector<ClusterId>> Preprocess(ColumnLayoutRelationDa
 boost::dynamic_bitset<> RestoreAgreeSet(boost::dynamic_bitset<> const& as,
                                         std::vector<ClusterId> const& og_mapping, size_t num_cols) {
     boost::dynamic_bitset<> mapped_as(num_cols);
-    for (size_t i = as.find_first(); i != boost::dynamic_bitset<>::npos; i = as.find_next(i)) {
+    for (size_t i : ::util::SetBits(as)) {
         mapped_as.set(og_mapping[i]);
     }
     return mapped_as;

--- a/src/core/algorithms/fd/hyfd/inductor.cpp
+++ b/src/core/algorithms/fd/hyfd/inductor.cpp
@@ -2,6 +2,8 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "util/set_bits_view.h"
+
 namespace algos::hyfd {
 
 void Inductor::UpdateFdTree(NonFDList&& non_fds) {
@@ -12,8 +14,7 @@ void Inductor::UpdateFdTree(NonFDList&& non_fds) {
             auto rhs_bits = lhs_bits;
             rhs_bits.flip();
 
-            for (size_t rhs_id = rhs_bits.find_first(); rhs_id != boost::dynamic_bitset<>::npos;
-                 rhs_id = rhs_bits.find_next(rhs_id)) {
+            for (size_t rhs_id : util::SetBits(rhs_bits)) {
                 SpecializeTreeForNonFd(lhs_bits, rhs_id);
             }
         }

--- a/src/core/algorithms/fd/hyfd/model/fd_tree.cpp
+++ b/src/core/algorithms/fd/hyfd/model/fd_tree.cpp
@@ -5,14 +5,15 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "util/set_bits_view.h"
+
 namespace algos::hyfd::fd_tree {
 
 std::shared_ptr<FDTreeVertex> FDTree::AddFD(boost::dynamic_bitset<> const& lhs, size_t rhs) {
     FDTreeVertex* cur_node = root_.get();
     cur_node->SetAttribute(rhs);
 
-    for (size_t bit = lhs.find_first(); bit != boost::dynamic_bitset<>::npos;
-         bit = lhs.find_next(bit)) {
+    for (size_t bit : util::SetBits(lhs)) {
         bool is_new = cur_node->AddChild(bit);
 
         if (is_new && lhs.find_next(bit) == boost::dynamic_bitset<>::npos) {
@@ -32,8 +33,7 @@ std::shared_ptr<FDTreeVertex> FDTree::AddFD(boost::dynamic_bitset<> const& lhs, 
 bool FDTree::ContainsFD(boost::dynamic_bitset<> const& lhs, size_t rhs) {
     FDTreeVertex const* cur_node = root_.get();
 
-    for (size_t bit = lhs.find_first(); bit != boost::dynamic_bitset<>::npos;
-         bit = lhs.find_next(bit)) {
+    for (size_t bit : util::SetBits(lhs)) {
         if (!cur_node->HasChildren() || !cur_node->ContainsChildAt(bit)) {
             return false;
         }

--- a/src/core/algorithms/fd/hyfd/model/fd_tree_vertex.cpp
+++ b/src/core/algorithms/fd/hyfd/model/fd_tree_vertex.cpp
@@ -5,6 +5,8 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "util/set_bits_view.h"
+
 namespace algos::hyfd::fd_tree {
 
 void FDTreeVertex::GetLevelRecursive(unsigned target_level, unsigned cur_level,
@@ -119,8 +121,7 @@ std::shared_ptr<FDTreeVertex> FDTreeVertex::GetChildIfExists(size_t pos) const {
 }
 
 void FDTreeVertex::FillFDs(std::vector<RawFD>& fds, boost::dynamic_bitset<>& lhs) const {
-    for (size_t rhs = fds_.find_first(); rhs != boost::dynamic_bitset<>::npos;
-         rhs = fds_.find_next(rhs)) {
+    for (size_t rhs : util::SetBits(fds_)) {
         fds.emplace_back(lhs, rhs);
     }
 

--- a/src/core/algorithms/fd/hyfd/validator.cpp
+++ b/src/core/algorithms/fd/hyfd/validator.cpp
@@ -13,13 +13,13 @@
 #include "algorithms/fd/hycommon/util/pli_util.h"
 #include "algorithms/fd/hycommon/validator_helpers.h"
 #include "hyfd_config.h"
+#include "util/set_bits_view.h"
 
 namespace {
 
 std::unordered_set<size_t> AsSet(boost::dynamic_bitset<> const& bitset) {
     std::unordered_set<size_t> valid_rhss(bitset.count());
-    for (size_t attr = bitset.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = bitset.find_next(attr)) {
+    for (size_t attr : util::SetBits(bitset)) {
         valid_rhss.insert(attr);
     }
     return valid_rhss;
@@ -31,8 +31,7 @@ std::pair<std::vector<size_t>, std::vector<size_t>> BuildRhsMappings(
     rhs_column_ids.reserve(rhs.count());
     std::vector<size_t> rhs_ranks(compressed_records[0].size());
 
-    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = rhs.find_next(attr)) {
+    for (size_t attr : util::SetBits(rhs)) {
         rhs_ranks[attr] = rhs_column_ids.size();
         rhs_column_ids.push_back(attr);
     }
@@ -154,8 +153,7 @@ Validator::FDValidations Validator::ProcessZeroLevel(LhsPair const& lhsPair) {
     result.SetCountValidations(rhs_count);
     result.SetCountIntersections(rhs_count);
 
-    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = rhs.find_next(attr)) {
+    for (size_t attr : util::SetBits(rhs)) {
         if (!(*plis_)[attr]->IsConstant()) {
             vertex->RemoveFd(attr);
             result.InvalidInstances().emplace_back(lhs, attr);
@@ -180,8 +178,7 @@ Validator::FDValidations Validator::ProcessFirstLevel(LhsPair const& lhs_pair) {
     result.SetCountIntersections(rhs_count);
     result.SetCountValidations(rhs_count);
 
-    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = rhs.find_next(attr)) {
+    for (size_t attr : util::SetBits(rhs)) {
         for (auto const& cluster : (*plis_)[lhs_attr]->GetIndex()) {
             size_t const cluster_id = (*compressed_records_)[cluster[0]][attr];
             if (algos::hy::PLIUtil::IsSingletonCluster(cluster_id) ||
@@ -221,8 +218,7 @@ Validator::FDValidations Validator::ProcessHigherLevel(LhsPair const& lhs_pair) 
     rhs &= ~valid_rhss;
     vertex->SetFds(valid_rhss);
 
-    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = rhs.find_next(attr)) {
+    for (size_t attr : util::SetBits(rhs)) {
         result.InvalidInstances().emplace_back(lhs, attr);
     }
 

--- a/src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h
+++ b/src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h
@@ -7,6 +7,7 @@
 #include <easylogging++.h>
 
 #include "agree_set_sample.h"
+#include "util/set_bits_view.h"
 
 namespace model {
 
@@ -62,9 +63,7 @@ std::unique_ptr<T> AgreeSetSample::CreateFocusedFor(ColumnLayoutRelationData con
     free_column_indices.set();
     free_column_indices &= ~restriction_vertical.GetColumnIndices();
     std::vector<std::reference_wrapper<ColumnData const>> relevant_column_data;
-    for (size_t column_index = free_column_indices.find_first();
-         column_index != boost::dynamic_bitset<>::npos;
-         column_index = free_column_indices.find_next(column_index)) {
+    for (size_t column_index : util::SetBits(free_column_indices)) {
         relevant_column_data.emplace_back(relation->GetColumnData(column_index));
     }
     boost::dynamic_bitset<> agree_set_prototype(restriction_vertical.GetColumnIndices());

--- a/src/core/algorithms/fd/tane/model/lattice_vertex.cpp
+++ b/src/core/algorithms/fd/tane/model/lattice_vertex.cpp
@@ -1,5 +1,7 @@
 #include "lattice_vertex.h"
 
+#include "util/set_bits_view.h"
+
 namespace model {
 
 using boost::dynamic_bitset, std::vector, std::shared_ptr, std::make_shared, std::string;
@@ -54,8 +56,7 @@ std::ostream& operator<<(std::ostream& os, LatticeVertex& lv) {
     os << "Vertex: " << lv.vertical_.ToString() << endl;
 
     string rhs;
-    for (size_t index = lv.rhs_candidates_.find_first(); index != dynamic_bitset<>::npos;
-         index = lv.rhs_candidates_.find_next(index)) {
+    for (size_t index : util::SetBits(lv.rhs_candidates_)) {
         rhs += std::to_string(index) + " ";
     }
     os << "Rhs Candidates: " << rhs << endl;

--- a/src/core/algorithms/fd/tane/tane_common.cpp
+++ b/src/core/algorithms/fd/tane/tane_common.cpp
@@ -14,6 +14,7 @@
 #include "model/table/column_data.h"
 #include "model/table/column_layout_relation_data.h"
 #include "model/table/relational_schema.h"
+#include "util/set_bits_view.h"
 
 namespace algos {
 using boost::dynamic_bitset;
@@ -47,9 +48,7 @@ void TaneCommon::Prune(model::LatticeLevel* level) {
 
                 vertex->SetKeyCandidate(false);
                 if (ucc_error == 0) {
-                    for (std::size_t rhs_index = vertex->GetRhsCandidates().find_first();
-                         rhs_index != boost::dynamic_bitset<>::npos;
-                         rhs_index = vertex->GetRhsCandidates().find_next(rhs_index)) {
+                    for (std::size_t rhs_index : util::SetBits(vertex->GetRhsCandidates())) {
                         Vertical rhs = static_cast<Vertical>(*schema->GetColumn((int)rhs_index));
                         if (!columns.Contains(rhs)) {
                             bool is_rhs_candidate = true;

--- a/src/core/algorithms/ucc/hpivalid/result_collector.cpp
+++ b/src/core/algorithms/ucc/hpivalid/result_collector.cpp
@@ -7,6 +7,8 @@
 
 #include <easylogging++.h>
 
+#include "util/set_bits_view.h"
+
 // see algorithms/ucc/hpivalid/LICENSE
 
 namespace algos::hpiv {
@@ -41,7 +43,7 @@ bool ResultCollector::UCCFound(Edge const& ucc) {
 void ResultCollector::FinalHypergraph(Hypergraph const& hg) {
     std::stringstream out;
     for (Edge const& e : hg) {
-        for (Edge::size_type v = e.find_first(); v != Edge::npos; v = e.find_next(v)) {
+        for (Edge::size_type v : util::SetBits(e)) {
             if (v != e.find_first()) {
                 out << ",";
             }

--- a/src/core/algorithms/ucc/hpivalid/tree_search.cpp
+++ b/src/core/algorithms/ucc/hpivalid/tree_search.cpp
@@ -15,6 +15,7 @@
 #include "algorithms/ucc/hpivalid/config.h"
 #include "algorithms/ucc/hpivalid/pli_table.h"
 #include "algorithms/ucc/hpivalid/result_collector.h"
+#include "util/set_bits_view.h"
 
 // see algorithms/ucc/hpivalid/LICENSE
 
@@ -60,8 +61,7 @@ void TreeSearch::Run() {
     std::vector<Edgemark> vertexhittings(partial_hg_.NumVertices(),
                                          Edgemark(partial_hg_.NumEdges()));
     for (std::vector<Edge>::size_type i_e = 0; i_e < partial_hg_.NumEdges(); ++i_e) {
-        for (Edge::size_type i_v = partial_hg_[i_e].find_first(); i_v != Edge::npos;
-             i_v = partial_hg_[i_e].find_next(i_v)) {
+        for (Edge::size_type i_v : util::SetBits(partial_hg_[i_e])) {
             vertexhittings[i_v].set(i_e);
         }
     }
@@ -85,7 +85,7 @@ void TreeSearch::Run() {
     cand -= c;
 
     try {
-        for (Edge::size_type v = c.find_first(); v != Edge::npos; v = c.find_next(v)) {
+        for (Edge::size_type v : util::SetBits(c)) {
             // update crit and uncov
             UpdateCritAndUncov(removed_criticals_stack, crit, uncov, vertexhittings[v]);
 
@@ -136,7 +136,7 @@ void TreeSearch::ComputeNiceness() {
 unsigned long TreeSearch::Niceness(Edge const& e) const {
     unsigned long niceness = 0;
     if (cfg_.tiebreaker_heuristic) {
-        for (std::size_t col = e.find_first(); col != Edge::npos; col = e.find_next(col)) {
+        for (std::size_t col : util::SetBits(e)) {
             if (niceness < niceness_[col]) {
                 niceness = niceness_[col];
             }
@@ -278,7 +278,7 @@ inline bool TreeSearch::ExtendOrConfirmS(
 
     cand -= c;
 
-    for (Edge::size_type v = c.find_first(); v != Edge::npos; v = c.find_next(v)) {
+    for (Edge::size_type v : util::SetBits(c)) {
         // don't branch if v is violater for S
         if (IsViolater(crit, vertexhittings[v])) {
             continue;
@@ -433,8 +433,7 @@ inline void TreeSearch::UpdateEdges(std::vector<Edgemark>& crit, Edgemark& uncov
     }
     for (std::size_t i_e = partial_hg_.NumEdges() - new_edges.NumEdges();
          i_e < partial_hg_.NumEdges(); ++i_e) {
-        for (Edge::size_type i_v = partial_hg_[i_e].find_first(); i_v != Edge::npos;
-             i_v = partial_hg_[i_e].find_next(i_v)) {
+        for (Edge::size_type i_v : util::SetBits(partial_hg_[i_e])) {
             vertexhittings[i_v].set(i_e);
         }
     }

--- a/src/core/algorithms/ucc/hyucc/model/ucc_tree.cpp
+++ b/src/core/algorithms/ucc/hyucc/model/ucc_tree.cpp
@@ -1,13 +1,14 @@
 #include "ucc_tree.h"
 
+#include "util/set_bits_view.h"
+
 namespace algos::hyucc {
 
 UCCTreeVertex* UCCTree::AddUCC(boost::dynamic_bitset<> const& ucc, bool* is_new_out) {
     UCCTreeVertex* cur_node = root_.get();
 
     assert(ucc.any());
-    for (size_t attr = ucc.find_first(); attr != boost::dynamic_bitset<>::npos;
-         attr = ucc.find_next(attr)) {
+    for (size_t attr : util::SetBits(ucc)) {
         bool is_new = cur_node->AddChild(attr);
         if (is_new_out != nullptr) {
             *is_new_out = is_new;

--- a/src/core/model/table/relational_schema.cpp
+++ b/src/core/model/table/relational_schema.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <utility>
 
+#include "util/set_bits_view.h"
 #include "vertical.h"
 #include "vertical_map.h"
 
@@ -89,10 +90,7 @@ std::unordered_set<Vertical> RelationalSchema::CalculateHittingSet(
         }
 
         for (auto& invalid_member : invalid_hitting_set_members) {
-            for (size_t corrective_column_index = vertical.GetColumnIndices().find_first();
-                 corrective_column_index != boost::dynamic_bitset<>::npos;
-                 corrective_column_index =
-                         vertical.GetColumnIndices().find_next(corrective_column_index)) {
+            for (size_t corrective_column_index : util::SetBits(vertical.GetColumnIndices())) {
                 auto corrective_column = *GetColumn(corrective_column_index);
                 auto corrected_member =
                         invalid_member.Union(static_cast<Vertical>(corrective_column));

--- a/src/core/model/table/vertical.cpp
+++ b/src/core/model/table/vertical.cpp
@@ -2,6 +2,8 @@
 
 #include <utility>
 
+#include "util/set_bits_view.h"
+
 Vertical::Vertical(RelationalSchema const* rel_schema, boost::dynamic_bitset<> indices)
     : column_indices_(std::move(indices)), schema_(rel_schema) {}
 
@@ -76,8 +78,7 @@ std::unique_ptr<Vertical> Vertical::EmptyVertical(RelationalSchema const* rel_sc
 
 std::vector<Column const*> Vertical::GetColumns() const {
     std::vector<Column const*> columns;
-    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = column_indices_.find_next(index)) {
+    for (size_t index : util::SetBits(column_indices_)) {
         columns.push_back(schema_->GetColumns()[index].get());
     }
     return columns;
@@ -85,8 +86,7 @@ std::vector<Column const*> Vertical::GetColumns() const {
 
 std::vector<unsigned> Vertical::GetColumnIndicesAsVector() const {
     std::vector<unsigned> columns;
-    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = column_indices_.find_next(index)) {
+    for (size_t index : util::SetBits(column_indices_)) {
         columns.push_back(schema_->GetColumns()[index].get()->GetIndex());
     }
     return columns;
@@ -97,8 +97,7 @@ std::string Vertical::ToString() const {
 
     if (column_indices_.find_first() == boost::dynamic_bitset<>::npos) return "[]";
 
-    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = column_indices_.find_next(index)) {
+    for (size_t index : util::SetBits(column_indices_)) {
         result += schema_->GetColumn(index)->GetName();
         if (column_indices_.find_next(index) != boost::dynamic_bitset<>::npos) {
             result += ' ';
@@ -117,8 +116,7 @@ std::string Vertical::ToIndicesString() const {
         return "[]";
     }
 
-    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = column_indices_.find_next(index)) {
+    for (size_t index : util::SetBits(column_indices_)) {
         result += std::to_string(index);
         if (column_indices_.find_next(index) != boost::dynamic_bitset<>::npos) {
             result += ',';
@@ -134,9 +132,7 @@ std::vector<Vertical> Vertical::GetParents() const {
     if (GetArity() < 2) return std::vector<Vertical>();
     std::vector<Vertical> parents(GetArity());
     int i = 0;
-    for (size_t column_index = column_indices_.find_first();
-         column_index != boost::dynamic_bitset<>::npos;
-         column_index = column_indices_.find_next(column_index)) {
+    for (size_t column_index : util::SetBits(column_indices_)) {
         auto parent_column_indices = column_indices_;
         parent_column_indices.reset(column_index);
         parents[i++] = GetSchema()->GetVertical(std::move(parent_column_indices));

--- a/src/core/util/bitset_utils.h
+++ b/src/core/util/bitset_utils.h
@@ -2,6 +2,8 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "set_bits_view.h"
+
 namespace util {
 
 template <typename ForwardIt>

--- a/src/core/util/bitset_utils.h
+++ b/src/core/util/bitset_utils.h
@@ -3,6 +3,7 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "set_bits_view.h"
+#include "util/set_bits_view.h"
 
 namespace util {
 
@@ -22,8 +23,7 @@ boost::dynamic_bitset<> IndicesToBitset(Container const& indices, size_t num_col
 
 template <typename UnaryFunction>
 void ForEachIndex(boost::dynamic_bitset<> const& bitset, UnaryFunction func) {
-    for (auto index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = bitset.find_next(index)) {
+    for (auto index : util::SetBits(bitset)) {
         func(index);
     }
 }

--- a/src/core/util/set_bits_view.h
+++ b/src/core/util/set_bits_view.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <iterator>
+
+#include <boost/dynamic_bitset.hpp>
+
+namespace util {
+
+template <class B>
+concept SgiFindableBitset = requires(B const& b, std::size_t p) {
+    { b._Find_first() } -> std::convertible_to<std::size_t>;
+    { b._Find_next(p) } -> std::convertible_to<std::size_t>;
+    { b.size() } -> std::convertible_to<std::size_t>;
+};
+
+template <SgiFindableBitset B>
+std::size_t BitsetNpos(B const& b) noexcept {
+    return b.size();
+}
+
+template <SgiFindableBitset B>
+std::size_t BitsetFindFirst(B const& b) noexcept {
+    return b._Find_first();
+}
+
+template <SgiFindableBitset B>
+std::size_t BitsetFindNext(B const& b, std::size_t pos) noexcept {
+    return b._Find_next(pos);
+}
+
+template <class Block, class Allocator>
+auto BitsetNpos(boost::dynamic_bitset<Block, Allocator> const&) {
+    return boost::dynamic_bitset<Block, Allocator>::npos;
+}
+
+template <class Block, class Allocator>
+auto BitsetFindFirst(boost::dynamic_bitset<Block, Allocator> const& b) {
+    return b.find_first();
+}
+
+template <class Block, class Allocator>
+auto BitsetFindNext(boost::dynamic_bitset<Block, Allocator> const& b,
+                    typename boost::dynamic_bitset<Block, Allocator>::size_type pos) {
+    return b.find_next(pos);
+}
+
+template <class B>
+concept BitsetFindable = requires(B const& b, std::size_t p) {
+    { BitsetNpos(b) } -> std::convertible_to<std::size_t>;
+    { BitsetFindFirst(b) } -> std::convertible_to<std::size_t>;
+    { BitsetFindNext(b, p) } -> std::convertible_to<std::size_t>;
+};
+
+template <BitsetFindable Bitset>
+class SetBitsView {
+public:
+    using IndexType = std::size_t;
+
+    struct Iterator {
+        using value_type = IndexType;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
+
+        Iterator() = default;
+
+        Iterator(Bitset const* bs, IndexType pos) noexcept : bs_(bs), pos_(pos) {}
+
+        [[nodiscard]] value_type operator*() const noexcept {
+            return pos_;
+        }
+
+        Iterator& operator++() noexcept {
+            pos_ = BitsetFindNext(*bs_, pos_);
+            return *this;
+        }
+
+        Iterator operator++(int) noexcept {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        friend bool operator==(Iterator const& a, Iterator const& b) noexcept {
+            return a.bs_ == b.bs_ && a.pos_ == b.pos_;
+        }
+
+        friend bool operator!=(Iterator const& a, Iterator const& b) noexcept {
+            return !(a == b);
+        }
+
+        [[nodiscard]] bool AtEnd() const noexcept {
+            return pos_ == BitsetNpos(*bs_);
+        }
+
+    private:
+        Bitset const* bs_ = nullptr;
+        IndexType pos_ = 0;
+    };
+
+    struct Sentinel {
+        friend bool operator==(Iterator const& it, Sentinel const&) noexcept {
+            return it.AtEnd();
+        }
+
+        friend bool operator==(Sentinel const& s, Iterator const& it) noexcept {
+            return it == s;
+        }
+
+        friend bool operator!=(Iterator const& it, Sentinel const& s) noexcept {
+            return !(it == s);
+        }
+
+        friend bool operator!=(Sentinel const& s, Iterator const& it) noexcept {
+            return !(s == it);
+        }
+    };
+
+    explicit SetBitsView(Bitset const& bs) noexcept : bs_(&bs) {}
+
+    [[nodiscard]] Iterator begin() const noexcept {
+        return Iterator{bs_, BitsetFindFirst(*bs_)};
+    }
+
+    [[nodiscard]] static Sentinel end() noexcept {
+        return {};
+    }
+
+private:
+    Bitset const* bs_;
+};
+
+template <BitsetFindable Bitset>
+[[nodiscard]] auto SetBits(Bitset const& bs) noexcept {
+    return SetBitsView<Bitset>{bs};
+}
+
+}  // namespace util

--- a/src/tests/unit/test_fd_algorithm.cpp
+++ b/src/tests/unit/test_fd_algorithm.cpp
@@ -14,6 +14,7 @@
 #include "algorithms/fd/tane/tane.h"
 #include "model/table/relational_schema.h"
 #include "test_fd_util.h"
+#include "util/set_bits_view.h"
 
 using std::string, std::vector;
 using ::testing::ContainerEq, ::testing::Eq;
@@ -36,8 +37,7 @@ namespace tests {
 
 std::vector<unsigned int> BitsetToIndexVector(boost::dynamic_bitset<> const& bitset) {
     std::vector<unsigned int> res;
-    for (size_t index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = bitset.find_next(index)) {
+    for (size_t index : util::SetBits(bitset)) {
         res.push_back(index);
     }
     return res;

--- a/src/tests/unit/test_fd_mine.cpp
+++ b/src/tests/unit/test_fd_mine.cpp
@@ -14,6 +14,7 @@
 #include "csv_config_util.h"
 #include "model/table/relational_schema.h"
 #include "test_fd_util.h"
+#include "util/set_bits_view.h"
 
 namespace tests {
 using ::testing::ContainerEq, ::testing::Eq;
@@ -40,8 +41,7 @@ using FDMineAlgorithmTest = tests::AlgorithmTest<FdMine>;
 
 std::vector<unsigned int> FdMineBitsetToIndexVector(boost::dynamic_bitset<> const& bitset) {
     std::vector<unsigned int> res;
-    for (size_t index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
-         index = bitset.find_next(index)) {
+    for (size_t index : util::SetBits(bitset)) {
         res.push_back(index);
     }
     return res;

--- a/src/tests/unit/test_set_bits_view.cpp
+++ b/src/tests/unit/test_set_bits_view.cpp
@@ -1,0 +1,321 @@
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+#include <boost/dynamic_bitset.hpp>
+#include <gtest/gtest.h>
+
+#include "bitset_utils.h"
+#include "model/types/bitset.h"
+
+namespace tests {
+
+template <std::size_t N>
+model::Bitset<N> MakeFixedBitset(std::vector<std::size_t> const& indices) {
+    model::Bitset<N> bs;
+    for (auto i : indices) {
+        bs.set(i);
+    }
+    return bs;
+}
+
+template <std::size_t S>
+struct FixedParam {
+    static constexpr std::size_t kSize = S;
+    using Bitset = model::Bitset<S>;
+};
+
+template <class Param>
+class FixedSetBitsViewTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(FixedSetBitsViewTest);
+
+TYPED_TEST_P(FixedSetBitsViewTest, EmptyHasNoIteration) {
+    using P = TypeParam;
+    using B = typename P::Bitset;
+
+    B bs;
+    auto view = util::SetBits(bs);
+    EXPECT_TRUE(view.begin() == view.end());
+
+    std::vector<std::size_t> seen;
+    for (auto i : view) {
+        seen.push_back(i);
+    }
+    EXPECT_TRUE(seen.empty());
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, SingleBitYieldsThatIndex) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+    if constexpr (n == 0) {
+        GTEST_SKIP() << "Size is zero.";
+    }
+
+    std::size_t const p = n / 2;
+    auto bs = MakeFixedBitset<n>({p});
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    ASSERT_EQ(seen.size(), 1u);
+    EXPECT_EQ(seen[0], p);
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, MultipleBitsAreAscendingAndUnique) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+    if constexpr (n < 5) {
+        GTEST_SKIP() << "Need at least 5 bits.";
+    }
+
+    std::vector<std::size_t> idx = {0u, 2u, n - 1, 3u, 2u};
+    auto bs = MakeFixedBitset<n>(idx);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+
+    auto exp = idx;
+    std::ranges::sort(exp);
+    exp.erase(std::unique(exp.begin(), exp.end()), exp.end());
+    EXPECT_EQ(seen, exp);
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, AllBitsAndDistanceEqualsCount) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+
+    std::vector<std::size_t> idx(n);
+    std::iota(idx.begin(), idx.end(), 0);
+    auto bs = MakeFixedBitset<n>(idx);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, idx);
+
+    EXPECT_EQ(std::ranges::distance(util::SetBits(bs)), static_cast<std::ptrdiff_t>(bs.count()));
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, AlternatingEvenBits) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+
+    std::vector<std::size_t> idx;
+    for (std::size_t i = 0; i < n; i += 2) {
+        idx.push_back(i);
+    }
+
+    auto bs = MakeFixedBitset<n>(idx);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, idx);
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, IteratorPrePostIncrementAndEquality) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+    if constexpr (n < 6) {
+        GTEST_SKIP() << "Need at least 6 bits.";
+    }
+
+    auto bs = MakeFixedBitset<n>({2, 5});
+    auto view = util::SetBits(bs);
+
+    auto it1 = view.begin();
+    auto it2 = it1;
+    EXPECT_TRUE(it1 == it2);
+    EXPECT_EQ(*it1, 2u);
+
+    auto it1_post = it1++;
+    EXPECT_EQ(*it1_post, 2u);
+    EXPECT_EQ(*it1, 5u);
+    EXPECT_NE(it1, it2);
+
+    ++it2;
+    EXPECT_EQ(*it2, 5u);
+    EXPECT_TRUE(it1 == it2);
+
+    ++it1;
+    EXPECT_TRUE(it1 == view.end());
+}
+
+TYPED_TEST_P(FixedSetBitsViewTest, WordBoundaries) {
+    using P = TypeParam;
+    constexpr auto n = P::kSize;
+    if constexpr (n < 66) {
+        GTEST_SKIP() << "Need at least 66 bits.";
+    }
+
+    auto bs = MakeFixedBitset<n>({0, 63, 64, 65, n - 1});
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, (std::vector<std::size_t>{0, 63, 64, 65, n - 1}));
+}
+
+REGISTER_TYPED_TEST_SUITE_P(FixedSetBitsViewTest, EmptyHasNoIteration, SingleBitYieldsThatIndex,
+                            MultipleBitsAreAscendingAndUnique, AllBitsAndDistanceEqualsCount,
+                            AlternatingEvenBits, IteratorPrePostIncrementAndEquality,
+                            WordBoundaries);
+
+using FixedSizes = ::testing::Types<FixedParam<0>, FixedParam<1>, FixedParam<2>, FixedParam<7>,
+                                    FixedParam<8>, FixedParam<63>, FixedParam<64>, FixedParam<65>,
+                                    FixedParam<127>, FixedParam<128>, FixedParam<129>>;
+INSTANTIATE_TYPED_TEST_SUITE_P(Fixed, FixedSetBitsViewTest, FixedSizes);
+
+template <std::size_t S>
+struct BoostParam {
+    static constexpr std::size_t kSize = S;
+    using Bitset = boost::dynamic_bitset<>;
+};
+
+template <class Param>
+class BoostSetBitsViewTest : public ::testing::Test {};
+
+TYPED_TEST_SUITE_P(BoostSetBitsViewTest);
+
+TYPED_TEST_P(BoostSetBitsViewTest, EmptyHasNoIteration) {
+    using P = TypeParam;
+    auto bs = util::IndicesToBitset(std::vector<std::size_t>{}, P::kSize);
+
+    auto view = util::SetBits(bs);
+    EXPECT_TRUE(view.begin() == view.end());
+
+    std::vector<std::size_t> seen;
+    for (auto i : view) {
+        seen.push_back(i);
+    }
+    EXPECT_TRUE(seen.empty());
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, SingleBitYieldsThatIndex) {
+    using P = TypeParam;
+    if constexpr (P::kSize == 0) {
+        GTEST_SKIP() << "Size is zero.";
+    }
+
+    std::size_t const p = P::kSize / 2;
+    auto bs = util::IndicesToBitset(std::vector<std::size_t>{p}, P::kSize);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    ASSERT_EQ(seen.size(), 1u);
+    EXPECT_EQ(seen[0], p);
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, MultipleBitsAreAscendingAndUnique) {
+    using P = TypeParam;
+    if constexpr (P::kSize < 5) {
+        GTEST_SKIP() << "Need at least 5 bits.";
+    }
+
+    std::vector<std::size_t> idx = {0u, 2u, P::kSize - 1, 3u, 2u};
+    auto bs = util::IndicesToBitset(idx, P::kSize);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+
+    auto exp = idx;
+    std::ranges::sort(exp);
+    exp.erase(std::unique(exp.begin(), exp.end()), exp.end());
+    EXPECT_EQ(seen, exp);
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, AllBitsAndDistanceEqualsCount) {
+    using P = TypeParam;
+    std::vector<std::size_t> idx(P::kSize);
+    std::iota(idx.begin(), idx.end(), 0);
+    auto bs = util::IndicesToBitset(idx, P::kSize);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, idx);
+
+    EXPECT_EQ(std::ranges::distance(util::SetBits(bs)), static_cast<std::ptrdiff_t>(bs.count()));
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, AlternatingEvenBits) {
+    using P = TypeParam;
+    std::vector<std::size_t> idx;
+    for (std::size_t i = 0; i < P::kSize; i += 2) {
+        idx.push_back(i);
+    }
+    auto bs = util::IndicesToBitset(idx, P::kSize);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, idx);
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, IteratorPrePostIncrementAndEquality) {
+    using P = TypeParam;
+    if constexpr (P::kSize < 6) {
+        GTEST_SKIP() << "Need at least 6 bits.";
+    }
+
+    auto bs = util::IndicesToBitset(std::vector<std::size_t>{2, 5}, P::kSize);
+    auto view = util::SetBits(bs);
+
+    auto it1 = view.begin();
+    auto it2 = it1;
+    EXPECT_TRUE(it1 == it2);
+    EXPECT_EQ(*it1, 2u);
+
+    auto it1_post = it1++;
+    EXPECT_EQ(*it1_post, 2u);
+    EXPECT_EQ(*it1, 5u);
+    EXPECT_NE(it1, it2);
+
+    ++it2;
+    EXPECT_EQ(*it2, 5u);
+    EXPECT_TRUE(it1 == it2);
+
+    ++it1;
+    EXPECT_TRUE(it1 == view.end());
+}
+
+TYPED_TEST_P(BoostSetBitsViewTest, WordBoundaries) {
+    using P = TypeParam;
+    if constexpr (P::kSize < 66) {
+        GTEST_SKIP() << "Need at least 66 bits.";
+    }
+
+    auto bs =
+            util::IndicesToBitset(std::vector<std::size_t>{0, 63, 64, 65, P::kSize - 1}, P::kSize);
+
+    std::vector<std::size_t> seen;
+    for (auto i : util::SetBits(bs)) {
+        seen.push_back(i);
+    }
+    EXPECT_EQ(seen, (std::vector<std::size_t>{0, 63, 64, 65, P::kSize - 1}));
+}
+
+REGISTER_TYPED_TEST_SUITE_P(BoostSetBitsViewTest, EmptyHasNoIteration, SingleBitYieldsThatIndex,
+                            MultipleBitsAreAscendingAndUnique, AllBitsAndDistanceEqualsCount,
+                            AlternatingEvenBits, IteratorPrePostIncrementAndEquality,
+                            WordBoundaries);
+
+using BoostSizes =
+        ::testing::Types<BoostParam<0>, BoostParam<1>, BoostParam<2>, BoostParam<63>,
+                         BoostParam<64>, BoostParam<65>, BoostParam<128>, BoostParam<129>>;
+INSTANTIATE_TYPED_TEST_SUITE_P(Boost, BoostSetBitsViewTest, BoostSizes);
+
+}  // namespace tests


### PR DESCRIPTION
While reviewing I noticed that we use the same `auto i = bitset.find_first(); i != boost::dynamic_bitset<>::npos; i = bitset.find_next(i)` about 50 times:
```cpp
tmp.py:#   - for (size_t i = bitset.find_first(); i != ...; i = bitset.find_next(i)) {
tmp.py:#   - for (Edge::size_type v = e.find_first(); v != ...; v = e.find_next(v)) {
tmp.py-REMOVED_CLASSIC_FOR = re.compile(
--
src/tests/unit/test_fd_algorithm.cpp:    for (size_t index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
src/tests/unit/test_fd_algorithm.cpp-         index = bitset.find_next(index)) {
--
src/core/util/bitset_utils.h:    for (auto index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
src/core/util/bitset_utils.h-         index = bitset.find_next(index)) {
--
src/tests/unit/test_fd_mine.cpp:    for (size_t index = bitset.find_first(); index != boost::dynamic_bitset<>::npos;
src/tests/unit/test_fd_mine.cpp-         index = bitset.find_next(index)) {
--
src/core/model/table/position_list_index.cpp:    for (unsigned long index = probing_indices.find_first(); index < probing_indices.size();
src/core/model/table/position_list_index.cpp-         index = probing_indices.find_next(index)) {
--
src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h:        for (unsigned int columnIndex = key.find_first(); columnIndex < key.size(); columnIndex =
src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h-    key.find_next(columnIndex)){ agreeSetCountersStr += std::to_string(columnIndex) + ' ';
--
src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp:            for (size_t a = dc1_cols.find_first(), b = dc2_cols.find_first(); a < dc1_cols.size();
src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp-                 a = dc1_cols.find_next(a), b = dc2_cols.find_next(b))
--
src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp:            for (size_t a = dc1_cols.find_first(), b = dc2_cols.find_first(); a < dc1_cols.size();
src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp-                 a = dc1_cols.find_next(a), b = dc2_cols.find_next(b))
--
src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp:    for (size_t index = column_indices.find_first(); index < column_indices.size();
src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp-         index = column_indices.find_next(index)) {
--
src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp:    for (size_t index = column_indices.find_first(); index < column_indices.size();
src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp-         index = column_indices.find_next(index)) {
--
src/core/algorithms/fd/hyfd/inductor.cpp:            for (size_t rhs_id = rhs_bits.find_first(); rhs_id != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/inductor.cpp-                 rhs_id = rhs_bits.find_next(rhs_id)) {
--
src/core/algorithms/fd/hyfd/validator.cpp:    for (size_t attr = bitset.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/validator.cpp-         attr = bitset.find_next(attr)) {
--
src/core/algorithms/fd/hyfd/validator.cpp:    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/validator.cpp-         attr = rhs.find_next(attr)) {
--
src/core/algorithms/fd/hyfd/validator.cpp:    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/validator.cpp-         attr = rhs.find_next(attr)) {
--
src/core/algorithms/fd/hyfd/validator.cpp:    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/validator.cpp-         attr = rhs.find_next(attr)) {
--
src/core/algorithms/fd/hyfd/validator.cpp:    for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/validator.cpp-         attr = rhs.find_next(attr)) {
--
src/core/algorithms/fd/tane/model/lattice_level.cpp:            for (unsigned int i = 0, skip_index = parent_indices.find_first(); i < arity - 1;
src/core/algorithms/fd/tane/model/lattice_level.cpp-                 i++, skip_index = parent_indices.find_next(skip_index)) {
--
src/core/algorithms/fd/tane/model/lattice_vertex.cpp:    for (size_t index = lv.rhs_candidates_.find_first(); index != dynamic_bitset<>::npos;
src/core/algorithms/fd/tane/model/lattice_vertex.cpp-         index = lv.rhs_candidates_.find_next(index)) {
--
src/core/algorithms/fd/hyfd/model/fd_tree.cpp:    for (size_t bit = lhs.find_first(); bit != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/model/fd_tree.cpp-         bit = lhs.find_next(bit)) {
--
src/core/algorithms/fd/hyfd/model/fd_tree.cpp:    for (size_t bit = lhs.find_first(); bit != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/model/fd_tree.cpp-         bit = lhs.find_next(bit)) {
--
src/core/algorithms/fd/hyfd/model/fd_tree_vertex.cpp:    for (size_t rhs = fds_.find_first(); rhs != boost::dynamic_bitset<>::npos;
src/core/algorithms/fd/hyfd/model/fd_tree_vertex.cpp-         rhs = fds_.find_next(rhs)) {
--
src/core/algorithms/fd/aidfd/search_tree.cpp:    for (size_t bit = set.find_first(); bit != Bitset::npos; bit = set.find_next(bit)) {
src/core/algorithms/fd/aidfd/search_tree.cpp-        Bitset bitset_to_add(number_of_attributes_);
--
src/core/algorithms/fd/eulerfd/search_tree.cpp:    for (size_t bit = set.find_first(); bit != Bitset::npos; bit = set.find_next(bit)) {
src/core/algorithms/fd/eulerfd/search_tree.cpp-        Bitset bitset_to_add(number_of_attributes_);
--
src/core/algorithms/fd/hycommon/preprocessor.cpp:    for (size_t i = as.find_first(); i != boost::dynamic_bitset<>::npos; i = as.find_next(i)) {
src/core/algorithms/fd/hycommon/preprocessor.cpp-        mapped_as.set(og_mapping[i]);
--
src/core/algorithms/ucc/hpivalid/result_collector.cpp:        for (Edge::size_type v = e.find_first(); v != Edge::npos; v = e.find_next(v)) {
src/core/algorithms/ucc/hpivalid/result_collector.cpp-            if (v != e.find_first()) {
--
src/core/algorithms/ucc/hpivalid/tree_search.cpp:        for (Edge::size_type i_v = partial_hg_[i_e].find_first(); i_v != Edge::npos;
src/core/algorithms/ucc/hpivalid/tree_search.cpp-             i_v = partial_hg_[i_e].find_next(i_v)) {
--
src/core/algorithms/ucc/hpivalid/tree_search.cpp:        for (Edge::size_type v = c.find_first(); v != Edge::npos; v = c.find_next(v)) {
src/core/algorithms/ucc/hpivalid/tree_search.cpp-            // update crit and uncov
--
src/core/algorithms/ucc/hpivalid/tree_search.cpp:        for (std::size_t col = e.find_first(); col != Edge::npos; col = e.find_next(col)) {
src/core/algorithms/ucc/hpivalid/tree_search.cpp-            if (niceness < niceness_[col]) {
--
src/core/algorithms/ucc/hpivalid/tree_search.cpp:    for (Edge::size_type v = c.find_first(); v != Edge::npos; v = c.find_next(v)) {
src/core/algorithms/ucc/hpivalid/tree_search.cpp-        // don't branch if v is violater for S
--
src/core/algorithms/ucc/hpivalid/tree_search.cpp:        for (Edge::size_type i_v = partial_hg_[i_e].find_first(); i_v != Edge::npos;
src/core/algorithms/ucc/hpivalid/tree_search.cpp-             i_v = partial_hg_[i_e].find_next(i_v)) {
--
src/core/algorithms/ucc/hyucc/model/ucc_tree.cpp:    for (size_t attr = ucc.find_first(); attr != boost::dynamic_bitset<>::npos;
src/core/algorithms/ucc/hyucc/model/ucc_tree.cpp-         attr = ucc.find_next(attr)) {
--
src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h:            for (size_t i = can_add.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h-                 i = can_add.find_next(i)) {
--
src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h:            for (size_t i = can_add.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/approximate_evidence_inverter.h-                 i = can_add.find_next(i)) {
--
src/core/model/table/vertical.cpp:    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
src/core/model/table/vertical.cpp-         index = column_indices_.find_next(index)) {
--
src/core/model/table/vertical.cpp:    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
src/core/model/table/vertical.cpp-         index = column_indices_.find_next(index)) {
--
src/core/model/table/vertical.cpp:    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
src/core/model/table/vertical.cpp-         index = column_indices_.find_next(index)) {
--
src/core/model/table/vertical.cpp:    for (size_t index = column_indices_.find_first(); index != boost::dynamic_bitset<>::npos;
src/core/model/table/vertical.cpp-         index = column_indices_.find_next(index)) {
--
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp:    for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp-         i = bitset.find_next(i)) {
--
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp:    for (size_t i = superset.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp-         i = superset.find_next(i)) {
--
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp:    for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/dc_candidate_trie.cpp-         i = bitset.find_next(i)) {
--
src/core/algorithms/dc/FastADC/util/predicate_organizer.h:        for (size_t i = bitset.find_first(); i != boost::dynamic_bitset<>::npos;
src/core/algorithms/dc/FastADC/util/predicate_organizer.h-             i = bitset.find_next(i)) {
```

This pr tries to fix this by introducing a wrapper `util::SetBits` that stores a pointer to a bitset and allows iteration with range-based for over it's set bits