### PR TITLE
Move compile DB generation to clang-tidy action

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -63,26 +63,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install dependencies
-        uses: ./.github/composite-actions/install-dependencies
-        with:
-          os: ubuntu
-          toolset: gcc
-          download-pybind: true
-      - name: Generate compile_commands.json
-        run: |
-          cmake -DCMAKE_CXX_COMPILER=g++-10 \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -Dgtest_disable_pthreads=OFF \
-            -DDESBORDANTE_BINDINGS=BUILD \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCPM_SOURCE_CACHE=${{github.workspace}}/cmake/cpm-cache \
-            -S . -B ${{github.workspace}}/build
-
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          apt_packages: libboost-dev,python3-dev
+          apt_packages: python3-dev,libboost1.88-all-dev
+          cmake_command: cmake . -B build -DCMAKE_BUILD_TYPE=Debug -Dgtest_disable_pthreads=OFF -DDESBORDANTE_BINDINGS=BUILD -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCPM_SOURCE_CACHE=cmake/cpm-cache
           build_dir: build
           config_file: '.clang-tidy'
           include: "*.c,*.cc,*.cpp,*.cxx"


### PR DESCRIPTION
Generating compile_commands.json in a separate step can lead to mismatches between Python versions on the runner and in the action's container.