### PR TITLE
Set BASE_DIRS in CMake lib macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.25)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 include(desbordante_helpers)
 
+list(APPEND DESBORDANTE_COMMON_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
 # ---- CMake Policies ----
 if(POLICY CMP0167)
     # To search for the upstream BoostConfig.cmake. Added in version 3.30.

--- a/cmake/desbordante_helpers.cmake
+++ b/cmake/desbordante_helpers.cmake
@@ -58,8 +58,14 @@ function(desbordante_add_lib name)
 
     if(ARGV1 STREQUAL "INTERFACE")
         target_link_libraries(${full_name} INTERFACE ${DESBORDANTE_PREFIX}.compile_feats)
+        target_sources(
+            ${full_name} INTERFACE FILE_SET HEADERS BASE_DIRS ${DESBORDANTE_COMMON_INCLUDE_DIRS}
+        )
     else()
         target_link_libraries(${full_name} PUBLIC ${DESBORDANTE_PREFIX}.compile_feats)
+        target_sources(
+            ${full_name} PUBLIC FILE_SET HEADERS BASE_DIRS ${DESBORDANTE_COMMON_INCLUDE_DIRS}
+        )
     endif()
 
     string(REPLACE "." "::" alias ${full_name})
@@ -95,11 +101,7 @@ function(desbordante_add_bind name)
     set(bind_name "bind.${name}")
     desbordante_add_lib(bind_name OBJECT)
 
-    target_sources(
-        ${bind_name}
-        PRIVATE ${arg_SRCS}
-        PRIVATE FILE_SET HEADERS BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-    )
+    target_sources(${bind_name} PRIVATE ${arg_SRCS})
 
     set_target_properties(${bind_name} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 

--- a/src/core/algorithms/CMakeLists.txt
+++ b/src/core/algorithms/CMakeLists.txt
@@ -25,15 +25,7 @@ endforeach()
 set(NAME create_algo)
 desbordante_add_lib(NAME INTERFACE)
 target_sources(
-    ${NAME}
-    PUBLIC FILE_SET
-           HEADERS
-           FILES
-           algorithms.h
-           algorithm_types.h
-           create_algorithm.h
-           BASE_DIRS
-           "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} INTERFACE FILE_SET HEADERS FILES algorithms.h algorithm_types.h create_algorithm.h
 )
 target_link_libraries(
     ${NAME}
@@ -75,11 +67,7 @@ target_link_libraries(
 
 set(NAME algos)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE algo_factory.cpp algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE algo_factory.cpp algorithm.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::util ${DESBORDANTE_PREFIX}::config

--- a/src/core/algorithms/algebraic_constraints/CMakeLists.txt
+++ b/src/core/algorithms/algebraic_constraints/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME ac)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE ac_algorithm.cpp ac_exception_finder.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE ac_algorithm.cpp ac_exception_finder.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types

--- a/src/core/algorithms/association_rules/CMakeLists.txt
+++ b/src/core/algorithms/association_rules/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME ar)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE apriori.cpp ar_algorithm.cpp candidate_hash_tree.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE apriori.cpp ar_algorithm.cpp candidate_hash_tree.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::transaction ${DESBORDANTE_PREFIX}::algos
                     spdlog::spdlog_header_only better-enums Boost::headers

--- a/src/core/algorithms/cfd/CMakeLists.txt
+++ b/src/core/algorithms/cfd/CMakeLists.txt
@@ -3,19 +3,15 @@ add_subdirectory(cfd_verifier)
 set(NAME cfd.util)
 desbordante_add_lib(NAME OBJECT)
 target_sources(
-    ${NAME}
-    PRIVATE util/cfd_output_util.cpp util/partition_tidlist_util.cpp util/partition_util.cpp
-            util/set_util.cpp util/tidlist_util.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE util/cfd_output_util.cpp util/partition_tidlist_util.cpp
+                    util/partition_util.cpp util/set_util.cpp util/tidlist_util.cpp
 )
 target_link_libraries(${NAME} PRIVATE Boost::headers)
 
 set(NAME cfd.model)
 desbordante_add_lib(NAME OBJECT)
 target_sources(
-    ${NAME}
-    PRIVATE model/cfd_relation_data.cpp model/partition_tidlist.cpp model/raw_cfd.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE model/cfd_relation_data.cpp model/partition_tidlist.cpp model/raw_cfd.cpp
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::cfd::util ${DESBORDANTE_PREFIX}::model::table
@@ -24,11 +20,7 @@ target_link_libraries(
 
 set(NAME cfd)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE cfd_discovery.cpp fd_first_algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE cfd_discovery.cpp fd_first_algorithm.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::cfd::model ${DESBORDANTE_PREFIX}::cfd::util

--- a/src/core/algorithms/cfd/cfd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/cfd/cfd_verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME cfd.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE cfd_stats_calculator.cpp cfd_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE cfd_stats_calculator.cpp cfd_verifier.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::cfd::util ${DESBORDANTE_PREFIX}::cfd::model

--- a/src/core/algorithms/dc/CMakeLists.txt
+++ b/src/core/algorithms/dc/CMakeLists.txt
@@ -3,11 +3,7 @@ add_subdirectory(verifier)
 
 set(NAME dc.model)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE model/component.cpp model/dc.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE model/component.cpp model/dc.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::algos spdlog::spdlog_header_only frozen better-enums
                     Boost::headers
@@ -15,9 +11,5 @@ target_link_libraries(
 
 set(NAME dc.parser)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE parser/dc_parser.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE parser/dc_parser.cpp)
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only frozen better-enums Boost::headers)

--- a/src/core/algorithms/dc/FastADC/CMakeLists.txt
+++ b/src/core/algorithms/dc/FastADC/CMakeLists.txt
@@ -14,17 +14,12 @@ target_sources(
             util/evidence_aux_structures_builder.cpp
             util/predicate_builder.cpp
             util/single_clue_set_builder.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only frozen better-enums Boost::headers)
 
 set(NAME dc.fastadc)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fastadc.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fastadc.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::dc::fastadc::structs spdlog::spdlog_header_only
                     better-enums frozen Boost::headers

--- a/src/core/algorithms/dc/verifier/CMakeLists.txt
+++ b/src/core/algorithms/dc/verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME dc.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE dc_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE dc_verifier.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::model::table

--- a/src/core/algorithms/dd/CMakeLists.txt
+++ b/src/core/algorithms/dd/CMakeLists.txt
@@ -3,4 +3,4 @@ add_subdirectory(dd_verifier)
 
 set(NAME dd)
 desbordante_add_lib(NAME INTERFACE)
-target_sources(${NAME} INTERFACE FILE_SET HEADERS FILES dd.h BASE_DIRS "${PROJECT_SOURCE_DIR}/src")
+target_sources(${NAME} INTERFACE FILE_SET HEADERS FILES dd.h)

--- a/src/core/algorithms/dd/dd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/dd/dd_verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME dd.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE dd_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE dd_verifier.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::dd

--- a/src/core/algorithms/dd/split/CMakeLists.txt
+++ b/src/core/algorithms/dd/split/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME dd.split)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE split.cpp model/distance_position_list_index.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE split.cpp model/distance_position_list_index.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::dd

--- a/src/core/algorithms/fd/CMakeLists.txt
+++ b/src/core/algorithms/fd/CMakeLists.txt
@@ -25,11 +25,7 @@ endforeach()
 # --- FD ---
 set(NAME fd)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE fd.cpp fd_algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fd.cpp fd_algorithm.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos Boost::headers
 )
@@ -37,9 +33,5 @@ target_link_libraries(
 # --- PliBasedFD ---
 set(NAME fd.pli)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE pli_based_fd_algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE pli_based_fd_algorithm.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)

--- a/src/core/algorithms/fd/afd_metric/CMakeLists.txt
+++ b/src/core/algorithms/fd/afd_metric/CMakeLists.txt
@@ -1,11 +1,7 @@
 # --- AFD metrics ---
 set(NAME fd.afd_metric)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE afd_metric_calculator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE afd_metric_calculator.cpp)
 target_link_libraries(
     ${NAME}
     PUBLIC better-enums

--- a/src/core/algorithms/fd/aidfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/aidfd/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME fd.aid)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE aid.cpp search_tree.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE aid.cpp search_tree.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)

--- a/src/core/algorithms/fd/depminer/CMakeLists.txt
+++ b/src/core/algorithms/fd/depminer/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.depminer)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE depminer.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE depminer.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::pli spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/fd/dfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/dfd/CMakeLists.txt
@@ -11,7 +11,6 @@ target_sources(
             pruning_maps/dependencies_map.cpp
             pruning_maps/non_dependencies_map.cpp
             pruning_maps/pruning_map.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::pli spdlog::spdlog_header_only Boost::headers

--- a/src/core/algorithms/fd/eulerfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/eulerfd/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME fd.euler)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE cluster.cpp eulerfd.cpp mlfq.cpp search_tree.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE cluster.cpp eulerfd.cpp mlfq.cpp search_tree.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)

--- a/src/core/algorithms/fd/fastfds/CMakeLists.txt
+++ b/src/core/algorithms/fd/fastfds/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.fastfds)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fastfds.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fastfds.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::fd::pli Boost::headers
 )

--- a/src/core/algorithms/fd/fd_mine/CMakeLists.txt
+++ b/src/core/algorithms/fd/fd_mine/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.mine)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fd_mine.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fd_mine.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::fd::pli Boost::headers
 )

--- a/src/core/algorithms/fd/fd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/fd/fd_verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fd_verifier.cpp stats_calculator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fd_verifier.cpp stats_calculator.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::model::table better-enums
                     Boost::headers
@@ -12,11 +8,7 @@ target_link_libraries(
 
 set(NAME fd.verifier.dynamic)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE dynamic_fd_verifier.cpp dynamic_stats_calculator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE dynamic_fd_verifier.cpp dynamic_stats_calculator.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only better-enums
                     Boost::headers

--- a/src/core/algorithms/fd/fdep/CMakeLists.txt
+++ b/src/core/algorithms/fd/fdep/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.fdep)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fdep.cpp fd_tree_element.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fdep.cpp fd_tree_element.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/fd/fun/CMakeLists.txt
+++ b/src/core/algorithms/fd/fun/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.fun)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE fun.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE fun.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::pli spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/fd/hycommon/CMakeLists.txt
+++ b/src/core/algorithms/fd/hycommon/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(NAME fd.hy.common)
 desbordante_add_lib(NAME OBJECT)
 target_sources(
-    ${NAME}
-    PRIVATE all_column_combinations.cpp preprocessor.cpp sampler.cpp validator_helpers.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE all_column_combinations.cpp preprocessor.cpp sampler.cpp validator_helpers.cpp
 )
 target_link_libraries(
     ${NAME} PRIVATE Boost::thread ${DESBORDANTE_PREFIX}::fd::hy::model spdlog::spdlog_header_only

--- a/src/core/algorithms/fd/hyfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/hyfd/CMakeLists.txt
@@ -1,19 +1,11 @@
 set(NAME fd.hy.model)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE model/fd_tree.cpp model/fd_tree_vertex.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE model/fd_tree.cpp model/fd_tree_vertex.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)
 
 set(NAME fd.hy)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE hyfd.cpp inductor.cpp validator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE hyfd.cpp inductor.cpp validator.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::fd::hy::common ${DESBORDANTE_PREFIX}::fd::hy::model

--- a/src/core/algorithms/fd/pfd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/fd/pfd_verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.pfd_verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE pfd_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE pfd_verifier.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table better-enums Boost::headers
 )

--- a/src/core/algorithms/fd/pyro/CMakeLists.txt
+++ b/src/core/algorithms/fd/pyro/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME fd.pyro)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE pyro.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE pyro.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::fd::pyro::common
                     ${DESBORDANTE_PREFIX}::fd::pli better-enums Boost::headers

--- a/src/core/algorithms/fd/pyrocommon/CMakeLists.txt
+++ b/src/core/algorithms/fd/pyrocommon/CMakeLists.txt
@@ -13,7 +13,6 @@ target_sources(
             model/confidence_interval.cpp
             model/pli_cache.cpp
             model/list_agree_set_sample.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::model::table Boost::headers

--- a/src/core/algorithms/fd/sfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/sfd/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME fd.sfd.cords)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE contingency_table.cpp cords.cpp frequency_handler.cpp sample.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE contingency_table.cpp cords.cpp frequency_handler.cpp sample.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd better-enums Boost::headers)

--- a/src/core/algorithms/fd/tane/CMakeLists.txt
+++ b/src/core/algorithms/fd/tane/CMakeLists.txt
@@ -1,11 +1,7 @@
 # --- TaneCommon ---
 set(NAME fd.tane.common)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE model/lattice_level.cpp model/lattice_vertex.cpp tane_common.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE model/lattice_level.cpp model/lattice_vertex.cpp tane_common.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::fd::pli Boost::headers
 )
@@ -13,11 +9,7 @@ target_link_libraries(
 # --- Tane ---
 set(NAME fd.tane)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE afd_measures.cpp tane.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE afd_measures.cpp tane.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::tane::common ${DESBORDANTE_PREFIX}::fd::pli
                     ${DESBORDANTE_PREFIX}::fd::afd_metric better-enums Boost::headers
@@ -26,11 +18,7 @@ target_link_libraries(
 # --- PFDTane ---
 set(NAME fd.tane.pfd)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE pfdtane.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE pfdtane.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd::tane::common ${DESBORDANTE_PREFIX}::fd::pli
                     better-enums Boost::headers

--- a/src/core/algorithms/gfd/CMakeLists.txt
+++ b/src/core/algorithms/gfd/CMakeLists.txt
@@ -3,9 +3,5 @@ add_subdirectory(gfd_validator)
 
 set(NAME gfd)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE comparator.cpp gfd.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE comparator.cpp gfd.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)

--- a/src/core/algorithms/gfd/gfd_miner/CMakeLists.txt
+++ b/src/core/algorithms/gfd/gfd_miner/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME gfd.miner)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE gfd_miner.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE gfd_miner.cpp)
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::parser::graph ${DESBORDANTE_PREFIX}::gfd

--- a/src/core/algorithms/gfd/gfd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gfd/gfd_validator/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(NAME gfd.validator)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME}
-    PRIVATE balancer.cpp egfd_validator.cpp gfd_handler.cpp gfd_validator.cpp naivegfd_validator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE balancer.cpp egfd_validator.cpp gfd_handler.cpp gfd_validator.cpp
+                    naivegfd_validator.cpp
 )
 target_link_libraries(
     ${NAME}

--- a/src/core/algorithms/ind/CMakeLists.txt
+++ b/src/core/algorithms/ind/CMakeLists.txt
@@ -5,11 +5,7 @@ add_subdirectory(spider)
 
 set(NAME ind)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE ind.cpp ind_algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE ind.cpp ind_algorithm.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos better-enums
                     Boost::headers

--- a/src/core/algorithms/ind/faida/CMakeLists.txt
+++ b/src/core/algorithms/ind/faida/CMakeLists.txt
@@ -11,7 +11,6 @@ target_sources(
             preprocessing/preprocessor.cpp
             util/simple_ind.cpp
             faida.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME}

--- a/src/core/algorithms/ind/ind_verifier/CMakeLists.txt
+++ b/src/core/algorithms/ind/ind_verifier/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME ind.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE ind_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE ind_verifier.cpp)
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only Boost::headers)

--- a/src/core/algorithms/ind/mind/CMakeLists.txt
+++ b/src/core/algorithms/ind/mind/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME ind.mind)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE mind.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE mind.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::create_algo spdlog::spdlog_header_only better-enums
                     Boost::headers

--- a/src/core/algorithms/ind/spider/CMakeLists.txt
+++ b/src/core/algorithms/ind/spider/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME ind.spider)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE spider.cpp attribute.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE spider.cpp attribute.cpp)
 target_link_libraries(${NAME} PRIVATE better-enums Boost::headers)

--- a/src/core/algorithms/md/CMakeLists.txt
+++ b/src/core/algorithms/md/CMakeLists.txt
@@ -3,9 +3,5 @@ add_subdirectory(md_verifier)
 
 set(NAME md)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE md.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE md.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::algos Boost::headers)

--- a/src/core/algorithms/md/hymd/CMakeLists.txt
+++ b/src/core/algorithms/md/hymd/CMakeLists.txt
@@ -11,7 +11,6 @@ target_sources(
             record_pair_inferrer.cpp
             similarity_data.cpp
             validator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::md::hy::preprocessing ${DESBORDANTE_PREFIX}::md
@@ -31,7 +30,6 @@ target_sources(
             preprocessing/column_matches/levenshtein.cpp
             preprocessing/column_matches/monge_elkan.cpp
             preprocessing/column_matches/smith_waterman_gotoh.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only better-enums

--- a/src/core/algorithms/md/md_verifier/CMakeLists.txt
+++ b/src/core/algorithms/md/md_verifier/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME md.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE validation/validation.cpp md_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE validation/validation.cpp md_verifier.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::md::hy ${DESBORDANTE_PREFIX}::md
                     spdlog::spdlog_header_only better-enums Boost::headers

--- a/src/core/algorithms/metric/CMakeLists.txt
+++ b/src/core/algorithms/metric/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME metric.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE highlight_calculator.cpp metric_verifier.cpp points_calculator.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE highlight_calculator.cpp metric_verifier.cpp points_calculator.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
                     spdlog::spdlog_header_only better-enums Boost::headers

--- a/src/core/algorithms/nar/CMakeLists.txt
+++ b/src/core/algorithms/nar/CMakeLists.txt
@@ -2,11 +2,7 @@ add_subdirectory(des)
 
 set(NAME nar)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE nar.cpp nar_algorithm.cpp value_range.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE nar.cpp nar_algorithm.cpp value_range.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table better-enums Boost::headers
 )

--- a/src/core/algorithms/nar/des/CMakeLists.txt
+++ b/src/core/algorithms/nar/des/CMakeLists.txt
@@ -1,8 +1,6 @@
 set(NAME nar.des)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME}
-    PRIVATE des.cpp differential_functions.cpp encoded_nar.cpp encoded_value_range.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE des.cpp differential_functions.cpp encoded_nar.cpp encoded_value_range.cpp
 )
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::nar better-enums Boost::headers)

--- a/src/core/algorithms/nd/CMakeLists.txt
+++ b/src/core/algorithms/nd/CMakeLists.txt
@@ -2,9 +2,5 @@ add_subdirectory(nd_verifier)
 
 set(NAME nd)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE nd.cpp util/get_vertical_names.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE nd.cpp util/get_vertical_names.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)

--- a/src/core/algorithms/nd/nd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/nd/nd_verifier/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(NAME nd.verifier)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME}
-    PRIVATE nd_verifier.cpp util/highlight.cpp util/stats_calculator.cpp util/value_combination.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE nd_verifier.cpp util/highlight.cpp util/stats_calculator.cpp
+                    util/value_combination.cpp
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos

--- a/src/core/algorithms/od/fastod/CMakeLists.txt
+++ b/src/core/algorithms/od/fastod/CMakeLists.txt
@@ -12,7 +12,6 @@ target_sources(
             storage/data_frame.cpp
             util/timer.cpp
             util/type_util.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only

--- a/src/core/algorithms/od/order/CMakeLists.txt
+++ b/src/core/algorithms/od/order/CMakeLists.txt
@@ -1,10 +1,8 @@
 set(NAME od.order)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME}
-    PRIVATE dependency_checker.cpp list_lattice.cpp order.cpp order_utility.cpp
-            sorted_partitions.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE dependency_checker.cpp list_lattice.cpp order.cpp order_utility.cpp
+                    sorted_partitions.cpp
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only

--- a/src/core/algorithms/od/set_based_verifier/CMakeLists.txt
+++ b/src/core/algorithms/od/set_based_verifier/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME od.set_based_aod_verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE verifier.cpp)
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only better-enums Boost::headers)

--- a/src/core/algorithms/statistics/CMakeLists.txt
+++ b/src/core/algorithms/statistics/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME datastats)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE data_stats.cpp statistic.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE data_stats.cpp statistic.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types
                     ${DESBORDANTE_PREFIX}::algos better-enums Boost::headers

--- a/src/core/algorithms/ucc/CMakeLists.txt
+++ b/src/core/algorithms/ucc/CMakeLists.txt
@@ -5,9 +5,5 @@ add_subdirectory(ucc_verifier)
 
 set(NAME ucc)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE ucc_algorithm.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE ucc_algorithm.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)

--- a/src/core/algorithms/ucc/hpivalid/CMakeLists.txt
+++ b/src/core/algorithms/ucc/hpivalid/CMakeLists.txt
@@ -1,10 +1,6 @@
 set(NAME ucc.hpivalid)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE hpivalid.cpp hypergraph.cpp result_collector.cpp tree_search.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE hpivalid.cpp hypergraph.cpp result_collector.cpp tree_search.cpp)
 target_link_libraries(
     ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::fd::hy::common better-enums
                     Boost::headers

--- a/src/core/algorithms/ucc/hyucc/CMakeLists.txt
+++ b/src/core/algorithms/ucc/hyucc/CMakeLists.txt
@@ -1,9 +1,8 @@
 set(NAME ucc.hy)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME}
-    PRIVATE hyucc.cpp inductor.cpp validator.cpp model/ucc_tree.cpp model/ucc_tree_vertex.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE hyucc.cpp inductor.cpp validator.cpp model/ucc_tree.cpp
+                    model/ucc_tree_vertex.cpp
 )
 target_link_libraries(
     ${NAME}

--- a/src/core/algorithms/ucc/pyroucc/CMakeLists.txt
+++ b/src/core/algorithms/ucc/pyroucc/CMakeLists.txt
@@ -1,11 +1,9 @@
 set(NAME ucc.pyro)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE pyroucc.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE pyroucc.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::ucc ${DESBORDANTE_PREFIX}::fd::pyro::common
-                    ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only better-enums Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::ucc ${DESBORDANTE_PREFIX}::fd::pyro::common
+            ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only better-enums
+            Boost::headers
 )

--- a/src/core/algorithms/ucc/ucc_verifier/CMakeLists.txt
+++ b/src/core/algorithms/ucc/ucc_verifier/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME ucc.verifier)
 desbordante_add_lib(NAME)
-target_sources(
-    ${NAME}
-    PRIVATE ucc_verifier.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE ucc_verifier.cpp)
 target_link_libraries(${NAME} PRIVATE better-enums Boost::headers)

--- a/src/core/config/CMakeLists.txt
+++ b/src/core/config/CMakeLists.txt
@@ -19,6 +19,5 @@ target_sources(
             tabular_data/input_tables/option.cpp
             thread_number/option.cpp
             time_limit/option.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(${NAME} PRIVATE better-enums Boost::headers)

--- a/src/core/model/table/CMakeLists.txt
+++ b/src/core/model/table/CMakeLists.txt
@@ -18,7 +18,6 @@ target_sources(
             typed_column_data.cpp
             vertical.cpp
             vertical_map.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::types spdlog::spdlog_header_only better-enums

--- a/src/core/model/transaction/CMakeLists.txt
+++ b/src/core/model/transaction/CMakeLists.txt
@@ -1,7 +1,3 @@
 set(NAME model.transaction)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE itemset.cpp transactional_data.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE itemset.cpp transactional_data.cpp)

--- a/src/core/model/types/CMakeLists.txt
+++ b/src/core/model/types/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME model.types)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE create_type.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE create_type.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::util better-enums Boost::headers)

--- a/src/core/parser/csv_parser/CMakeLists.txt
+++ b/src/core/parser/csv_parser/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME parser.csv)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE csv_parser.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE csv_parser.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)

--- a/src/core/parser/graph_parser/CMakeLists.txt
+++ b/src/core/parser/graph_parser/CMakeLists.txt
@@ -1,8 +1,4 @@
 set(NAME parser.graph)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE graph_parser.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE graph_parser.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::graph)

--- a/src/core/util/CMakeLists.txt
+++ b/src/core/util/CMakeLists.txt
@@ -1,9 +1,7 @@
 set(NAME util)
 desbordante_add_lib(NAME OBJECT)
 target_sources(
-    ${NAME}
-    PRIVATE convex_hull.cpp create_dd.cpp levenshtein_distance.cpp progress.cpp qgram_vector.cpp
-            worker_thread_pool.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
+    ${NAME} PRIVATE convex_hull.cpp create_dd.cpp levenshtein_distance.cpp progress.cpp
+                    qgram_vector.cpp worker_thread_pool.cpp
 )
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only better-enums Boost::headers)

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -34,11 +34,7 @@ target_link_libraries(
 
 set(NAME bindlib.data)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE data/bind_data_types.cpp
-    PRIVATE FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/.."
-)
+target_sources(${NAME} PRIVATE data/bind_data_types.cpp)
 target_link_libraries(${NAME} PRIVATE pybind11::pybind11)
 set_target_properties(${NAME} PROPERTIES CXX_VISIBILITY_PRESET "hidden")
 
@@ -53,7 +49,6 @@ target_sources(
             py_util/opt_to_py.cpp
             py_util/py_to_any.cpp
             py_util/table_serialization.cpp
-    PRIVATE FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/.."
 )
 target_link_libraries(
     ${NAME} PRIVATE better-enums spdlog::spdlog_header_only Boost::headers pybind11::pybind11
@@ -71,8 +66,8 @@ desbordante_add_bind(
 )
 
 desbordante_add_bind(
-    afd_metric SRCS afd_metric/bind_afd_metric_calculation.cpp LIBS ${DESBORDANTE_PREFIX}::fd::afd_metric
-    Boost::headers
+    afd_metric SRCS afd_metric/bind_afd_metric_calculation.cpp LIBS
+    ${DESBORDANTE_PREFIX}::fd::afd_metric Boost::headers
 )
 
 desbordante_add_bind(

--- a/src/tests/benchmark/CMakeLists.txt
+++ b/src/tests/benchmark/CMakeLists.txt
@@ -1,11 +1,8 @@
 # Create benchmark executable
 set(NAME ${DESBORDANTE_PREFIX}.benchmark)
 add_executable(${NAME})
-target_sources(
-    ${NAME}
-    PRIVATE main.cpp benchmark_cli.cpp benchmark_comparer.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE main.cpp benchmark_cli.cpp benchmark_comparer.cpp)
+target_include_directories(${NAME} PRIVATE ${DESBORDANTE_COMMON_INCLUDE_DIRS})
 target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::testlib::common

--- a/src/tests/common/CMakeLists.txt
+++ b/src/tests/common/CMakeLists.txt
@@ -1,7 +1,3 @@
 set(NAME testlib.common)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE all_csv_configs.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE all_csv_configs.cpp)

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -4,37 +4,21 @@ include(GoogleTest)
 # --- Libs for tests ---
 set(NAME testlib.main)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE main.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE main.cpp)
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only gtest)
 
 set(NAME testlib.gfd.paths)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE all_gfd_paths.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE all_gfd_paths.cpp)
 target_link_libraries(${NAME} PRIVATE Boost::headers)
 
 set(NAME testlib.hash)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE test_hash_util.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE test_hash_util.cpp)
 
 set(NAME testlib.ind)
 desbordante_add_lib(NAME OBJECT)
-target_sources(
-    ${NAME}
-    PRIVATE test_ind_util.cpp
-    PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
-)
+target_sources(${NAME} PRIVATE test_ind_util.cpp)
 target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::ind gtest Boost::headers)
 
 # --- AC ---


### PR DESCRIPTION
This helps avoid repeating the same code in target_sources. The Google style guide recommends having the headers specify the path relative to src/ so it makes sense to have it in the library definition macro.