### PR TITLE
Add output-on-failure flag to CI tests

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -103,4 +103,4 @@ jobs:
             export CTEST_ARGS="-j ${nproc}"
           fi
 
-          ctest --exclude-regex ".*HeavyDatasets.*" $CTEST_ARGS
+          ctest --exclude-regex ".*HeavyDatasets.*" --output-on-failure $CTEST_ARGS


### PR DESCRIPTION
This helps to see how exactly tests failed without having to build these tests yourself.