### PR TITLE
build(docs): improve comment for color diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 # --- Setting CMake build variables ---
 
-# Enable colored output for Ninja messages
+# Enable colored Ninja and compilers diagnostics
 set(CMAKE_COLOR_DIAGNOSTICS ON)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
The previous comment only mentioned Ninja, but according to the [docs](https://cmake.org/cmake/help/latest/variable/CMAKE_COLOR_DIAGNOSTICS.html) CMAKE_COLOR_DIAGNOSTICS also affects compiler's output.