### PR TITLE
Remove RV policy argument in BindPrimitive

### DIFF
--- a/src/python_bindings/fd/bind_fd.cpp
+++ b/src/python_bindings/fd/bind_fd.cpp
@@ -83,8 +83,7 @@ void BindFd(py::module_& main_module) {
                                          FdMine, FUN, Pyro, Tane, PFDTane>(
             fd_module, &FDAlgorithm::SortedFdList, "FdAlgorithm", "get_fds",
             {"HyFD", "Aid", "EulerFD", "Depminer", "DFD", "FastFDs", "FDep", "FdMine", "FUN",
-             kPyroName, kTaneName, kPFDTaneName},
-            pybind11::return_value_policy::copy);
+             kPyroName, kTaneName, kPFDTaneName});
 
     auto define_submodule = [&fd_algos_module, &main_module](char const* name,
                                                              std::vector<char const*> algorithms) {

--- a/src/python_bindings/gfd/bind_gfd_verification.cpp
+++ b/src/python_bindings/gfd/bind_gfd_verification.cpp
@@ -20,6 +20,6 @@ void BindGfdVerification(pybind11::module_& main_module) {
 
     BindPrimitive<GfdValidator, EGfdValidator, NaiveGfdValidator>(
             gfd_module, &GfdHandler::GfdList, "GfdAlgorithm", "get_gfds",
-            {"GfdValid", "EGfdValid", "NaiveGfdValid"}, py::return_value_policy::copy);
+            {"GfdValid", "EGfdValid", "NaiveGfdValid"});
 }
 }  // namespace python_bindings

--- a/src/python_bindings/ind/bind_ind.cpp
+++ b/src/python_bindings/ind/bind_ind.cpp
@@ -78,9 +78,9 @@ void BindInd(py::module_& main_module) {
     static constexpr auto kSpiderName = "Spider";
     static constexpr auto kMindName = "Mind";
 
-    auto ind_algos_module = BindPrimitive<Spider, Faida, Mind>(
-            ind_module, &INDAlgorithm::INDList, "IndAlgorithm", "get_inds",
-            {kSpiderName, "Faida", kMindName}, pybind11::return_value_policy::copy);
+    auto ind_algos_module =
+            BindPrimitive<Spider, Faida, Mind>(ind_module, &INDAlgorithm::INDList, "IndAlgorithm",
+                                               "get_inds", {kSpiderName, "Faida", kMindName});
     auto define_submodule = [&ind_algos_module, &main_module](char const* name,
                                                               std::vector<char const*> algorithms) {
         auto algos_module = main_module.def_submodule(name).def_submodule("algorithms");

--- a/src/python_bindings/md/bind_md.cpp
+++ b/src/python_bindings/md/bind_md.cpp
@@ -241,7 +241,6 @@ void BindMd(py::module_& main_module) {
                          .none(false))
             .doc() = R"(Defines a column match with a custom similarity measure.)";
 
-    BindPrimitive<HyMD>(md_module, &MdAlgorithm::MdList, "MdAlgorithm", "get_mds", {"HyMD"},
-                        pybind11::return_value_policy::copy);
+    BindPrimitive<HyMD>(md_module, &MdAlgorithm::MdList, "MdAlgorithm", "get_mds", {"HyMD"});
 }
 }  // namespace python_bindings

--- a/src/python_bindings/nar/bind_nar.cpp
+++ b/src/python_bindings/nar/bind_nar.cpp
@@ -163,7 +163,7 @@ void BindNar(py::module_& main_module) {
                         return nar;
                     }));
 
-    BindPrimitive<DES>(nar_module, &NARAlgorithm::GetNARVector, "NarAlgorithm", "get_nars", {"DES"},
-                       pybind11::return_value_policy::copy);
+    BindPrimitive<DES>(nar_module, &NARAlgorithm::GetNARVector, "NarAlgorithm", "get_nars",
+                       {"DES"});
 }
 }  // namespace python_bindings

--- a/src/python_bindings/py_util/bind_primitive.h
+++ b/src/python_bindings/py_util/bind_primitive.h
@@ -54,20 +54,14 @@ using MemberPointerClass = typename MemberPointerClassHelper<MemberPointer>::typ
 template <typename Default, typename... Others>
 auto BindPrimitive(pybind11::module_& module, auto result_method, char const* base_name,
                    char const* base_result_method_name,
-                   std::array<char const*, sizeof...(Others) + 1> algo_names,
-                   // UB if incorrect. If your algorithm base method is a simple
-                   // util::PrimitiveCollection<...>::AsList() call, the default should work,
-                   // otherwise consult pybind11's docs.
-                   pybind11::return_value_policy result_rv_policy =
-                           pybind11::return_value_policy::reference_internal) {
+                   std::array<char const*, sizeof...(Others) + 1> algo_names) {
     namespace py = pybind11;
     using algos::Algorithm;
 
     using ResultMethodType = std::decay_t<decltype(result_method)>;
     static_assert(std::is_member_pointer_v<ResultMethodType>);
     using Base = util::MemPtrDeduce<ResultMethodType>::Class;
-    py::class_<Base, Algorithm>(module, base_name)
-            .def(base_result_method_name, result_method, result_rv_policy);
+    py::class_<Base, Algorithm>(module, base_name).def(base_result_method_name, result_method);
     auto algos_module = module.def_submodule("algorithms");
     auto arr_iter = algo_names.begin();
     auto default_module = detail::RegisterAlgorithm<Default, Base>(algos_module, *arr_iter++);

--- a/src/python_bindings/ucc/bind_ucc.cpp
+++ b/src/python_bindings/ucc/bind_ucc.cpp
@@ -63,6 +63,6 @@ void BindUcc(py::module_& main_module) {
                     }));
     BindPrimitive<HPIValid, HyUCC, PyroUCC>(
             ucc_module, py::overload_cast<>(&UCCAlgorithm::UCCList, py::const_), "UccAlgorithm",
-            "get_uccs", {"HPIValid", "HyUCC", "PyroUCC"}, pybind11::return_value_policy::copy);
+            "get_uccs", {"HPIValid", "HyUCC", "PyroUCC"});
 }
 }  // namespace python_bindings


### PR DESCRIPTION
That argument was added to solve a historical problem where pattern objects depended on algorithm lifetime. It is getting erroneously set to an incorrect value by people copying code but is irrelevant for new patterns.