### PR TITLE
Add optional PLIWS

### DIFF
--- a/src/core/algorithms/fd/afd_metric/afd_metric_calculator.cpp
+++ b/src/core/algorithms/fd/afd_metric/afd_metric_calculator.cpp
@@ -30,13 +30,14 @@ void AFDMetricCalculator::RegisterOptions() {
     RegisterOption(config::kLhsIndicesOpt(&lhs_indices_, get_schema_cols));
     RegisterOption(config::kRhsIndicesOpt(&rhs_indices_, get_schema_cols));
     RegisterOption(Option{&metric_, kMetric, kDAFDMetric});
+    RegisterOption(config::kUsePliwsOpt(&use_pliws_));
 }
 
 void AFDMetricCalculator::MakeExecuteOptsAvailable() {
     using namespace config::names;
 
-    MakeOptionsAvailable(
-            {kMetric, config::kLhsIndicesOpt.GetName(), config::kRhsIndicesOpt.GetName()});
+    MakeOptionsAvailable({kMetric, config::kLhsIndicesOpt.GetName(),
+                          config::kRhsIndicesOpt.GetName(), config::kUsePliwsOpt.GetName()});
 }
 
 void AFDMetricCalculator::LoadDataInternal() {
@@ -54,26 +55,46 @@ unsigned long long AFDMetricCalculator::ExecuteInternal() {
     return elapsed_milliseconds;
 }
 
+namespace {
+
+template <typename PLIT>
+auto CalculateMetric(PLIT&& lhs_ptr, PLIT&& rhs_ptr, AFDMetric metric, size_t num_rows) {
+    auto* lhs_raw = lhs_ptr.get();
+    auto* rhs_raw = rhs_ptr.get();
+
+    switch (metric) {
+        case AFDMetric::kG2:
+            return AFDMetricCalculator::CalculateG2(lhs_raw, rhs_raw, num_rows);
+        case AFDMetric::kTau: {
+            auto joint = lhs_raw->Intersect(rhs_raw);
+            return AFDMetricCalculator::CalculateTau(lhs_raw, rhs_raw, joint.get());
+        }
+        case AFDMetric::kMuPlus: {
+            auto joint = lhs_raw->Intersect(rhs_raw);
+            return AFDMetricCalculator::CalculateMuPlus(lhs_raw, rhs_raw, joint.get());
+        }
+        case AFDMetric::kFi:
+            return AFDMetricCalculator::CalculateFI(lhs_raw, rhs_raw, num_rows);
+    }
+
+    assert(false);
+    __builtin_unreachable();
+}
+}  // namespace
+
 void AFDMetricCalculator::CalculateMetric() {
     auto num_rows = relation_->GetNumRows();
-    auto lhs_pli = relation_->CalculatePLIWS(lhs_indices_);
-    auto rhs_pli = relation_->CalculatePLIWS(rhs_indices_);
 
-    switch (metric_) {
-        case AFDMetric::kG2:
-            result_ = CalculateG2(lhs_pli.get(), rhs_pli.get(), num_rows);
-            break;
-        case AFDMetric::kTau:
-            result_ = CalculateTau(lhs_pli.get(), rhs_pli.get(),
-                                   lhs_pli->Intersect(rhs_pli.get()).get());
-            break;
-        case AFDMetric::kMuPlus:
-            result_ = CalculateMuPlus(lhs_pli.get(), rhs_pli.get(),
-                                      lhs_pli->Intersect(rhs_pli.get()).get());
-            break;
-        case AFDMetric::kFi:
-            result_ = CalculateFI(lhs_pli.get(), rhs_pli.get(), num_rows);
-            break;
+    if (use_pliws_) {
+        auto lhs_pli = relation_->CalculatePLIWS(lhs_indices_);
+        auto rhs_pli = relation_->CalculatePLIWS(rhs_indices_);
+        result_ = ::algos::afd_metric_calculator::CalculateMetric(lhs_pli, rhs_pli, metric_,
+                                                                  num_rows);
+    } else {
+        auto lhs_pli = relation_->CalculatePLI(lhs_indices_);
+        auto rhs_pli = relation_->CalculatePLI(rhs_indices_);
+        result_ = ::algos::afd_metric_calculator::CalculateMetric(lhs_pli, rhs_pli, metric_,
+                                                                  num_rows);
     }
 }
 
@@ -95,7 +116,7 @@ long double AFDMetricCalculator::CalculateG2(model::PLI const* lhs_pli, model::P
     return num_error_rows / num_rows;
 }
 
-long double AFDMetricCalculator::CalculatePdepSelf(model::PLIWithSingletons const* x_pli) {
+long double AFDMetricCalculator::CalculatePdepSelf(model::PLI const* x_pli) {
     size_t n = x_pli->GetRelationSize();
     config::ErrorType sum = 0;
     std::size_t cluster_rows_count = 0;
@@ -150,9 +171,58 @@ long double AFDMetricCalculator::CalculatePdepMeasure(model::PLIWithSingletons c
     return (sum / static_cast<config::ErrorType>(n));
 }
 
+long double AFDMetricCalculator::CalculatePdepMeasure(model::PositionListIndex const* x_pli,
+                                                      model::PositionListIndex const* xa_pli) {
+    std::deque<Cluster> xa_index = xa_pli->GetIndex();
+    std::deque<Cluster> x_index = x_pli->GetIndex();
+    size_t n = x_pli->GetRelationSize();
+
+    config::ErrorType sum = 0;
+
+    std::unordered_map<int, size_t> x_frequencies;
+
+    int x_value_id = 1;
+    for (Cluster const& x_cluster : x_index) {
+        x_frequencies[x_value_id++] = x_cluster.size();
+    }
+
+    x_frequencies[model::PositionListIndex::kSingletonValueId] = 1;
+
+    auto x_prob = x_pli->CalculateAndGetProbingTable();
+
+    auto get_x_freq_by_tuple_ind{[&x_prob, &x_frequencies](int tuple_ind) {
+        int value_id = x_prob->at(tuple_ind);
+        return static_cast<config::ErrorType>(x_frequencies[value_id]);
+    }};
+
+    for (Cluster const& xa_cluster : xa_index) {
+        config::ErrorType num = xa_cluster.size() * xa_cluster.size();
+        config::ErrorType denum = get_x_freq_by_tuple_ind(xa_cluster.front());
+        sum += num / denum;
+    }
+
+    auto xa_prob = xa_pli->CalculateAndGetProbingTable();
+    for (size_t i = 0; i < xa_prob->size(); i++) {
+        if (xa_prob->at(i) == 0) {
+            sum += 1 / get_x_freq_by_tuple_ind(i);
+        }
+    }
+    return (sum / static_cast<config::ErrorType>(n));
+}
+
 long double AFDMetricCalculator::CalculateTau(model::PLIWS const* lhs_pli,
                                               model::PLIWS const* rhs_pli,
                                               model::PLIWS const* joint_pli) {
+    auto p1 = CalculatePdepSelf(rhs_pli);
+    if (p1 == 1) return 1;
+
+    auto p2 = CalculatePdepMeasure(lhs_pli, joint_pli);
+
+    return (p2 - p1) / (1 - p1);
+}
+
+long double AFDMetricCalculator::CalculateTau(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                              model::PLI const* joint_pli) {
     auto p1 = CalculatePdepSelf(rhs_pli);
     if (p1 == 1) return 1;
 
@@ -186,6 +256,33 @@ long double AFDMetricCalculator::CalculateMuPlus(model::PLIWS const* lhs_pli,
     return std::max(mu, 0.L);
 }
 
+long double AFDMetricCalculator::CalculateMuPlus(model::PositionListIndex const* x_pli,
+                                                 model::PositionListIndex const* a_pli,
+                                                 model::PositionListIndex const* xa_pli) {
+    config::ErrorType pdep_y = CalculatePdepSelf(a_pli);
+    if (pdep_y == 1) return 1;
+
+    config::ErrorType pdep_xy = CalculatePdepMeasure(x_pli, xa_pli);
+
+    size_t n = x_pli->GetRelationSize();
+    std::size_t cluster_rows_count = 0;
+    std::deque<Cluster> const& x_index = x_pli->GetIndex();
+    size_t k = x_index.size();
+
+    for (Cluster const& x_cluster : x_index) {
+        cluster_rows_count += x_cluster.size();
+    }
+
+    std::size_t unique_rows = x_pli->GetRelationSize() - cluster_rows_count;
+    k += unique_rows;
+
+    if (k == n) return 1;
+
+    config::ErrorType mu = 1 - (1 - pdep_xy) / (1 - pdep_y) * (n - 1) / (n - k);
+    config::ErrorType mu_plus = std::max(0., mu);
+    return mu_plus;
+}
+
 long double AFDMetricCalculator::CalculateFI(model::PLIWS const* lhs_pli,
                                              model::PLIWS const* rhs_pli, size_t num_rows) {
     if (num_rows <= 0) throw std::invalid_argument("received unpositive number of rows");
@@ -213,6 +310,44 @@ long double AFDMetricCalculator::CalculateFI(model::PLIWS const* lhs_pli,
             if (size == 0.L) continue;
             conditional_entropy -= size * (std::log(size) - log_x);
         }
+    }
+    conditional_entropy /= num_rows;
+    auto mutual_information = entropy - conditional_entropy;
+    return mutual_information / entropy;
+}
+
+long double AFDMetricCalculator::CalculateFI(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                             size_t num_rows) {
+    if (num_rows <= 0) throw std::invalid_argument("received unpositive number of rows");
+
+    if (rhs_pli->GetNumCluster() < 2) {
+        return 0.L;
+    }
+
+    auto entropy = rhs_pli->GetEntropy();
+
+    std::deque<Cluster> rhs_clusters{rhs_pli->GetIndex()};
+    for (auto& y : rhs_clusters) {
+        std::sort(y.begin(), y.end());
+    }
+
+    auto conditional_entropy = 0.L;
+    for (auto& x : std::deque<Cluster>{lhs_pli->GetIndex()}) {
+        std::sort(x.begin(), x.end());
+        auto log_x = std::log(x.size());
+
+        size_t xy_calc_cnt = 0;
+        for (auto const& y : rhs_clusters) {
+            model::PositionListIndex::Cluster xy;
+            std::set_intersection(x.begin(), x.end(), y.begin(), y.end(), std::back_inserter(xy));
+
+            auto size = (long double)xy.size();
+            if (size == 0.L) continue;
+            xy_calc_cnt += size;
+            conditional_entropy -= size * (std::log(size) - log_x);
+        }
+
+        conditional_entropy -= (long double)(x.size() - xy_calc_cnt) * (-log_x);
     }
     conditional_entropy /= num_rows;
     auto mutual_information = entropy - conditional_entropy;

--- a/src/core/algorithms/fd/afd_metric/afd_metric_calculator.h
+++ b/src/core/algorithms/fd/afd_metric/afd_metric_calculator.h
@@ -9,6 +9,7 @@
 #include "core/config/equal_nulls/type.h"
 #include "core/config/indices/type.h"
 #include "core/config/tabular_data/input_table_type.h"
+#include "core/config/use_pliws/option.h"
 #include "core/model/table/column_layout_relation_data.h"
 #include "core/model/table/position_list_index.h"
 #include "core/model/table/position_list_index_with_singletons.h"
@@ -20,6 +21,7 @@ private:
     config::InputTable input_table_;
 
     AFDMetric metric_ = magic_enum::enum_values<AFDMetric>().front();
+    bool use_pliws_ = false;
     config::IndicesType lhs_indices_;
     config::IndicesType rhs_indices_;
 
@@ -45,10 +47,13 @@ public:
             size_t num_rows, std::deque<model::PositionListIndex::Cluster>&& lhs_clusters,
             std::deque<model::PositionListIndex::Cluster>&& rhs_clusters);
 
-    static long double CalculatePdepSelf(model::PLIWithSingletons const* x_pli);
+    static long double CalculatePdepSelf(model::PLI const* x_pli);
 
     static long double CalculatePdepMeasure(model::PLIWithSingletons const* x_pli,
                                             model::PLIWithSingletons const* xa_pli);
+
+    static long double CalculatePdepMeasure(model::PositionListIndex const* x_pli,
+                                            model::PositionListIndex const* xa_pli);
 
     static long double CalculateG2(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
                                    size_t num_rows);
@@ -56,10 +61,19 @@ public:
     static long double CalculateTau(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
                                     model::PLIWS const* joint_pli);
 
+    static long double CalculateTau(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                    model::PLI const* joint_pli);
+
     static long double CalculateMuPlus(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
                                        model::PLIWS const* joint_pli);
 
+    static long double CalculateMuPlus(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                       model::PLI const* joint_pli);
+
     static long double CalculateFI(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
+                                   size_t num_rows);
+
+    static long double CalculateFI(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
                                    size_t num_rows);
 
     long double GetResult() const {

--- a/src/core/algorithms/fd/tane/afd_measures.cpp
+++ b/src/core/algorithms/fd/tane/afd_measures.cpp
@@ -8,7 +8,7 @@ config::ErrorType CalculateZeroAryG1(ColumnData const* rhs, unsigned long long n
                        static_cast<config::ErrorType>(num_tuple_pairs);
 }
 
-config::ErrorType CalculateG1Error(model::PLIWS const* lhs_pli, model::PLIWS const* joint_pli,
+config::ErrorType CalculateG1Error(model::PLI const* lhs_pli, model::PLI const* joint_pli,
                                    unsigned long long num_tuple_pairs) {
     return static_cast<config::ErrorType>((lhs_pli->GetNepAsLong() - joint_pli->GetNepAsLong()) /
                                           static_cast<config::ErrorType>(num_tuple_pairs));
@@ -102,7 +102,7 @@ config::ErrorType CalculateMuPlusMeasure(model::PLIWS const* x_pli, model::PLIWS
     return mu_plus;
 }
 
-config::ErrorType CalculateRhoMeasure(model::PLIWS const* x_pli, model::PLIWS const* xa_pli) {
+config::ErrorType CalculateRhoMeasure(model::PLI const* x_pli, model::PLI const* xa_pli) {
     auto calculate_dom = [](model::PositionListIndex const* pli) {
         auto index = pli->GetIndex();
         size_t dom = index.size();

--- a/src/core/algorithms/fd/tane/afd_measures.h
+++ b/src/core/algorithms/fd/tane/afd_measures.h
@@ -7,7 +7,7 @@
 namespace algos {
 config::ErrorType CalculateZeroAryG1(ColumnData const* rhs, unsigned long long num_tuple_pairs);
 
-config::ErrorType CalculateG1Error(model::PLIWS const* lhs_pli, model::PLIWS const* joint_pli,
+config::ErrorType CalculateG1Error(model::PLI const* lhs_pli, model::PLI const* joint_pli,
                                    unsigned long long num_tuple_pairs);
 
 config::ErrorType PdepSelf(model::PLI const* x_pli);
@@ -20,5 +20,5 @@ config::ErrorType CalculateTauMeasure(model::PLIWS const* x_pli, model::PLIWS co
 config::ErrorType CalculateMuPlusMeasure(model::PLIWS const* x_pli, model::PLIWS const* a_pli,
                                          model::PLIWS const* xa_pli);
 
-config::ErrorType CalculateRhoMeasure(model::PLIWS const* x_pli, model::PLIWS const* xa_pli);
+config::ErrorType CalculateRhoMeasure(model::PLI const* x_pli, model::PLI const* xa_pli);
 }  // namespace algos

--- a/src/core/algorithms/fd/tane/pfdtane.cpp
+++ b/src/core/algorithms/fd/tane/pfdtane.cpp
@@ -33,6 +33,12 @@ config::ErrorType PFDTane::CalculateFdError(model::PLIWS const* lhs_pli,
     return CalculatePFDError(lhs_pli, joint_pli, pfd_error_measure_);
 }
 
+config::ErrorType PFDTane::CalculateFdError(model::PLI const* lhs_pli,
+                                            [[maybe_unused]] model::PLI const* rhs_pli,
+                                            model::PLI const* joint_pli) {
+    return CalculatePFDError(lhs_pli, joint_pli, pfd_error_measure_);
+}
+
 config::ErrorType PFDTane::CalculateZeroAryPFDError(ColumnData const* rhs) {
     std::size_t max = 1;
     model::PositionListIndex const* x_pli = rhs->GetPositionListIndex();

--- a/src/core/algorithms/fd/tane/pfdtane.h
+++ b/src/core/algorithms/fd/tane/pfdtane.h
@@ -15,7 +15,11 @@ private:
     void RegisterOptions();
     void MakeExecuteOptsAvailableFDInternal() final;
     config::ErrorType CalculateZeroAryFdError(ColumnData const* rhs) override;
-    config::ErrorType CalculateFdError(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
+    config::ErrorType CalculateFdError(model::PLI const* lhs_pli,
+                                       [[maybe_unused]] model::PLI const* rhs_pli,
+                                       model::PLI const* joint_pli) override;
+    config::ErrorType CalculateFdError(model::PLIWS const* lhs_pli,
+                                       [[maybe_unused]] model::PLIWS const* rhs_pli,
                                        model::PLIWS const* joint_pli) override;
 
 public:

--- a/src/core/algorithms/fd/tane/tane.cpp
+++ b/src/core/algorithms/fd/tane/tane.cpp
@@ -24,9 +24,27 @@ config::ErrorType Tane::CalculateZeroAryFdError(ColumnData const* rhs) {
     return 1;
 }
 
-config::ErrorType Tane::CalculateFdError(model::PLIWithSingletons const* lhs_pli,
-                                         model::PLIWithSingletons const* rhs_pli,
-                                         model::PLIWithSingletons const* joint_pli) {
+config::ErrorType Tane::CalculateFdError(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                         model::PLI const* joint_pli) {
+    switch (afd_error_measure_) {
+        case AfdErrorMeasure::kPdep:
+            return 1 - afd_metric_calculator::AFDMetricCalculator::CalculatePdepMeasure(lhs_pli,
+                                                                                        joint_pli);
+        case AfdErrorMeasure::kTau:
+            return 1 - afd_metric_calculator::AFDMetricCalculator::CalculateTau(lhs_pli, rhs_pli,
+                                                                                joint_pli);
+        case AfdErrorMeasure::kMuPlus:
+            return 1 - afd_metric_calculator::AFDMetricCalculator::CalculateMuPlus(lhs_pli, rhs_pli,
+                                                                                   joint_pli);
+        case AfdErrorMeasure::kRho:
+            return 1 - CalculateRhoMeasure(lhs_pli, joint_pli);
+        default:
+            return CalculateG1Error(lhs_pli, joint_pli, relation_.get()->GetNumTuplePairs());
+    }
+}
+
+config::ErrorType Tane::CalculateFdError(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
+                                         model::PLIWS const* joint_pli) {
     switch (afd_error_measure_) {
         case AfdErrorMeasure::kPdep:
             return 1 - afd_metric_calculator::AFDMetricCalculator::CalculatePdepMeasure(lhs_pli,

--- a/src/core/algorithms/fd/tane/tane.h
+++ b/src/core/algorithms/fd/tane/tane.h
@@ -13,9 +13,10 @@ private:
     AfdErrorMeasure afd_error_measure_ = AfdErrorMeasure::kG1;
     void MakeExecuteOptsAvailableFDInternal() override final;
     config::ErrorType CalculateZeroAryFdError(ColumnData const* rhs) override;
-    config::ErrorType CalculateFdError(model::PLIWithSingletons const* lhs_pli,
-                                       model::PLIWithSingletons const* rhs_pli,
-                                       model::PLIWithSingletons const* joint_pli) override;
+    config::ErrorType CalculateFdError(model::PLI const* lhs_pli, model::PLI const* rhs_pli,
+                                       model::PLI const* joint_pli) override;
+    config::ErrorType CalculateFdError(model::PLIWS const* lhs_pli, model::PLIWS const* rhs_pli,
+                                       model::PLIWS const* joint_pli) override;
 
 public:
     Tane();

--- a/src/core/algorithms/fd/tane/tane_common.cpp
+++ b/src/core/algorithms/fd/tane/tane_common.cpp
@@ -4,11 +4,14 @@
 #include <iomanip>
 #include <list>
 #include <memory>
+#include <variant>
 
 #include "core/algorithms/fd/pli_based_fd_algorithm.h"
 #include "core/algorithms/fd/tane/model/lattice_level.h"
 #include "core/algorithms/fd/tane/model/lattice_vertex.h"
 #include "core/config/error/option.h"
+#include "core/config/option.h"
+#include "core/config/use_pliws/option.h"
 #include "core/model/table/column_data.h"
 #include "core/model/table/column_layout_relation_data.h"
 #include "core/model/table/relational_schema.h"
@@ -21,6 +24,7 @@ namespace tane {
 
 TaneCommon::TaneCommon() : PliBasedFDAlgorithm() {
     RegisterOption(config::kErrorOpt(&max_ucc_error_));
+    RegisterOption(config::kUsePliwsOpt(&use_pliws_));
 }
 
 double TaneCommon::CalculateUccError(model::PositionListIndex const* pli,
@@ -93,14 +97,27 @@ void TaneCommon::ComputeDependencies(model::LatticeLevel* level) {
         Vertical xa = xa_vertex->GetVertical();
         // Calculate XA PLI
         if (xa_vertex->GetPositionListIndex() == nullptr) {
-            auto parent_pli_1 = xa_vertex->GetParents()[0]->GetPositionListIndexWithSingletons();
-            auto parent_pli_2 = xa_vertex->GetParents()[1]->GetPositionListIndexWithSingletons();
-            xa_vertex->AcquirePLIWithSingletons(parent_pli_1->Intersect(parent_pli_2));
+            if (use_pliws_) {
+                auto parent_pli_1 =
+                        xa_vertex->GetParents()[0]->GetPositionListIndexWithSingletons();
+                auto parent_pli_2 =
+                        xa_vertex->GetParents()[1]->GetPositionListIndexWithSingletons();
+                xa_vertex->AcquirePLIWithSingletons(parent_pli_1->Intersect(parent_pli_2));
+            } else {
+                auto parent_pli_1 = xa_vertex->GetParents()[0]->GetPositionListIndex();
+                auto parent_pli_2 = xa_vertex->GetParents()[1]->GetPositionListIndex();
+                xa_vertex->AcquirePositionListIndex(parent_pli_1->Intersect(parent_pli_2));
+            }
         }
 
         dynamic_bitset<> xa_indices = xa.GetColumnIndices();
         dynamic_bitset<> a_candidates = xa_vertex->GetRhsCandidates();
-        auto xa_pli = xa_vertex->GetPositionListIndexWithSingletons();
+        std::variant<model::PLI const*, model::PLIWS const*> xa_pli;
+        if (use_pliws_) {
+            xa_pli = xa_vertex->GetPositionListIndexWithSingletons();
+        } else {
+            xa_pli = xa_vertex->GetPositionListIndex();
+        }
         for (auto const& x_vertex : xa_vertex->GetParents()) {
             Vertical const& lhs = x_vertex->GetVertical();
 
@@ -110,10 +127,18 @@ void TaneCommon::ComputeDependencies(model::LatticeLevel* level) {
             if (!a_candidates[a_index]) {
                 continue;
             }
-            auto x_pli = x_vertex->GetPositionListIndexWithSingletons();
-            auto a_pli = relation_->GetColumnData(a_index).GetPLWSIndex();
+
+            config::ErrorType error;
+            if (use_pliws_) {
+                model::PLIWS const* x_pli = x_vertex->GetPositionListIndexWithSingletons();
+                model::PLIWS const* a_pli = relation_->GetColumnData(a_index).GetPLWSIndex();
+                error = CalculateFdError(x_pli, a_pli, std::get<model::PLIWS const*>(xa_pli));
+            } else {
+                model::PLI const* x_pli = x_vertex->GetPositionListIndex();
+                model::PLI const* a_pli = relation_->GetColumnData(a_index).GetPositionListIndex();
+                error = CalculateFdError(x_pli, a_pli, std::get<model::PLI const*>(xa_pli));
+            }
             // Check X -> A
-            config::ErrorType error = CalculateFdError(x_pli, a_pli, xa_pli);
             if (error <= max_fd_error_) {
                 Column const* rhs = schema->GetColumns()[a_index].get();
 

--- a/src/core/algorithms/fd/tane/tane_common.h
+++ b/src/core/algorithms/fd/tane/tane_common.h
@@ -13,6 +13,7 @@ class TaneCommon : public PliBasedFDAlgorithm {
 protected:
     config::ErrorType max_fd_error_;
     config::ErrorType max_ucc_error_;
+    bool use_pliws_ = false;
 
 private:
     void ResetStateFd() final {}
@@ -21,6 +22,9 @@ private:
     void ComputeDependencies(model::LatticeLevel* level);
     unsigned long long ExecuteInternal() final;
     virtual config::ErrorType CalculateZeroAryFdError(ColumnData const* rhs) = 0;
+    virtual config::ErrorType CalculateFdError(model::PLI const* lhs_pli,
+                                               [[maybe_unused]] model::PLI const* rhs_pli,
+                                               model::PLI const* joint_pli) = 0;
     virtual config::ErrorType CalculateFdError(model::PLIWS const* lhs_pli,
                                                [[maybe_unused]] model::PLIWS const* rhs_pli,
                                                model::PLIWS const* joint_pli) = 0;

--- a/src/core/config/CMakeLists.txt
+++ b/src/core/config/CMakeLists.txt
@@ -25,5 +25,6 @@ target_sources(
             thread_number/option.cpp
             time_limit/option.cpp
             transactional_data/option.cpp
+            use_pliws/option.cpp
 )
 target_link_libraries(${NAME} PRIVATE magic_enum::magic_enum Boost::headers)

--- a/src/core/config/descriptions.h
+++ b/src/core/config/descriptions.h
@@ -217,6 +217,11 @@ auto const kDMetricAlgorithm = details::kDMetricAlgorithmString.c_str();
 constexpr auto kDQGramLength = "q-gram length for cosine metric";
 // ND
 constexpr auto kDNDWeight = "Weight of ND to verify (positive integer)";
+// AFD metric calculator
+constexpr auto kDUsePliws =
+        "Whether to use PLIs with singletons for error calculation. Using PLIWS "
+        "can reduce the runtime for discovering approximate FDs, but "
+        "also significantly increase memory usage.";
 // Pyro
 constexpr auto kDCustomRandom =
         "seed for the custom random generator. Used for consistency of results across platforms.";

--- a/src/core/config/names.h
+++ b/src/core/config/names.h
@@ -112,6 +112,8 @@ constexpr auto kMetric = "metric";
 constexpr auto kMetricAlgorithm = "metric_algorithm";
 constexpr auto kParameter = "parameter";
 constexpr auto kQGramLength = "q";
+// AFD metric calculator
+constexpr auto kUsePliws = "use_pliws";
 // Pyro
 constexpr auto kCustomRandom = "custom_random_seed";
 // Spider

--- a/src/core/config/use_pliws/option.cpp
+++ b/src/core/config/use_pliws/option.cpp
@@ -1,0 +1,8 @@
+#include "core/config/use_pliws/option.h"
+
+#include "core/config/names_and_descriptions.h"
+
+namespace config {
+using names::kUsePliws, descriptions::kDUsePliws;
+extern CommonOption<bool> const kUsePliwsOpt{kUsePliws, kDUsePliws, false};
+}  // namespace config

--- a/src/core/config/use_pliws/option.h
+++ b/src/core/config/use_pliws/option.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "core/config/common_option.h"
+
+namespace config {
+extern CommonOption<bool> const kUsePliwsOpt;
+}  // namespace config

--- a/src/tests/unit/test_afd_metric_calculator.cpp
+++ b/src/tests/unit/test_afd_metric_calculator.cpp
@@ -16,12 +16,13 @@ struct AFDMetricCalculatorParams {
     long double const expected = 0.L;
 
     AFDMetricCalculatorParams(config::IndicesType lhs_indices, config::IndicesType rhs_indices,
-                              AFDMetric metric, long double expected,
+                              AFDMetric metric, long double expected, bool use_pliws = false,
                               CSVConfig const& csv_config = kTestFD)
         : params({{kCsvConfig, csv_config},
                   {kLhsIndices, std::move(lhs_indices)},
                   {kRhsIndices, std::move(rhs_indices)},
                   {kEqualNulls, true},
+                  {kUsePliws, use_pliws},
                   {kMetric, metric}}),
           expected(expected) {}
 };
@@ -42,13 +43,21 @@ INSTANTIATE_TEST_SUITE_P(
         AFDMetricCalculatorTestSuite, TestAFDMetrics,
         ::testing::Values(
             AFDMetricCalculatorParams({4}, {3}, AFDMetric::kTau, 78.L/90),
+            AFDMetricCalculatorParams({4}, {3}, AFDMetric::kTau, 78.L/90, true),
             AFDMetricCalculatorParams({4}, {3}, AFDMetric::kG2, 1.L/6),
+            AFDMetricCalculatorParams({4}, {3}, AFDMetric::kG2, 1.L/6, true),
             AFDMetricCalculatorParams({4}, {3}, AFDMetric::kFi, 1 - std::log(4) / std::log(746496)),
+            AFDMetricCalculatorParams({4}, {3}, AFDMetric::kFi, 1 - std::log(4) / std::log(746496), true),
             AFDMetricCalculatorParams({4}, {3}, AFDMetric::kMuPlus, 498.L/630),
+            AFDMetricCalculatorParams({4}, {3}, AFDMetric::kMuPlus, 498.L/630, true),
             AFDMetricCalculatorParams({3}, {4}, AFDMetric::kTau, 54.L/114),
+            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kTau, 54.L/114, true),
             AFDMetricCalculatorParams({3}, {4}, AFDMetric::kG2, 5.L/6),
+            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kG2, 5.L/6, true),
             AFDMetricCalculatorParams({3}, {4}, AFDMetric::kFi, std::log(432) / std::log(13824)),
-            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kMuPlus, 252.L/912)
+            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kFi, std::log(432) / std::log(13824), true),
+            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kMuPlus, 252.L/912),
+            AFDMetricCalculatorParams({3}, {4}, AFDMetric::kMuPlus, 252.L/912, true)
             ));
 // clang-format on
 

--- a/src/tests/unit/test_pfdtane.cpp
+++ b/src/tests/unit/test_pfdtane.cpp
@@ -21,10 +21,12 @@ struct PFDTaneMiningParams {
     unsigned int result_hash;
 
     PFDTaneMiningParams(unsigned int result_hash, config::ErrorType error,
-                        algos::PfdErrorMeasure error_measure, CSVConfig const& csv_config)
+                        algos::PfdErrorMeasure error_measure, CSVConfig const& csv_config,
+                        bool use_pliws = false)
         : params({{onam::kCsvConfig, csv_config},
                   {onam::kError, error},
-                  {onam::kPfdErrorMeasure, error_measure}}),
+                  {onam::kPfdErrorMeasure, error_measure},
+                  {onam::kUsePliws, use_pliws}}),
           result_hash(result_hash) {}
 };
 
@@ -64,11 +66,17 @@ INSTANTIATE_TEST_SUITE_P(
         PFDTaneTestMiningSuite, TestPFDTaneMining,
         ::testing::Values(
                 PFDTaneMiningParams(44381, 0.3, algos::PfdErrorMeasure::kPerValue, kTestFD),
+                PFDTaneMiningParams(44381, 0.3, algos::PfdErrorMeasure::kPerValue, kTestFD, true),
                 PFDTaneMiningParams(19266, 0.1, algos::PfdErrorMeasure::kPerValue, kIris),
+                PFDTaneMiningParams(19266, 0.1, algos::PfdErrorMeasure::kPerValue, kIris, true),
                 PFDTaneMiningParams(10695, 0.01, algos::PfdErrorMeasure::kPerValue, kIris),
+                PFDTaneMiningParams(10695, 0.01, algos::PfdErrorMeasure::kPerValue, kIris, true),
                 PFDTaneMiningParams(44088, 0.1, algos::PfdErrorMeasure::kPerValue, kNeighbors10k),
-                PFDTaneMiningParams(41837, 0.01, algos::PfdErrorMeasure::kPerValue,
-                                    kNeighbors10k)));
+                PFDTaneMiningParams(44088, 0.1, algos::PfdErrorMeasure::kPerValue, kNeighbors10k,
+                                    true),
+                PFDTaneMiningParams(41837, 0.01, algos::PfdErrorMeasure::kPerValue, kNeighbors10k),
+                PFDTaneMiningParams(41837, 0.01, algos::PfdErrorMeasure::kPerValue, kNeighbors10k,
+                                    true)));
 
 INSTANTIATE_TEST_SUITE_P(
         PFDTaneTestValidationSuite, TestPFDTaneValidation,


### PR DESCRIPTION
### This PR makes Tane and AfdMetricCalc use PLIWS only when explicitly enabled via a boolean flag.

### Changes:

- In AfdMetricCalc (src/core/algorithms/fd/afd_metric):
  - Added methods to support computations with both PLI and PLIWS.
  - Rewrote ExecuteInternal logic using `std::variant` to select between PLI and PLIWS based on the `use_pliws` flag (default: false).

- In TaneCommon:
  - Rewrote ComputeDependencies logic with `std::variant` to work with both PLI and PLIWS.

### Behavior:

- The public interface remains unchanged for existing callers. An optional `use_pliws` parameter (default false) can now be passed at algorithm creation.
- Old code continues to work as before.

### Testing:

- Added new tests for AfdMetricCalc with and without PLIWS to verify correctness.
- All existing tests still pass, confirming no regression.