### PR TITLE
Refactor: make type checker order deterministic

### DIFF
--- a/src/core/model/table/typed_column_data.cpp
+++ b/src/core/model/table/typed_column_data.cpp
@@ -25,11 +25,15 @@ TypeId TypedColumnDataFactory::DeduceColumnType() const {
     bool is_undefined = true;
     std::bitset<5> candidate_types_bitset("11111");
     TypeId first_type_id = TypeId::kUndefined;
+    auto matcher_map_iter = kTypeIdToChecker.begin();
     for (std::size_t i = 0; i != unparsed_.size(); ++i) {
         if (!kNullCheck(unparsed_[i]) && !kEmptyCheck(unparsed_[i])) {
             is_undefined = false;
             if (first_type_id != TypeId::kUndefined) {
-                auto& type_check = kTypeIdToChecker.at(first_type_id);
+                auto it =
+                        std::find_if(matcher_map_iter, kTypeIdToChecker.end(),
+                                     [&](auto const& pair) { return pair.first == first_type_id; });
+                auto& type_check = it->second;
                 if (type_check(unparsed_[i])) {
                     // undelimited and delimited dates have different bitsets
                     if (first_type_id == TypeId::kDate && kDelimitedDateCheck(unparsed_[i])) {

--- a/src/core/model/table/typed_column_data.h
+++ b/src/core/model/table/typed_column_data.h
@@ -216,23 +216,23 @@ private:
                 }
                 return is_simple_date;
             };
-    inline static std::unordered_map<TypeId, std::function<bool(std::string const&)>> const
+    inline static std::vector<std::pair<TypeId, std::function<bool(std::string const&)>>> const
             kTypeIdToChecker = {
-                    {TypeId::kDouble,
+                    {TypeId::kDate,
                      [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDouble));
-                     }},
-                    {TypeId::kBigInt,
-                     [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kBigInt));
+                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDate)) &&
+                                (kDelimitedDateCheck(val) || kUndelimitedDateCheck(val));
                      }},
                     {TypeId::kInt,
                      [](std::string const& val) {
                          return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kInt));
                      }},
-                    {TypeId::kDate, [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDate)) &&
-                                (kDelimitedDateCheck(val) || kUndelimitedDateCheck(val));
+                    {TypeId::kBigInt,
+                     [](std::string const& val) {
+                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kBigInt));
+                     }},
+                    {TypeId::kDouble, [](std::string const& val) {
+                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDouble));
                      }}};
     // each 1 represents a possible type from kAllCandidateTypes
     inline static std::unordered_map<TypeId, std::bitset<5>> const kTypeIdToBitset = {


### PR DESCRIPTION
Replaces unordered_map iteration with deterministic ordering for type checking