### PR TITLE
Allow multiple Python interpreter use in bindings

### DIFF
--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -6,7 +6,7 @@ project(
     DESCRIPTION "Python bindings to the interface of the Desbordante C++ core library"
 )
 
-CPMAddPackage("gh:pybind/pybind11@2.13.4")
+CPMAddPackage("gh:pybind/pybind11@3.0.4")
 
 # ---- Python Bindings Configuration ----
 

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -47,7 +47,8 @@
 
 namespace python_bindings {
 
-PYBIND11_MODULE(desbordante, module, pybind11::mod_gil_not_used()) {
+PYBIND11_MODULE(desbordante, module, pybind11::mod_gil_not_used(),
+                pybind11::multiple_interpreters::per_interpreter_gil()) {
     using namespace pybind11::literals;
     for (auto bind_func : {BindMainClasses,
                            BindDataTypes,


### PR DESCRIPTION
Depends on #744, #768, #769, #773, last 2 commits belong to this one