### PR TITLE
Bindings for user-defined metrics

### DIFF
--- a/src/core/config/CMakeLists.txt
+++ b/src/core/config/CMakeLists.txt
@@ -14,6 +14,9 @@ target_sources(
             ${CONDITIONS_SRCS}
             column_index/option.cpp
             column_index/validate_index.cpp
+            custom_metric/custom_metric/option.cpp
+            custom_metric/custom_metrics/option.cpp
+            custom_metric/custom_vector_metric/option.cpp
             custom_random_seed/option.cpp
             descriptions.cpp
             equal_nulls/option.cpp

--- a/src/core/config/custom_metric/custom_metric/option.cpp
+++ b/src/core/config/custom_metric/custom_metric/option.cpp
@@ -1,0 +1,22 @@
+#include "core/config/custom_metric/custom_metric/option.h"
+
+#include "core/config/custom_metric/custom_metric/type.h"
+#include "core/config/option.h"
+
+namespace config {
+
+namespace {
+void Normalize(CustomMetricType& value) {
+    if (!value) {
+        value = std::make_shared<util::DefaultCustomMetric>();
+    }
+}
+}  // namespace
+
+Option<CustomMetricType> MetricOption(CustomMetricType* value_ptr, std::string_view name,
+                                      std::string_view description) {
+    Option<CustomMetricType> option{value_ptr, name, description, CustomMetricType{nullptr}};
+    option.SetNormalizeFunc(&Normalize);
+    return option;
+}
+}  // namespace config

--- a/src/core/config/custom_metric/custom_metric/option.h
+++ b/src/core/config/custom_metric/custom_metric/option.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string_view>
+
+#include "core/config/custom_metric/custom_metric/type.h"
+#include "core/config/descriptions.h"
+#include "core/config/names.h"
+#include "core/config/option.h"
+
+namespace config {
+Option<CustomMetricType> MetricOption(CustomMetricType* value_ptr,
+                                      std::string_view name = names::kCustomMetric,
+                                      std::string_view description = descriptions::kDCustomMetric);
+}  // namespace config

--- a/src/core/config/custom_metric/custom_metric/type.h
+++ b/src/core/config/custom_metric/custom_metric/type.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <memory>
+
+#include "core/util/custom_metric/custom_metric.h"
+
+namespace config {
+using CustomMetricType = std::shared_ptr<util::ICustomMetric>;
+}  // namespace config

--- a/src/core/config/custom_metric/custom_metrics/option.cpp
+++ b/src/core/config/custom_metric/custom_metrics/option.cpp
@@ -1,0 +1,21 @@
+#include "core/config/custom_metric/custom_metrics/option.h"
+
+#include <cassert>
+#include <functional>
+
+#include "core/config/column_index/type.h"
+#include "core/config/option.h"
+
+namespace config {
+Option<CustomMetricsType> MetricsOption::operator()(
+        CustomMetricsType* value_ptr, std::function<IndexType()> get_col_count) const {
+    assert(get_col_count);
+    auto make_default = [get_col_count]() { return MakeDefaultMetrics(get_col_count()); };
+    auto option = Option<CustomMetricsType>(value_ptr, name_, description_, make_default);
+    option.SetValueCheck([get_col_count](CustomMetricsType const& value) {
+        return CheckMetrics(value, get_col_count());
+    });
+    option.SetNormalizeFunc(NormalizeMetrics);
+    return option;
+}
+}  // namespace config

--- a/src/core/config/custom_metric/custom_metrics/option.h
+++ b/src/core/config/custom_metric/custom_metrics/option.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string_view>
+
+#include "core/config/column_index/type.h"
+#include "core/config/custom_metric/custom_metrics/type.h"
+#include "core/config/descriptions.h"
+#include "core/config/exceptions.h"
+#include "core/config/names.h"
+#include "core/config/option.h"
+
+namespace config {
+/// @brief Option for a collection of user-defined metrics
+class MetricsOption {
+private:
+    std::string_view name_;
+    std::string_view description_;
+
+    static CustomMetricsType MakeDefaultMetrics(std::size_t indices_count) {
+        return CustomMetricsType(indices_count, nullptr);
+    }
+
+    static void CheckMetrics(CustomMetricsType const& value, std::size_t indices_count) {
+        if (value.size() != indices_count) {
+            std::ostringstream msg;
+            msg << "Expected " << indices_count << " user-defined metrics, got " << value.size();
+            throw ConfigurationError(msg.str());
+        }
+    }
+
+    /// User can pass @c nullptr to use the default metric explicitly
+    static void NormalizeMetrics(CustomMetricsType& value) {
+        auto default_metric = std::make_shared<util::DefaultCustomMetric>();
+
+        std::ranges::replace_if(value, std::logical_not{}, default_metric);
+    }
+
+public:
+    MetricsOption(std::string_view name = names::kCustomMetrics,
+                  std::string_view description = descriptions::kDCustomMetrics)
+        : name_(name), description_(description) {}
+
+    // NOTE: This option should depend on indices option (see @c SetConditionalOpts)
+    // to properly get column count
+    [[nodiscard]] Option<CustomMetricsType> operator()(
+            CustomMetricsType* value_ptr, std::function<IndexType()> get_col_count) const;
+};
+}  // namespace config

--- a/src/core/config/custom_metric/custom_metrics/type.h
+++ b/src/core/config/custom_metric/custom_metrics/type.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "core/util/custom_metric/custom_metric.h"
+
+namespace config {
+using CustomMetricsType = std::vector<std::shared_ptr<util::ICustomMetric>>;
+}  // namespace config

--- a/src/core/config/custom_metric/custom_vector_metric/option.cpp
+++ b/src/core/config/custom_metric/custom_vector_metric/option.cpp
@@ -1,0 +1,22 @@
+#include "core/config/custom_metric/custom_vector_metric/option.h"
+
+namespace config {
+
+namespace {
+void Normalize(CustomVectorMetricType& value) {
+    if (!value) {
+        value = std::make_shared<util::DefaultCustomVectorMetric>();
+    }
+}
+}  // namespace
+
+Option<CustomVectorMetricType> VectorMetricOption(CustomVectorMetricType* value_ptr,
+                                                  std::string_view name,
+                                                  std::string_view description) {
+    Option<CustomVectorMetricType> option{value_ptr, name, description,
+                                          CustomVectorMetricType{nullptr}};
+    option.SetNormalizeFunc(&Normalize);
+    return option;
+}
+
+}  // namespace config

--- a/src/core/config/custom_metric/custom_vector_metric/option.h
+++ b/src/core/config/custom_metric/custom_vector_metric/option.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string_view>
+
+#include "core/config/custom_metric/custom_vector_metric/type.h"
+#include "core/config/descriptions.h"
+#include "core/config/names.h"
+#include "core/config/option.h"
+
+namespace config {
+Option<CustomVectorMetricType> VectorMetricOption(
+        CustomVectorMetricType* value_ptr, std::string_view name = names::kCustomMetric,
+        std::string_view description = descriptions::kDCustomMetric);
+}  // namespace config

--- a/src/core/config/custom_metric/custom_vector_metric/type.h
+++ b/src/core/config/custom_metric/custom_vector_metric/type.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <memory>
+
+#include "core/util/custom_metric/custom_vector_metric.h"
+
+namespace config {
+using CustomVectorMetricType = std::shared_ptr<util::ICustomVectorMetric>;
+}  // namespace config

--- a/src/core/config/descriptions.h
+++ b/src/core/config/descriptions.h
@@ -4,6 +4,8 @@
 
 namespace config::descriptions {
 // Common
+constexpr auto kDCustomMetric = "user-defined metric";
+constexpr auto kDCustomMetrics = "user-defined metrics";
 constexpr auto kDEqualNulls = "specify whether two NULLs should be considered equal";
 constexpr auto kDError = "error threshold value for Approximate FD algorithms";
 constexpr auto kDLhsIndices = "LHS column indices";

--- a/src/core/config/names.h
+++ b/src/core/config/names.h
@@ -3,6 +3,8 @@
 namespace config::names {
 // Common
 constexpr auto kCsvConfig = "csv_config";
+constexpr auto kCustomMetric = "metric";
+constexpr auto kCustomMetrics = "metrics";
 constexpr auto kEqualNulls = "is_null_equal_null";
 constexpr auto kError = "error";
 constexpr auto kLhsIndices = "lhs_indices";

--- a/src/core/util/custom_metric/custom_metric.h
+++ b/src/core/util/custom_metric/custom_metric.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <utility>
+
+#include "core/config/exceptions.h"
+#include "core/model/types/imetrizable_type.h"
+#include "core/model/types/type.h"
+#include "core/util/export.h"
+
+namespace util {
+/// @brief User-defined metric on a single typed column
+/// Together with @c PyCustomMetric, @c DynamicCustomMetric and @c StaticCustomMetric provides
+/// a convenient user interface (especially, in Python) without extra overhead on conversions
+// NOTE: these objects are wrapped in `shared_ptr`, and this encourages user to use the same object
+// for several columns. Keep it in mind if you are planning to implement some complex internal state
+/// WARN: NULL value is represented by nullptr
+class DESBORDANTE_EXPORT ICustomMetric {
+public:
+    virtual ~ICustomMetric() = default;
+
+    virtual double Dist(model::Type const* type, std::byte const* first,
+                        std::byte const* second) const = 0;
+};
+
+/// @brief Provides a convenient way to define custom metric, when column type is known in advance
+/// WARN: Ignores real column type. Passing incorrect type leads to undefined behaviour
+template <typename ArgType>
+class StaticCustomMetric : public ICustomMetric {
+private:
+    using OptArg = std::optional<ArgType>;
+    using Metric = std::function<double(OptArg const&, OptArg const&)>;
+
+    Metric metric_;
+
+    static OptArg GetValue(std::byte const* value) {
+        if (!value) {
+            return std::nullopt;
+        }
+        return model::Type::GetValue<ArgType>(value);
+    }
+
+public:
+    explicit StaticCustomMetric(Metric metric) : metric_(std::move(metric)) {}
+
+    double Dist(model::Type const*, std::byte const* first,
+                std::byte const* second) const override {
+        return metric_(GetValue(first), GetValue(second));
+    }
+};
+
+/// @brief A custom metric, which uses real column type
+class DynamicCustomMetric : public ICustomMetric {
+private:
+    using Metric = std::function<double(model::Type const*, std::byte const*, std::byte const*)>;
+
+    Metric metric_;
+
+public:
+    explicit DynamicCustomMetric(Metric metric) : metric_(std::move(metric)) {}
+
+    double Dist(model::Type const* type, std::byte const* first,
+                std::byte const* second) const override {
+        return metric_(type, first, second);
+    }
+};
+
+/// @brief A default value for custom metric option
+/// Uses default metric for the type. Works only with metrizable types
+class DefaultCustomMetric : public ICustomMetric {
+private:
+    static model::IMetrizableType const* ConvertType(model::Type const* type) {
+        auto const* metr_type = dynamic_cast<model::IMetrizableType const*>(type);
+        if (!metr_type) {
+            std::ostringstream msg;
+            msg << "Cannot use default metric, because column type " << type->ToString()
+                << " is not metrizable. Consider defining custom metric";
+            throw config::ConfigurationError(msg.str());
+        }
+        return metr_type;
+    }
+
+public:
+    double Dist(model::Type const* type, std::byte const* first,
+                std::byte const* second) const override {
+        if (!first || !second) {
+            return 0;
+        }
+        return ConvertType(type)->Dist(first, second);
+    }
+};
+}  // namespace util

--- a/src/core/util/custom_metric/custom_vector_metric.h
+++ b/src/core/util/custom_metric/custom_vector_metric.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "core/config/exceptions.h"
+#include "core/model/types/imetrizable_type.h"
+#include "core/model/types/type.h"
+#include "core/util/export.h"
+
+namespace util {
+/// @brief User-defined metric on a set of columns, that treats values as tuples (vectors)
+/// Together with @c PyCustomVectorMetric and @c CustomVectorMetric provides
+/// a convenient user interface (especially, in Python) without extra overhead on conversions
+// NOTE: these objects are wrapped in `shared_ptr`, and this encourages user to use the same object
+// for several columns. Keep it in mind if you are planning to implement some complex internal state
+/// WARN: NULL value is represented by nullptr
+class DESBORDANTE_EXPORT ICustomVectorMetric {
+protected:
+    using Types = std::vector<model::Type const*>;
+    using Values = std::vector<std::byte const*>;
+
+public:
+    virtual ~ICustomVectorMetric() = default;
+
+    virtual double Dist(Types const& types, Values const& first, Values const& second) const = 0;
+};
+
+/// @brief A custom vector metric, which uses real column types
+class CustomVectorMetric : public ICustomVectorMetric {
+private:
+    using Metric = std::function<double(Types const&, Values const&, Values const&)>;
+
+    Metric metric_;
+
+public:
+    explicit CustomVectorMetric(Metric metric) : metric_(std::move(metric)) {}
+
+    double Dist(Types const& types, Values const& first, Values const& second) const override {
+        return metric_(types, first, second);
+    }
+};
+
+/// @brief A default value for custom vector metric option
+/// Uses euclidean metric and default metrics for individual coordinates.
+/// Works only with metrizable types
+class DefaultCustomVectorMetric : public ICustomVectorMetric {
+private:
+    static model::IMetrizableType const* ConvertType(model::Type const* type) {
+        auto const* metr_type = dynamic_cast<model::IMetrizableType const*>(type);
+        if (!metr_type) {
+            std::ostringstream msg;
+            msg << "Cannot use default metric, because column type " << type->ToString()
+                << " is not metrizable. Consider defining custom metric";
+            throw config::ConfigurationError(msg.str());
+        }
+        return metr_type;
+    }
+
+public:
+    double Dist(Types const& types, Values const& first, Values const& second) const override {
+        assert(types.size() == first.size() && types.size() == second.size());
+
+        double result = 0;
+        for (std::size_t i = 0; i < types.size(); ++i) {
+            if (first[i] && second[i]) {
+                double dist = ConvertType(types[i])->Dist(first[i], second[i]);
+                result += dist * dist;
+            }
+        }
+        return std::sqrt(result);
+    }
+};
+}  // namespace util

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(
             py_util/iterable_sequence_stream.cpp
             py_util/logging.cpp
             py_util/opt_to_py.cpp
+            py_util/py_custom_metrics.cpp
             py_util/py_to_any.cpp
             py_util/table_serialization.cpp
             py_util/value_to_py.cpp

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -39,6 +39,7 @@
 #include "python_bindings/pac/bind_pac_verification.h"
 #include "python_bindings/pfd/bind_pfd_verification.h"
 #include "python_bindings/py_util/logging.h"
+#include "python_bindings/py_util/py_custom_metrics.h"
 #include "python_bindings/sd/bind_sd_verification.h"
 #include "python_bindings/sfd/bind_sfd.h"
 #include "python_bindings/statistics/bind_statistics.h"
@@ -51,6 +52,7 @@ PYBIND11_MODULE(desbordante, module, pybind11::mod_gil_not_used()) {
     using namespace pybind11::literals;
     for (auto bind_func : {BindMainClasses,
                            BindDataTypes,
+                           BindCustomMetrics,
                            BindLogging,
                            BindFd,
                            BindCfd,

--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -23,6 +23,9 @@
 #include "core/algorithms/nar/des/enums.h"
 #include "core/algorithms/od/fastod/od_ordering.h"
 #include "core/algorithms/pac/model/idomain.h"
+#include "core/config/custom_metric/custom_metric/type.h"
+#include "core/config/custom_metric/custom_metrics/type.h"
+#include "core/config/custom_metric/custom_vector_metric/type.h"
 #include "core/config/custom_random_seed/type.h"
 #include "core/config/error_measure/type.h"
 #include "core/config/tabular_data/input_table_type.h"
@@ -43,6 +46,7 @@ namespace {
 // tuple -> PyTuple_Type
 // set -> PySet_Type
 // dict -> PyDict_Type
+// function -> PyFunction_Type
 
 py::handle MakeType(py::type type) {
     return type;
@@ -140,6 +144,9 @@ py::tuple GetPyType(std::type_index type_index) {
             kPyTypePair<std::vector<double>, &PyList_Type, &PyFloat_Type>,
             {typeid(std::shared_ptr<pac::model::IDomain>),
              []() { return MakeTypeTuple(py::type::of<pac::model::IDomain>()); }},
+            kPyTypePair<config::CustomMetricType, &PyFunction_Type>,
+            kPyTypePair<config::CustomMetricsType, &PyList_Type, &PyFunction_Type>,
+            kPyTypePair<config::CustomVectorMetricType, &PyFunction_Type>,
     };
 
     auto const it = type_map.find(type_index);

--- a/src/python_bindings/py_util/opt_to_py.cpp
+++ b/src/python_bindings/py_util/opt_to_py.cpp
@@ -17,6 +17,9 @@
 #include "core/algorithms/nar/des/enums.h"
 #include "core/algorithms/od/fastod/od_ordering.h"
 #include "core/algorithms/pac/model/idomain.h"
+#include "core/config/custom_metric/custom_metric/type.h"
+#include "core/config/custom_metric/custom_metrics/type.h"
+#include "core/config/custom_metric/custom_vector_metric/type.h"
 #include "core/config/custom_random_seed/type.h"
 #include "core/config/equal_nulls/type.h"
 #include "core/config/error/type.h"
@@ -57,6 +60,9 @@ std::unordered_map<std::type_index, ConvFunction> const kConverters{
         kNormalConvPair<model::DDString>,
         kNormalConvPair<model::Gdd>,
         kNormalConvPair<std::shared_ptr<pac::model::IDomain>>,
+        kNormalConvPair<config::CustomMetricType>,
+        kNormalConvPair<config::CustomMetricsType>,
+        kNormalConvPair<config::CustomVectorMetricType>,
         kEnumConvPair<algos::metric::MetricAlgo>,
         kEnumConvPair<algos::metric::Metric>,
         kEnumConvPair<model::InputFormatType>,

--- a/src/python_bindings/py_util/py_custom_metrics.cpp
+++ b/src/python_bindings/py_util/py_custom_metrics.cpp
@@ -1,0 +1,22 @@
+#include "python_bindings/py_util/py_custom_metrics.h"
+
+#include <pybind11/pybind11.h>
+
+#include <memory>
+
+#include "core/util/custom_metric/custom_metric.h"
+#include "core/util/custom_metric/custom_vector_metric.h"
+
+namespace py = pybind11;
+
+namespace python_bindings {
+void BindCustomMetrics(pybind11::module_& main_module) {
+    auto metrics_module = main_module.def_submodule("metrics");
+
+    // These classes are used only in get_opts
+    py::class_<util::ICustomMetric, std::shared_ptr<util::ICustomMetric>>(metrics_module,
+                                                                          "CustomMetric");
+    py::class_<util::ICustomVectorMetric, std::shared_ptr<util::ICustomVectorMetric>>(
+            metrics_module, "CustomVectorMetrics");
+}
+}  // namespace python_bindings

--- a/src/python_bindings/py_util/py_custom_metrics.h
+++ b/src/python_bindings/py_util/py_custom_metrics.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <cstddef>
+#include <utility>
+
+#include <pybind11/pytypes.h>
+
+#include "core/model/types/type.h"
+#include "core/util/custom_metric/custom_metric.h"
+#include "core/util/custom_metric/custom_vector_metric.h"
+#include "python_bindings/py_util/value_to_py.h"
+
+namespace python_bindings {
+class PyCustomMetric : public util::ICustomMetric {
+private:
+    pybind11::object metric_;
+
+public:
+    explicit PyCustomMetric(pybind11::object&& metric) : metric_(std::move(metric)) {}
+
+    double Dist(model::Type const* type, std::byte const* first,
+                std::byte const* second) const override {
+        return pybind11::cast<double>(metric_(ValueToPy(type, first), ValueToPy(type, second)));
+    }
+};
+
+class PyCustomVectorMetric : public util::ICustomVectorMetric {
+private:
+    pybind11::object metric_;
+
+public:
+    explicit PyCustomVectorMetric(pybind11::object&& metric) : metric_(std::move(metric)) {}
+
+    double Dist(Types const& types, Values const& first, Values const& second) const override {
+        return pybind11::cast<double>(metric_(ValuesToPy(types, first), ValuesToPy(types, second)));
+    }
+};
+
+void BindCustomMetrics(pybind11::module_& main_module);
+}  // namespace python_bindings

--- a/src/python_bindings/py_util/py_to_any.cpp
+++ b/src/python_bindings/py_util/py_to_any.cpp
@@ -1,6 +1,8 @@
 #include <pybind11/pybind11.h>
 
+#include <algorithm>
 #include <functional>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -25,6 +27,9 @@
 #include "core/algorithms/nar/des/enums.h"
 #include "core/algorithms/od/fastod/od_ordering.h"
 #include "core/algorithms/pac/model/idomain.h"
+#include "core/config/custom_metric/custom_metric/type.h"
+#include "core/config/custom_metric/custom_metrics/type.h"
+#include "core/config/custom_metric/custom_vector_metric/type.h"
 #include "core/config/enum_members_string.h"
 #include "core/config/error_measure/type.h"
 #include "core/config/exceptions.h"
@@ -36,6 +41,7 @@
 #include "core/util/enum_to_str.h"
 #include "python_bindings/py_util/create_dataframe_reader.h"
 #include "python_bindings/py_util/iterable_sequence_stream.h"
+#include "python_bindings/py_util/py_custom_metrics.h"
 
 namespace {
 
@@ -187,6 +193,30 @@ boost::any StringVectorToAny(std::string_view option_name, py::handle obj) {
     return out;
 }
 
+boost::any CustomMetricToAny(std::string_view, py::handle obj) {
+    return config::CustomMetricType{
+            new python_bindings::PyCustomMetric(py::reinterpret_borrow<py::object>(obj))};
+}
+
+boost::any CustomMetricsToAny(std::string_view option_name, py::handle obj) {
+    auto metric_handles = CastAndReplaceCastError<std::vector<py::handle>>(option_name, obj);
+    config::CustomMetricsType result(metric_handles.size());
+    std::ranges::transform(metric_handles, result.begin(),
+                           [](py::handle handle) -> config::CustomMetricType {
+                               if (handle.is_none()) {
+                                   return nullptr;
+                               }
+                               return std::make_shared<python_bindings::PyCustomMetric>(
+                                       py::reinterpret_borrow<py::object>(handle));
+                           });
+    return result;
+}
+
+boost::any CustomVectorMetricToAny(std::string_view, py::handle obj) {
+    return config::CustomVectorMetricType{
+            new python_bindings::PyCustomVectorMetric(py::reinterpret_borrow<py::object>(obj))};
+}
+
 std::unordered_map<std::type_index, ConvFunc> const kConverters{
         kNormalConvPair<bool>,
         kNormalConvPair<double>,
@@ -231,6 +261,9 @@ std::unordered_map<std::type_index, ConvFunc> const kConverters{
         kNormalConvPair<std::vector<std::string>>,
         kNormalConvPair<std::unordered_map<std::string, std::vector<unsigned int>>>,
         kNormalConvPair<std::shared_ptr<pac::model::IDomain>>,
+        {typeid(config::CustomMetricType), CustomMetricToAny},
+        {typeid(config::CustomMetricsType), CustomMetricsToAny},
+        {typeid(config::CustomVectorMetricType), CustomVectorMetricToAny},
 };
 
 }  // namespace


### PR DESCRIPTION
Add classes for user-defined metrics that allow transparent usage from Python (i. e. user's function gets values directly, not strings or something), without introducing extra overhead in C++.

There are two types of metrics:
- A single-column metric (and a separate option for a set of single-column metrics)
- A multi-column metric, that treats its arguments as vectors

There are three classes provided by default:
- `Py*Metric` -- allows the user to pass a Python function, which will be called on real values
- `Static*Metric` -- C++ metric that converts all values to some fixed type (very convenient in tests!)
- `Dynamic*Metric` -- C++ metric that passes real column type and raw value to the user function, allowing it to do all conversions
Other types of metrics can be introduced by implementing the `IMetric` interface, if some non-standard behavior is required in some algorithm.

Also, there are default metrics for metrizable types (vector metric uses the euclidean distance)