### PR TITLE
Fix clang-tidy-review header input handling

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -79,15 +79,16 @@ jobs:
             -DCPM_SOURCE_CACHE=${{github.workspace}}/cmake/cpm-cache \
             -S . -B ${{github.workspace}}/build
 
-      - uses: ZedThree/clang-tidy-review@v0.19.0
+      - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
           apt_packages: libboost-dev,python3-dev
           build_dir: build
           config_file: '.clang-tidy'
+          include: "*.c,*.cc,*.cpp,*.cxx"
           split_workflow: true
 
-      - uses: ZedThree/clang-tidy-review/upload@v0.19.0
+      - uses: ZedThree/clang-tidy-review/upload@v0.23.1
 
       - name: Fail the check if clang-tidy reported issues
         if: steps.review.outputs.total_comments > 0

--- a/.github/workflows/post-review.yml
+++ b/.github/workflows/post-review.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.13.4
+      - uses: ZedThree/clang-tidy-review/post@v0.23.1
         id: post
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Run clang-tidy-review only on source files to avoid false CI failures when changed headers are processed as standalone inputs. Also bump ZedThree/clang-tidy-review to v0.23.1.