### PR TITLE
Set hidden visibility, add build target for afd_metric and link it correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ set(CMAKE_COLOR_DIAGNOSTICS ON)
 set(CMAKE_OPTIMIZE_DEPENDENCIES ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/target")
 
+# Set hidden visibility for object symbols for smaller and faster loading binaries
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
 if(DESBORDANTE_BUILD_NATIVE)
     string(JOIN ";" BUILD_OPTS "${BUILD_OPTS}" "-march=native")
 endif()

--- a/src/core/algorithms/fd/CMakeLists.txt
+++ b/src/core/algorithms/fd/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SUBDIRS
+    afd_metric
     aidfd
     depminer
     dfd

--- a/src/core/algorithms/fd/afd_metric/CMakeLists.txt
+++ b/src/core/algorithms/fd/afd_metric/CMakeLists.txt
@@ -1,0 +1,13 @@
+# --- AFD metrics ---
+set(NAME fd.afd_metric)
+desbordante_add_lib(NAME OBJECT)
+target_sources(
+    ${NAME}
+    PRIVATE afd_metric_calculator.cpp
+    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+)
+target_link_libraries(
+    ${NAME}
+    PUBLIC better-enums
+    PRIVATE Boost::headers
+)

--- a/src/core/algorithms/fd/afd_metric/afd_metric.h
+++ b/src/core/algorithms/fd/afd_metric/afd_metric.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <enum.h>
+#include "core/util/better_enum_with_visibility.h"
 
 namespace algos::afd_metric_calculator {
 

--- a/src/core/algorithms/fd/tane/CMakeLists.txt
+++ b/src/core/algorithms/fd/tane/CMakeLists.txt
@@ -20,7 +20,7 @@ target_sources(
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::tane::common ${DESBORDANTE_PREFIX}::fd::pli
-                    better-enums Boost::headers
+                    ${DESBORDANTE_PREFIX}::fd::afd_metric better-enums Boost::headers
 )
 
 # --- PFDTane ---

--- a/src/core/config/exceptions.h
+++ b/src/core/config/exceptions.h
@@ -3,9 +3,11 @@
 #include <stdexcept>
 #include <string>
 
+#include "core/util/export.h"
+
 namespace config {
 
-class ConfigurationError : public std::exception {
+class DESBORDANTE_EXPORT ConfigurationError : public std::exception {
     std::string message_;
 
 public:

--- a/src/core/model/table/CMakeLists.txt
+++ b/src/core/model/table/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(
             dynamic_position_list_index.cpp
             identifier_set.cpp
             position_list_index.cpp
+            position_list_index_with_singletons.cpp
             relational_schema.cpp
             typed_column_data.cpp
             vertical.cpp

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -71,6 +71,11 @@ desbordante_add_bind(
 )
 
 desbordante_add_bind(
+    afd_metric SRCS afd_metric/bind_afd_metric_calculation.cpp LIBS Desbordante::fd::afd_metric
+    Boost::headers
+)
+
+desbordante_add_bind(
     ar
     SRCS
     ar/bind_ar.cpp

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -70,7 +70,8 @@ PYBIND11_MODULE(desbordante, module, pybind11::mod_gil_not_used()) {
                            BindGfd,
                            BindCFDVerification,
                            BindDDVerification,
-                           BindAODVerification}) {
+                           BindAODVerification,
+                           BindAfdMetricCalculation}) {
         bind_func(module);
     }
 }

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -245,6 +245,18 @@ desbordante_add_test(
     Boost::headers
 )
 desbordante_add_test(
+    fd.afd_metric
+    SRCS
+    test_afd_metric_calculator.cpp
+    LIBS
+    ${DESBORDANTE_PREFIX}::fd::afd_metric
+    ${DESBORDANTE_PREFIX}::testlib::common
+    ${DESBORDANTE_PREFIX}::model::table
+    ${DESBORDANTE_PREFIX}::model::types
+    spdlog::spdlog_header_only
+    Boost::headers
+)
+desbordante_add_test(
     fd.mine
     SRCS
     test_fd_mine.cpp


### PR DESCRIPTION
Hidden visibility enables some optimizations and reduces binary size. In
exchange, we have to manually specify what symbols should be made
public. See https://gcc.gnu.org/wiki/Visibility for details.

For our case, what matters is that we need to share the `type_info`
objects across shared object boundaries: the Option object compares
`type_info`s to alert the user with a proper error message that contains
the option name in case the value type is incorrect. Otherwise, the
comparison would have been done by `boost::any`'s cast method that would
fail with a less comprehensible error message.

Hidden visibility was already set on all pybind11 libraries, for the
reasoning see the -Wattributes section in
https://pybind11.readthedocs.io/en/stable/faq.html.

Previously when compiling bindings we only had to deal with a single
bindings library and the `type_info` issues did not cause trouble as
the corresponding symbols were merged together. Currently, the bindings
consist of several libraries, which appears to have changed linker
behavior on MacOS.
See https://github.com/Desbordante/desbordante-core/pull/652#issuecomment-3944962633 for
details. Now, if we do not specify default visibility for the
non-standard types that are used as algorithm options, the conversions
from Python will fail in the library built on MacOS as the `type_info`s
from different libraries would not compare equal.

Basically, now we have to explicitly specify default visibility for the
types used as options even though the library is not built with hidden
visibility. So we get the troubles, but not the benefits. Thus, we
might as well set hidden visibility for the whole project to get the
benefits too.

The visibility issues are also relevant for exception types, see the
"Problems with C++ exceptions (please read!)" section in the GCC wiki
above. Thus, this commit adds the visibility specifier for the
configuration exception.