### PR TITLE
Add dynamic DC verification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ string(
     "${DESBORDANTE_DEBUG_INFO_FLAG}"
     "-Wall"
     "-Wextra"
+    "-Wno-error=unused-parameter"
     "-Werror"
     "-fno-omit-frame-pointer"
     "-fno-optimize-sibling-calls"

--- a/cmake/desbordante_deps.cmake
+++ b/cmake/desbordante_deps.cmake
@@ -48,6 +48,14 @@ CPMAddPackage(
     SYSTEM YES
 )
 
+CPMAddPackage(
+    NAME roaring
+    GITHUB_REPOSITORY RoaringBitmap/CRoaring
+    GIT_TAG v2.1.2
+    OPTIONS "ROARING_BUILD_TESTS OFF" "ROARING_BUILD_BENCHMARKS OFF"
+    SYSTEM YES
+)
+
 if(DESBORDANTE_BUILD_TESTS)
     CPMAddPackage(
         NAME googletest

--- a/examples/basic/dynamic_verifying_dc.py
+++ b/examples/basic/dynamic_verifying_dc.py
@@ -1,0 +1,89 @@
+from os import path
+from tracemalloc import start
+import desbordante as db
+import pandas as pd
+
+print("""This example demonstrates dynamic Denial Constraint (DC) verification using the Weever algorithm.
+Basic static scenario is located in examples/basic/verifying_dc.py
+
+Weever efficiently maintains the set of DC violations as rows are inserted, deleted, or updated,
+avoiding a full re-verification after each change. Weever algorithm is described in the following article:
+
+Youri Kaminsky, Eduardo H. M. Pena, and Felix Naumann. 2024.
+Incremental Detection of Denial Constraint Violations.
+Proc. VLDB Endow. 18, 4 (December 2024), 1000–1012.
+https://doi.org/10.14778/3717755.3717761
+""")
+
+RED_CODE = "\033[1;41m"
+GREEN_CODE = "\033[1;42m"
+BOLD_CODE = "\033[1;49m"
+DEFAULT_COLOR_CODE = "\033[0m"
+
+# The DC: for any two people in the same state, the one with a lower salary
+# must not have a higher tax rate.
+DC = "!(s.State == t.State and s.Salary < t.Salary and s.FedTaxRate > t.FedTaxRate)"
+
+TABLE = "datasets/taxes_1.csv"
+
+
+def print_table(df: pd.DataFrame, isIndexed: bool = True, startIndex: int = 0) -> None:
+    display = df.copy()
+    display.index = display.index + startIndex
+    print(display.to_string(index=isIndexed))
+    print()
+
+
+def print_violations(violations: list) -> None:
+    if not violations:
+        print(GREEN_CODE + "DC holds — no violations found." + DEFAULT_COLOR_CODE)
+    else:
+        viol_str = ", ".join(f"({a}, {b})" for a, b in violations)
+        print(RED_CODE + f"DC violated — violation pairs: {viol_str}" + DEFAULT_COLOR_CODE)
+    print()
+
+
+print(f"""DC: {DC}
+
+The constraint says: for every pair of employees in the same state,
+if one earns less they must not pay a higher tax rate.
+
+Starting dataset (taxes_1.csv):
+""")
+
+data = pd.read_csv(TABLE)
+print_table(data, True, 2)
+
+# ── Initial verification ────────────────────────────────────────────────────
+print("Step 1: initial DC verification on the base table.")
+
+algo = db.weever.algorithms.Default()
+algo.load_data(table=(TABLE, ',', True))
+algo.execute(denial_constraint=DC)
+
+print_violations(algo.get_violations())
+
+# ── Insert a violating row ──────────────────────────────────────────────────
+print("""Step 2: insert a new Texas employee who earns 5000 but pays only 0.05 tax.
+This creates a violation with all records in Texas state where new record acts as 't' tuple.
+""")
+
+insert_df = pd.DataFrame({"State": ["Texas"], "Salary": [5000], "FedTaxRate": [0.05]})
+print("Inserted row:")
+print_table(insert_df, True, 11)
+
+algo.execute(insert=insert_df)
+print_violations(algo.get_violations())
+
+# ── Delete the violating row ────────────────────────────────────────────────
+# After the insert, the new row got index 11.
+# Weever tracks tuple IDs that match the index_offset used internally;
+# the index used here matches what was passed to insert statements.
+print("""Step 3: delete the violating row (index 11) to restore DC compliance.""")
+
+# Weever uses 1-based IDs counting from line 1 of the CSV (including header),
+# so pandas 0-based index N maps to Weever ID N+2.
+violating_index = data.index.max() + 3  # = 11
+
+algo.execute(denial_constraint=DC, delete={violating_index})
+print_violations(algo.get_violations())

--- a/examples/basic/test_dynamic_verifying_dc.py
+++ b/examples/basic/test_dynamic_verifying_dc.py
@@ -1,0 +1,106 @@
+# from os import path
+# from tracemalloc import start
+# import desbordante as db
+# import pandas as pd
+
+# print("""This example demonstrates dynamic Denial Constraint (DC) verification using the Weever algorithm.
+
+# Weever efficiently maintains the set of DC violations as rows are inserted, deleted, or updated,
+# avoiding a full re-verification after each change.
+
+# Reference: the algorithm is described in the Weever paper on incremental DC verification.
+# """)
+
+# RED_CODE = "\033[1;41m"
+# GREEN_CODE = "\033[1;42m"
+# BOLD_CODE = "\033[1;49m"
+# DEFAULT_COLOR_CODE = "\033[0m"
+
+# # The DC: for any two people in the same state, the one with a lower salary
+# # must not have a higher tax rate.
+# DC = "!(s.State == t.State and s.Salary < t.Salary and s.FedTaxRate > t.FedTaxRate)"
+
+# TABLE = "datasets/taxes_1.csv"
+
+
+# def print_table(df: pd.DataFrame, isIndexed: bool = True, startIndex: int = 0) -> None:
+#     display = df.copy()
+#     display.index = display.index + startIndex
+#     print(display.to_string(index=isIndexed))
+#     print()
+
+
+# def print_violations(violations: list) -> None:
+#     if not violations:
+#         print(GREEN_CODE + "DC holds — no violations found." + DEFAULT_COLOR_CODE)
+#     else:
+#         viol_str = ", ".join(f"({a}, {b})" for a, b in violations)
+#         print(RED_CODE + f"DC violated — violation pairs: {viol_str}" + DEFAULT_COLOR_CODE)
+#     print()
+
+
+# print(f"""DC: {DC}
+
+# The constraint says: for every pair of employees in the same state,
+# if one earns less they must not pay a higher tax rate.
+
+# Starting dataset (taxes_1.csv):
+# """)
+
+# data = pd.read_csv(TABLE)
+# print_table(data, True, 2)
+
+# # ── Initial verification ────────────────────────────────────────────────────
+# print("Step 1: initial DC verification on the base table.")
+
+# algo = db.weever.algorithms.Default()
+# algo.load_data(table=(TABLE, ',', True))
+# algo.execute(denial_constraint=DC)
+
+# print_violations(algo.get_violations())
+
+# # ── Insert a violating row ──────────────────────────────────────────────────
+# print("""Step 2: insert a new Texas employee who earns 5000 but pays only 0.05 tax.
+# This creates a violation: Texas/5000/0.05 paired with Texas/1000/0.15
+# (lower salary but higher tax rate).
+# """)
+
+# insert_df = pd.DataFrame({"State": ["Texas"], "Salary": [5000], "FedTaxRate": [0.05]})
+# print("Inserted row:")
+# print_table(insert_df, True, 11)
+
+# algo.execute(insert=insert_df)
+# print_violations(algo.get_violations())
+
+# # ── Delete the violating row ────────────────────────────────────────────────
+# # After the insert, the new row got index 11.
+# # Weever tracks tuple IDs that match the index_offset used internally;
+# # the index used here matches what was passed to insert statements.
+# print("""Step 3: delete the violating row (index 11) to restore DC compliance.
+# """)
+
+# # Weever uses 1-based IDs counting from line 1 of the CSV (including header),
+# # so pandas 0-based index N maps to Weever ID N+2.
+# violating_index = data.index.max() + 3  # = 11
+
+# algo.execute(denial_constraint=DC, delete={violating_index})
+# print_violations(algo.get_violations())
+
+# # ── Update an existing row ──────────────────────────────────────────────────
+# print("""Step 4: update row 8 (Texas/1000/0.15) — raise tax rate to 0.35,
+# which would conflict with Texas/3000/0.3 (higher salary, lower tax rate).
+# """)
+
+# update_df = pd.DataFrame({"_id": [8], "State": ["Texas"], "Salary": [1000], "FedTaxRate": [0.35]})
+# print("Update statement (_id = row to replace):")
+# print_table(update_df, False)
+
+# algo.execute(denial_constraint=DC, denial_update=update_df)
+# print_violations(algo.get_violations())
+
+# # ── Revert the update ───────────────────────────────────────────────────────
+# print("Step 5: revert row 8 back to its original values.")
+
+# revert_df = pd.DataFrame({"_id": [8], "State": ["Texas"], "Salary": [1000], "FedTaxRate": [0.15]})
+# algo.execute(denial_constraint=DC, update=revert_df)
+# print_violations(algo.get_violations())

--- a/src/core/algorithms/CMakeLists.txt
+++ b/src/core/algorithms/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(
               ${DESBORDANTE_PREFIX}::ucc::hpivalid
               ${DESBORDANTE_PREFIX}::ucc::verifier
               ${DESBORDANTE_PREFIX}::sd::verifier
+              ${DESBORDANTE_PREFIX}::dc::weever
 )
 
 set(NAME algos)
@@ -92,4 +93,5 @@ target_link_libraries(
             ${DESBORDANTE_PREFIX}::model::sequence
             spdlog::spdlog_header_only
             Boost::headers
+            roaring
 )

--- a/src/core/algorithms/algorithm_types.h
+++ b/src/core/algorithms/algorithm_types.h
@@ -13,7 +13,8 @@ using AlgorithmTypes =
                    ACAlgorithm, UCCVerifier, Faida, Spider, Mind, INDVerifier, cind::CINDVerifier,
                    Fastod, GfdValidator, EGfdValidator, NaiveGfdValidator, order::Order, dd::Split,
                    Cords, hymd::HyMD, PFDVerifier, cfd_verifier::CFDVerifier,
-                   ar_verifier::ARVerifier, GSpan, sd_verifier::SDVerifier, maxfem::MaxFEM>;
+                   ar_verifier::ARVerifier, GSpan, sd_verifier::SDVerifier, maxfem::MaxFEM,
+                   DCVerifier, Weever>;
 
 /* Enumeration of all supported non-pipeline algorithms. If you implement a new
  * algorithm please add its corresponding value to this enum and to the type
@@ -101,6 +102,10 @@ enum class AlgorithmType : char {
 
     /* CFD verifier algorithm */
     kCfdVerifier,
+
+    /* DC verifier algorithm */
+    dc_verifier,
+    weever,
 
     /* AR verifier algorithm */
     kArVerifier,

--- a/src/core/algorithms/algorithms.h
+++ b/src/core/algorithms/algorithms.h
@@ -6,6 +6,7 @@
 #include "core/algorithms/cfd/cfd_verifier/cfd_verifier.h"
 #include "core/algorithms/cfd/mining_algorithms.h"
 #include "core/algorithms/cind/verification_algorithms.h"
+#include "core/algorithms/dc/verification_algorithms.h"
 #include "core/algorithms/dd/mining_algorithms.h"
 #include "core/algorithms/fd/mining_algorithms.h"
 #include "core/algorithms/fd/sfd/cords.h"

--- a/src/core/algorithms/cind/CMakeLists.txt
+++ b/src/core/algorithms/cind/CMakeLists.txt
@@ -9,5 +9,5 @@ target_link_libraries(
     PUBLIC ${DESBORDANTE_PREFIX}::config
     PRIVATE ${DESBORDANTE_PREFIX}::cind::miners ${DESBORDANTE_PREFIX}::ind::spider
             ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum spdlog::spdlog_header_only
-            Boost::headers
+            Boost::headers roaring
 )

--- a/src/core/algorithms/dc/CMakeLists.txt
+++ b/src/core/algorithms/dc/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(FastADC)
 add_subdirectory(verifier)
+add_subdirectory(weever)
 
 set(NAME dc.model)
 desbordante_add_lib(NAME OBJECT)

--- a/src/core/algorithms/dc/model/column_operand.h
+++ b/src/core/algorithms/dc/model/column_operand.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "core/algorithms/dc/model/component.h"
 #include "core/algorithms/dc/model/tuple.h"
 #include "core/model/table/column.h"
 #include "core/model/table/relation_data.h"
@@ -103,6 +104,10 @@ public:
         return column_;
     }
 
+    model::ColumnIndex GetColumnIndex() const noexcept {
+        return column_->GetIndex();
+    }
+
     Tuple GetTuple() const {
         assert(tuple_.has_value());
         return tuple_.value();
@@ -134,6 +139,12 @@ public:
         }
 
         return res;
+    }
+
+    dc::Component Eval(std::vector<std::byte const*> const& row = {}) const {
+        if (IsConstant()) return {val_, type_};
+        assert(!row.empty());
+        return {row[column_->GetIndex()], type_};
     }
 
     ~ColumnOperand() {

--- a/src/core/algorithms/dc/model/component.h
+++ b/src/core/algorithms/dc/model/component.h
@@ -17,13 +17,41 @@ private:
     std::byte const* val_;
     model::Type const* type_;
     ValType val_type_;
+    bool owns_;
 
 public:
-    Component() noexcept : val_(nullptr), type_(nullptr), val_type_(ValType::kFinite) {};
+    Component() noexcept
+        : val_(nullptr), type_(nullptr), val_type_(ValType::kFinite), owns_(false) {}
 
-    Component(std::byte const* value, model::Type const* type,
-              ValType val_type = ValType::kFinite) noexcept
-        : val_(value), type_(type), val_type_(val_type) {};
+    Component(std::byte const* value, model::Type const* type, ValType val_type = ValType::kFinite,
+              bool owns = false)
+        : val_(owns ? type->Clone(value) : value), type_(type), val_type_(val_type), owns_(owns) {
+        assert(value != nullptr);
+    }
+
+    Component(std::byte const* value, model::Type const* type, bool owns)
+        : Component(value, type, ValType::kFinite, owns) {}
+
+    Component(Component const& other)
+        : val_(other.owns_ && other.val_ != nullptr ? other.type_->Clone(other.val_) : other.val_),
+          type_(other.type_),
+          val_type_(other.val_type_),
+          owns_(other.owns_ && other.val_ != nullptr) {}
+
+    Component(Component&& other) noexcept
+        : val_(other.val_), type_(other.type_), val_type_(other.val_type_), owns_(other.owns_) {
+        other.owns_ = false;
+        other.val_ = nullptr;
+    }
+
+    Component& operator=(Component other) noexcept {
+        Swap(other);
+        return *this;
+    }
+
+    ~Component() {
+        if (owns_) type_->Free(val_);
+    }
 
     std::string ToString() const;
 
@@ -55,6 +83,7 @@ public:
         std::swap(val_, rhs.val_);
         std::swap(type_, rhs.type_);
         std::swap(val_type_, rhs.val_type_);
+        std::swap(owns_, rhs.owns_);
     }
 
     ValType& GetValType() noexcept {

--- a/src/core/algorithms/dc/model/dc.h
+++ b/src/core/algorithms/dc/model/dc.h
@@ -61,6 +61,11 @@ public:
         return {res.begin(), res.end()};
     }
 
+    std::vector<Column::IndexType> GetColumnIndicesWithOperator(OperatorType type) const {
+        return GetColumnIndicesWithOperator(
+                [type](Operator const& op) { return op.GetType() == type; });
+    }
+
     std::vector<Column::IndexType> GetColumnIndices() const {
         return GetColumnIndicesWithOperator([](Operator) { return true; });
     }
@@ -83,6 +88,12 @@ public:
 
     // Convert all two-tuple equality predicates: s.A == t.B -> (s.A <= t.B and s.A >= t.B)
     void ConvertEqualities();
+
+    void Canonize() {
+        for (auto& pred : predicates_) {
+            pred.Canonize();
+        }
+    }
 };
 
 }  // namespace algos::dc

--- a/src/core/algorithms/dc/model/operator.h
+++ b/src/core/algorithms/dc/model/operator.h
@@ -4,8 +4,6 @@
 #include <string>
 #include <string_view>
 
-#include <magic_enum/magic_enum.hpp>
-
 #include "core/util/static_map.h"
 
 namespace algos::dc {

--- a/src/core/algorithms/dc/model/predicate.h
+++ b/src/core/algorithms/dc/model/predicate.h
@@ -4,6 +4,7 @@
 #include <variant>
 
 #include "core/algorithms/dc/model/column_operand.h"
+#include "core/algorithms/dc/model/component.h"
 #include "core/algorithms/dc/model/operator.h"
 #include "core/algorithms/dc/model/tuple.h"
 #include "core/model/table/typed_column_data.h"
@@ -75,6 +76,32 @@ public:
         if (IsConstant()) return GetVariableOperand().GetTuple();
         if (IsCrossTuple()) return Tuple::kMixed;
         return l_.GetTuple();
+    }
+
+    // Transform a predicate to the following form: s.A op t.B
+    void Canonize() {
+        if (!IsCrossTuple()) return;
+        if (l_.GetTuple() != dc::Tuple::kS) {
+            std::swap(l_, r_);
+            op_.Inverse();
+        }
+    }
+
+    bool Eval(std::vector<std::byte const*> const& row) const {
+        assert(IsOneTuple());
+        dc::Component l_comp = l_.Eval(row);
+        dc::Component r_comp = r_.Eval(row);
+        return dc::Component::Eval(l_comp, r_comp, op_);
+    }
+
+    bool Eval(std::vector<std::byte const*> const& s_row,
+              std::vector<std::byte const*> const& t_row) const {
+        assert(IsCrossTuple());
+        auto const& l_row = (l_.GetTuple() == Tuple::kT) ? t_row : s_row;
+        auto const& r_row = (r_.GetTuple() == Tuple::kT) ? t_row : s_row;
+        dc::Component l_comp = l_.Eval(l_row);
+        dc::Component r_comp = r_.Eval(r_row);
+        return dc::Component::Eval(l_comp, r_comp, op_);
     }
 };
 

--- a/src/core/algorithms/dc/model/table_index.h
+++ b/src/core/algorithms/dc/model/table_index.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "core/algorithms/dc/model/component.h"
+#include "core/model/table/dynamic_data/typed_dynamic_row_table_data.h"
+#include "core/util/logger.h"
+#include "core/util/lttree.h"
+
+namespace algos::dc {
+
+using EqualityIndex = std::unordered_map<Component, roaring::Roaring, Component::Hasher>;
+using LessThanIndex = utils::LTTree<Component>;
+
+class TableIndex {
+    // for each column store its own index
+    std::unordered_map<model::ColumnIndex, EqualityIndex> eq_index_;
+    std::unordered_map<model::ColumnIndex, LessThanIndex> lt_index_;
+    model::ITypedDynamicTableData const* table_;
+    roaring::Roaring indexed_ids_;
+
+    void DeleteFromIndices(size_t row_id, std::vector<std::byte const*> const& row) {
+        auto types = table_->GetTypes();
+
+        // Remove from LT index
+        for (auto& [col, lt_tree] : lt_index_) {
+            dc::Component val = {row[col], types[col]};
+            lt_tree.Remove(val, row_id);
+        }
+
+        // Remove from equality index
+        for (auto& [col, eq_map] : eq_index_) {
+            dc::Component val = {row[col], types[col]};
+            eq_map[val].remove(static_cast<uint32_t>(row_id));
+        }
+    }
+
+    void InsertIntoIndices(size_t row_id) {
+        auto types = table_->GetTypes();
+        std::vector<std::byte const*> const& row = table_->GetRow(row_id);
+
+        for (auto& [col, lt_tree] : lt_index_) {
+            dc::Component val = {row[col], types[col], true};
+            lt_tree.Insert(std::move(val), row_id);
+        }
+        for (auto& [col, eq_map] : eq_index_) {
+            dc::Component val = {row[col], types[col], true};
+            eq_map[std::move(val)].add(static_cast<uint32_t>(row_id));
+        }
+    }
+
+public:
+    TableIndex() = default;
+
+    TableIndex(model::ITypedDynamicTableData const* table) : table_(table) {}
+
+    void DeleteRow(size_t row_id, std::vector<std::byte const*> const& row) {
+        indexed_ids_.remove(static_cast<uint32_t>(row_id));
+        DeleteFromIndices(row_id, row);
+    }
+
+    void InsertRow(size_t row_id) {
+        assert(table_->RowExists(row_id));
+        indexed_ids_.add(static_cast<uint32_t>(row_id));
+        InsertIntoIndices(row_id);
+    }
+
+    roaring::Roaring const& GetIndexedIds() const noexcept {
+        return indexed_ids_;
+    }
+
+    bool IndexExists(model::ColumnIndex col, dc::OperatorType op) const {
+        if (op == dc::OperatorType::kEqual || op == dc::OperatorType::kUnequal) {
+            return eq_index_.contains(col);
+        } else {
+            return lt_index_.contains(col);
+        }
+    }
+
+    void CreateIndex(model::ColumnIndex col, dc::OperatorType op) {
+        if (IndexExists(col, op)) return;
+
+        // Create appropriate empty index for each column
+        if (op == dc::OperatorType::kEqual or op == dc::OperatorType::kUnequal) {
+            eq_index_[col] = EqualityIndex();
+        } else {
+            lt_index_[col] = LessThanIndex();
+        }
+    }
+
+    EqualityIndex const& GetEqualityIndex(model::ColumnIndex col) const {
+        return eq_index_.at(col);
+    }
+
+    LessThanIndex const& GetLessThanIndex(model::ColumnIndex col) const {
+        return lt_index_.at(col);
+    }
+
+    void Update() {
+        auto const& inserted = table_->GetInserted();
+        auto const& updated = table_->GetUpdated();
+        auto const& deleted = table_->GetDeleted();
+
+        // Process deleted rows - remove from cached data if available
+        for (auto const& [row_id, row] : deleted) {
+            assert(!table_->RowExists(row_id));
+            DeleteFromIndices(row_id, row.GetData());
+        }
+
+        // Process inserted rows - add to indices
+        for (size_t row_id : inserted) {
+            assert(table_->RowExists(row_id));
+            InsertIntoIndices(row_id);
+        }
+
+        // Process updated rows - remove old entries and add new ones
+        for (auto const& [row_id, row] : updated) {
+            assert(table_->RowExists(row_id));
+            DeleteFromIndices(row_id, row.GetData());
+            InsertIntoIndices(row_id);
+        }
+    }
+};
+
+}  // namespace algos::dc

--- a/src/core/algorithms/dc/parser/dc_parser.cpp
+++ b/src/core/algorithms/dc/parser/dc_parser.cpp
@@ -8,17 +8,17 @@
 #include "core/algorithms/dc/model/dc.h"
 #include "core/algorithms/dc/model/operator.h"
 #include "core/algorithms/dc/model/predicate.h"
-#include "core/model/table/column_layout_relation_data.h"
+#include "core/model/table/relational_schema.h"
 #include "core/model/table/typed_column_data.h"
 
 namespace mo = model;
 
 namespace algos::dc {
 
-DCParser::DCParser(std::string dc_string, ColumnLayoutRelationData const* relation,
-                   std::vector<model::TypedColumnData> const& data)
-    : relation_(relation),
-      data_(data),
+DCParser::DCParser(std::string dc_string, RelationalSchema const* schema,
+                   std::vector<model::Type const*> const& types)
+    : schema_(schema),
+      types_(types),
       dc_string_(std::move(dc_string)),
       has_next_predicate_(true),
       cur_(0) {
@@ -138,7 +138,7 @@ bool DCParser::IsVarOperand(std::string op) const {
 ColumnOperand DCParser::ConvertToVariableOperand(std::string const& operand) const {
     dc::Tuple tuple = operand.front() == 't' ? dc::Tuple::kT : dc::Tuple::kS;
     std::string name = operand.substr(2);
-    std::vector<std::unique_ptr<Column>> const& cols = relation_->GetSchema()->GetColumns();
+    std::vector<std::unique_ptr<Column>> const& cols = schema_->GetColumns();
     std::vector<std::unique_ptr<Column>>::const_iterator it;
     if (!cols.front()->GetName().empty()) {  // Has header
         auto pred = [&name](auto const& col) { return name == col->GetName(); };
@@ -159,7 +159,7 @@ ColumnOperand DCParser::ConvertToVariableOperand(std::string const& operand) con
     }
 
     size_t col_ind = column->GetIndex();
-    return {column, tuple, &data_[col_ind].GetType()};
+    return {column, tuple, types_[col_ind]};
 }
 
 }  // namespace algos::dc

--- a/src/core/algorithms/dc/parser/dc_parser.h
+++ b/src/core/algorithms/dc/parser/dc_parser.h
@@ -5,7 +5,7 @@
 #include "core/algorithms/dc/model/dc.h"
 #include "core/algorithms/dc/model/operator.h"
 #include "core/algorithms/dc/model/predicate.h"
-#include "core/model/table/column_layout_relation_data.h"
+#include "core/model/table/relational_schema.h"
 #include "core/model/table/typed_column_data.h"
 
 namespace algos::dc {
@@ -13,8 +13,8 @@ namespace algos::dc {
 class DCParser {
 private:
     std::vector<std::string> str_operators_;
-    ColumnLayoutRelationData const* relation_;
-    std::vector<model::TypedColumnData> const& data_;
+    RelationalSchema const* schema_;
+    std::vector<model::Type const*> const& types_;
     static constexpr std::string_view const kSep = " and ";
     std::string dc_string_;
     bool has_next_predicate_;
@@ -22,8 +22,8 @@ private:
     size_t cur_;
 
 public:
-    DCParser(std::string dc_string, ColumnLayoutRelationData const* relation,
-             std::vector<model::TypedColumnData> const& data);
+    DCParser(std::string dc_string, RelationalSchema const* schema,
+             std::vector<model::Type const*> const& types);
 
     DC Parse();
     Predicate GetNextPredicate();

--- a/src/core/algorithms/dc/verification_algorithms.h
+++ b/src/core/algorithms/dc/verification_algorithms.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "core/algorithms/dc/verifier/dc_verifier.h"
+#include "core/algorithms/dc/weever/weever.h"

--- a/src/core/algorithms/dc/verifier/dc_verifier.cpp
+++ b/src/core/algorithms/dc/verifier/dc_verifier.cpp
@@ -50,40 +50,43 @@ void DCVerifier::RegisterOptions() {
     RegisterOption(config::kTableOpt(&input_table_));
     RegisterOption(Option<bool>(&do_collect_violations_, kDoCollectViolations,
                                 kDDoCollectViolations, false));
+    RegisterOption(Option<bool>(&enable_ordering_, kEnableOrdering, kDEnableOrdering, false));
 }
 
 void DCVerifier::MakeExecuteOptsAvailable() {
     MakeOptionsAvailable({config::names::kDenialConstraint});
     MakeOptionsAvailable({config::names::kDoCollectViolations});
+    MakeOptionsAvailable({config::names::kEnableOrdering});
 }
 
 void DCVerifier::LoadDataInternal() {
     data_ = model::CreateTypedColumnData(*input_table_, true);
     input_table_->Reset();
     relation_ = ColumnLayoutRelationData::CreateFrom(*input_table_);
+    index_offset_ = GetIndexOffset();
 }
 
 void DCVerifier::ExecuteInternal() {
-    dc::DC dc;
-    try {
-        dc::DCParser parser = dc::DCParser(dc_string_, relation_.get(), data_);
-        dc = parser.Parse();
-    } catch (std::exception const& e) {
-        LOG_INFO("{}", e.what());
-        return;
-    }
-
-    std::string col_name = relation_->GetSchema()->GetColumns().front().get()->GetName();
-    boost::regex re("[0-9]+");
-    bool has_header = !boost::regex_match(col_name, re);
-    index_offset_ = 1 + static_cast<size_t>(has_header);
-    result_ = Verify(dc);
+    result_ = Verify({dc_string_});
 }
 
-bool DCVerifier::Verify(dc::DC dc) {
-    dc.ConvertEqualities();
+bool DCVerifier::Verify(std::string dc_string) {
+    try {
+        std::vector<model::Type const*> types;
+        for (auto const& col : data_) {
+            types.push_back(&col.GetType());
+        }
+
+        dc::DCParser parser = dc::DCParser(dc_string, relation_->GetSchema(), types);
+        dc_ = parser.Parse();
+    } catch (std::exception const& e) {
+        LOG_INFO("{}", e.what());
+        return 0;
+    }
+
+    dc_.ConvertEqualities();
     std::vector<dc::Predicate> no_diseq_preds, diseq_preds;
-    std::vector<dc::Predicate> predicates = dc.GetPredicates();
+    std::vector<dc::Predicate> predicates = dc_.GetPredicates();
 
     for (auto& pred : predicates) {
         auto op = pred.GetOperator();
@@ -97,7 +100,7 @@ bool DCVerifier::Verify(dc::DC dc) {
 
     size_t diseq_preds_count = diseq_preds.size();
     size_t all_comb_count = std::pow(2, diseq_preds_count);
-    dc::DCType dc_type = dc.GetType();
+    dc::DCType dc_type = dc_.GetType();
 
     // Otherwise it is not possible to collect violations
     if (dc_type == dc::DCType::kOneInequality and do_collect_violations_ == true)
@@ -458,6 +461,36 @@ bool DCVerifier::ContainsNullOrEmpty(std::vector<mo::ColumnIndex> const& indices
                                      size_t tuple_ind) const {
     auto l = [this, tuple_ind](mo::ColumnIndex ind) { return data_[ind].IsNullOrEmpty(tuple_ind); };
     return std::any_of(indices.begin(), indices.end(), l);
+}
+
+bool DCVerifier::ViolationHolds(size_t s_ind, size_t t_ind, dc::DC const& dc) {
+    std::vector<std::byte const*> s_row = GetRow(s_ind - index_offset_);
+    std::vector<std::byte const*> t_row = GetRow(t_ind - index_offset_);
+
+    std::vector<dc::Predicate> predicates = dc.GetPredicates();
+    return std::ranges::all_of(predicates, [&s_row, &t_row](dc::Predicate const& pred) {
+        return pred.Eval(s_row, t_row);
+    });
+}
+
+void DCVerifier::EnrichViolations() {
+    std::vector<dc::Violation> new_violations;
+    LOG_DEBUG("[DCVerifier] Enrich violations start, violations_ size: {}", violations_.size());
+    for (dc::Violation const& v : violations_) {
+        if (v.first == v.second) {
+            new_violations.push_back({v.first, v.second});
+            continue;
+        }
+        if (ViolationHolds(v.second, v.first, dc_)) {
+            new_violations.push_back({v.second, v.first});
+        }
+        if (ViolationHolds(v.first, v.second, dc_)) {
+            new_violations.push_back({v.first, v.second});
+        }
+    }
+    LOG_DEBUG("[DCVerifier] Enrich violations end");
+    violations_.clear();
+    violations_.insert(new_violations.begin(), new_violations.end());
 }
 
 }  // namespace algos

--- a/src/core/algorithms/dc/verifier/dc_verifier.h
+++ b/src/core/algorithms/dc/verifier/dc_verifier.h
@@ -18,9 +18,11 @@
 
 namespace algos {
 namespace dc {
+
+using Violation = std::pair<size_t, size_t>;
+
 struct SetComparator {
-    bool operator()(std::pair<size_t, size_t> const& lhs,
-                    std::pair<size_t, size_t> const& rhs) const {
+    bool operator()(Violation const& lhs, Violation const& rhs) const {
         return (lhs.first != rhs.first) ? (lhs.first < rhs.first) : (lhs.second < rhs.second);
     }
 };
@@ -37,20 +39,24 @@ private:
     // If a certain pair contains equal left and right record number
     // it means that that DC is a one-tuple one and it sufficient
     // for a single tuple to violate it. e.g. {{2, 2}}
-    std::set<std::pair<size_t, size_t>, dc::SetComparator> violations_;
+    std::set<dc::Violation, dc::SetComparator> violations_;
     std::unique_ptr<ColumnLayoutRelationData> relation_;
     std::vector<model::TypedColumnData> data_;
-    config::InputTable input_table_;
-    bool do_collect_violations_;
-    std::string dc_string_;
     size_t index_offset_;
     bool result_;
+    dc::DC dc_;
+
+    // options
+    config::InputTable input_table_;
+    std::string dc_string_;
+    bool do_collect_violations_;
+    bool enable_ordering_;
 
     void RegisterOptions();
 
     void MakeExecuteOptsAvailable();
 
-    bool Verify(dc::DC dc);
+    bool Verify(std::string dc);
 
     bool VerifyOneTuple(dc::DC const& dc);
 
@@ -105,6 +111,10 @@ private:
         }
     }
 
+    void EnrichViolations();
+
+    bool ViolationHolds(size_t s_ind, size_t t_ind, dc::DC const& dc);
+
 public:
     DCVerifier();
 
@@ -112,13 +122,22 @@ public:
         return result_;
     }
 
-    std::vector<std::pair<size_t, size_t>> GetViolations() {
+    std::vector<dc::Violation> GetViolations() {
+        if (enable_ordering_) EnrichViolations();
         return {violations_.begin(), violations_.end()};
     }
 
     void ResetState() final {
         violations_.clear();
     };
+
+    size_t GetIndexOffset() const noexcept {
+        assert(relation_);
+        std::string col_name = relation_->GetSchema()->GetColumns().front().get()->GetName();
+        boost::regex re("[0-9]+");
+        bool has_header = !boost::regex_match(col_name, re);
+        return 1 + static_cast<size_t>(has_header);
+    }
 
     void LoadDataInternal() final;
     void ExecuteInternal() final;

--- a/src/core/algorithms/dc/weever/CMakeLists.txt
+++ b/src/core/algorithms/dc/weever/CMakeLists.txt
@@ -1,15 +1,13 @@
-set(NAME dc.verifier)
+set(NAME dc.weever)
 desbordante_add_lib(NAME)
-target_sources(${NAME} PRIVATE dc_verifier.cpp)
+target_sources(${NAME} PRIVATE weever.cpp)
 target_link_libraries(
     ${NAME}
-    PUBLIC ${DESBORDANTE_PREFIX}::config
     PRIVATE ${DESBORDANTE_PREFIX}::model::table
             ${DESBORDANTE_PREFIX}::model::types
             ${DESBORDANTE_PREFIX}::dc::model
             ${DESBORDANTE_PREFIX}::dc::parser
             spdlog::spdlog_header_only
-            magic_enum::magic_enum
-            Boost::headers
             roaring
+            Boost::headers
 )

--- a/src/core/algorithms/dc/weever/weever.cpp
+++ b/src/core/algorithms/dc/weever/weever.cpp
@@ -1,0 +1,267 @@
+#include "core/algorithms/dc/weever/weever.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+
+#include "core/algorithms/dc/model/column_operand.h"
+#include "core/algorithms/dc/parser/dc_parser.h"
+#include "core/config/descriptions.h"
+#include "core/config/names.h"
+#include "core/config/option.h"
+#include "core/config/option_using.h"
+#include "core/config/tabular_data/crud_operations/delete/option.h"
+#include "core/config/tabular_data/crud_operations/insert/option.h"
+#include "core/config/tabular_data/crud_operations/operations.h"
+#include "core/config/tabular_data/crud_operations/update/option.h"
+#include "core/config/tabular_data/input_table/option.h"
+#include "core/model/table/dynamic_data/typed_dynamic_row_table_data.h"
+#include "core/model/table/dynamic_data/update_strategies/separate_update_strategy.h"
+#include "core/parser/csv_parser/csv_parser.h"
+#include "core/util/logger.h"
+
+namespace algos {
+
+void Weever::ResetState() {}
+
+void Weever::MakeExecuteOptsAvailable() {
+    using namespace config::names;
+    MakeOptionsAvailable(kCrudOptions);
+    MakeOptionsAvailable({kDenialConstraint});
+}
+
+Weever::Weever() {
+    RegisterOptions();
+}
+
+void Weever::RegisterOptions() {
+    DESBORDANTE_OPTION_USING;
+
+    RegisterOption(Option<std::string>(&dc_string_, kDenialConstraint, kDDenialConstraint, ""));
+    RegisterOption(config::kTableOpt(&input_table_));
+    RegisterOption(config::kInsertStatementsOpt(&insert_statements_table_));
+    RegisterOption(config::kDeleteStatementsOpt(&delete_statement_indices_));
+    RegisterOption(config::kUpdateStatementsOpt(&update_statements_table_));
+
+    MakeOptionsAvailable({config::names::kTable});
+}
+
+void Weever::LoadDataInternal() {
+    relation_ = std::make_unique<RelationalSchema>(input_table_->GetRelationName());
+    for (size_t i = 0; i < input_table_->GetNumberOfColumns(); ++i) {
+        relation_->AppendColumn(input_table_->GetColumnName(i));
+    }
+
+    // Mirror DCVerifier's GetIndexOffset(): +1 for 1-based IDs, +1 for a header row.
+    auto* parser = dynamic_cast<CSVParser const*>(input_table_.get());
+    bool has_header = parser ? parser->HasHeader() : false;
+    index_offset_ = 1 + static_cast<size_t>(has_header);
+
+    data_ = std::make_unique<model::TypedDynamicRowTableData>(*input_table_, index_offset_);
+    table_index_ = dc::TableIndex(data_.get());
+}
+
+void Weever::BuildIndices(dc::DC const& dc) {
+    std::vector<dc::Predicate> const& preds = dc.GetPredicates();
+
+    // Create indices for each predicate
+    for (auto const& pred : preds) {
+        dc::ColumnOperand l_operand = pred.GetLeftOperand();
+        dc::ColumnOperand r_operand = pred.GetRightOperand();
+        dc::OperatorType op = pred.GetOperator().GetType();
+
+        model::ColumnIndex l_col = l_operand.GetColumnIndex();
+        model::ColumnIndex r_col = r_operand.GetColumnIndex();
+
+        // For each column involved in the predicate, create appropriate index if not exists
+        table_index_.CreateIndex(l_col, op);
+        table_index_.CreateIndex(r_col, op);
+    }
+}
+
+void Weever::Preprocess() {
+    try {
+        dc::DCParser parser = dc::DCParser(dc_string_, relation_.get(), data_->GetTypes());
+        dc_ = parser.Parse();
+    } catch (std::exception const& e) {
+        LOG_INFO("[Weever] DC parse error: {}", e.what());
+        return;
+    }
+
+    dc_.Canonize();
+    BuildIndices(dc_);
+
+    for (size_t row_id : data_->GetAllIds()) {
+        InsertTuple(row_id);
+        table_index_.InsertRow(row_id);
+    }
+}
+
+unsigned long long int Weever::ExecuteInternal() {
+    auto start = std::chrono::system_clock::now();
+
+    data_->SetStrategy(std::make_unique<model::SeparateUpdateStrategy>(
+            insert_statements_table_, update_statements_table_, delete_statement_indices_));
+
+    if (!is_preprocessed_) {
+        Preprocess();
+        is_preprocessed_ = true;
+    }
+
+    Update();
+
+    auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now() - start);
+
+    return elapsed_time.count();
+}
+
+void Weever::Update() {
+    data_->Update();
+
+    auto const& deleted = data_->GetDeleted();
+    auto const& inserted = data_->GetInserted();
+    auto const& updated = data_->GetUpdated();
+
+    for (auto const& [tuple_id, old_data] : deleted) {
+        DeleteTuple(tuple_id);
+        table_index_.DeleteRow(tuple_id, old_data.GetData());
+    }
+
+    for (size_t tuple_id : inserted) {
+        InsertTuple(tuple_id);
+        table_index_.InsertRow(tuple_id);
+    }
+
+    for (auto const& [tuple_id, old_data] : updated) {
+        DeleteTuple(tuple_id);
+        table_index_.DeleteRow(tuple_id, old_data.GetData());
+
+        InsertTuple(tuple_id);
+        table_index_.InsertRow(tuple_id);
+    }
+}
+
+void Weever::DeleteTuple(size_t tuple_id) {
+    auto inv_it = inv_violations_.find(tuple_id);
+    if (inv_it != inv_violations_.end()) {
+        for (uint32_t x : inv_it->second) {
+            violations_[x].remove(static_cast<uint32_t>(tuple_id));
+        }
+        inv_violations_.erase(inv_it);
+    }
+
+    auto v_it = violations_.find(tuple_id);
+    if (v_it != violations_.end()) {
+        for (uint32_t y : v_it->second) {
+            inv_violations_[y].remove(static_cast<uint32_t>(tuple_id));
+        }
+        violations_.erase(v_it);
+    }
+}
+
+void Weever::InsertTuple(size_t new_tuple_id) {
+    assert(data_->RowExists(new_tuple_id));
+
+    roaring::Roaring s_candidates = table_index_.GetIndexedIds();
+    roaring::Roaring t_candidates = table_index_.GetIndexedIds();
+
+    auto const& new_row = data_->GetRow(new_tuple_id);
+    auto const& types = data_->GetTypes();
+
+    // Process each predicate to refine the intermediates
+    for (auto const& pred : dc_.GetPredicates()) {
+        model::ColumnIndex l_col = pred.GetLeftOperand().GetColumnIndex();
+        model::ColumnIndex r_col = pred.GetRightOperand().GetColumnIndex();
+
+        dc::OperatorType op = pred.GetOperator().GetType();
+        roaring::Roaring operand_l, operand_r;
+
+        // Predicate: s.l_col OP t.r_col
+        // s_candidates holds candidates where s is a new tuple, t is an existing tuple
+        // t_candidates holds candidates where t is a new tuple, s is an existing tuple
+        if (op == dc::OperatorType::kEqual or op == dc::OperatorType::kUnequal) {
+            dc::Component val_r = {new_row[r_col], types[r_col]};
+            auto const& eq_index_r = table_index_.GetEqualityIndex(r_col);
+            if (eq_index_r.count(val_r)) {
+                operand_r = eq_index_r.at(val_r);
+            }
+
+            dc::Component val_l = {new_row[l_col], types[l_col]};
+            auto const& eq_index_l = table_index_.GetEqualityIndex(l_col);
+            if (eq_index_l.count(val_l)) {
+                operand_l = eq_index_l.at(val_l);
+            }
+
+            if (op == dc::OperatorType::kEqual) {
+                s_candidates &= operand_l;
+                t_candidates &= operand_r;
+            } else {
+                s_candidates -= operand_l;
+                t_candidates -= operand_r;
+            }
+        } else {
+            dc::Component val_l = {new_row[l_col], types[l_col]};
+            auto const& lt_index_l = table_index_.GetLessThanIndex(l_col);
+
+            dc::Component val_r = {new_row[r_col], types[r_col]};
+            auto const& lt_index_r = table_index_.GetLessThanIndex(r_col);
+
+            roaring::Roaring operand_l;
+            roaring::Roaring operand_r;
+
+            if (op == dc::OperatorType::kLess) {
+                s_candidates -= lt_index_r.FindLessOrEqual(val_l);
+                t_candidates &= lt_index_l.FindLess(val_r);
+            } else if (op == dc::OperatorType::kLessEqual) {
+                operand_l = lt_index_r.FindLess(val_l);
+                s_candidates -= operand_l;
+                operand_r = lt_index_l.FindLessOrEqual(val_r);
+                t_candidates &= operand_r;
+            } else if (op == dc::OperatorType::kGreater) {
+                s_candidates &= lt_index_r.FindLess(val_l);
+                t_candidates -= lt_index_l.FindLessOrEqual(val_r);
+            } else {  // kGreaterEqual
+                operand_l = lt_index_r.FindLessOrEqual(val_l);
+                s_candidates &= operand_l;
+                operand_r = lt_index_l.FindLess(val_r);
+                t_candidates -= operand_r;
+            }
+        }
+
+        // Stop if both intermediates are empty
+        if (s_candidates.isEmpty() and t_candidates.isEmpty()) {
+            break;
+        }
+    }
+
+    for (uint32_t s_cand : s_candidates) {
+        violations_[new_tuple_id].add(s_cand);
+        inv_violations_[s_cand].add(static_cast<uint32_t>(new_tuple_id));
+    }
+    for (uint32_t t_cand : t_candidates) {
+        violations_[t_cand].add(static_cast<uint32_t>(new_tuple_id));
+        inv_violations_[new_tuple_id].add(t_cand);
+    }
+}
+
+std::vector<dc::Violation> Weever::GetViolations() const {
+    std::vector<dc::Violation> result;
+    for (auto const& [first_id, bitmap] : violations_) {
+        for (uint32_t second_id : bitmap) {
+            result.push_back({first_id, second_id});
+        }
+    }
+
+    return result;
+}
+
+size_t Weever::GetViolationsSize() const {
+    size_t res = 0;
+    for (auto const& [_, bitmap] : violations_) {
+        res += bitmap.cardinality();
+    }
+    return res;
+}
+
+}  // namespace algos

--- a/src/core/algorithms/dc/weever/weever.h
+++ b/src/core/algorithms/dc/weever/weever.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "core/algorithms/algorithm.h"
+#include "core/algorithms/dc/model/dc.h"
+#include "core/algorithms/dc/model/table_index.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/dynamic_data/dynamic_table_data.h"
+#include "core/model/table/relational_schema.h"
+
+namespace algos {
+
+namespace dc {
+using Violation = std::pair<size_t, size_t>;
+}
+
+class Weever final : public Algorithm {
+private:
+    dc::DC dc_;
+    std::unique_ptr<RelationalSchema> relation_;
+    std::unique_ptr<model::ITypedDynamicTableData> data_;
+    std::unordered_map<size_t, roaring::Roaring> violations_;
+    std::unordered_map<size_t, roaring::Roaring> inv_violations_;
+    dc::TableIndex table_index_;
+    size_t index_offset_ = 0;
+    bool is_preprocessed_ = false;
+
+    // Options
+    std::string dc_string_;
+    config::InputTable input_table_;
+    config::InputTable insert_statements_table_;
+    config::InputTable update_statements_table_;
+    std::unordered_set<size_t> delete_statement_indices_;
+
+    void Preprocess();
+    void BuildIndices(dc::DC const& dc);
+
+    // Dynamic update methods
+    void InsertTuple(size_t tuple_id);
+    void DeleteTuple(size_t tuple_id);
+    void Update();
+
+    void ResetState() override;
+    void MakeExecuteOptsAvailable() override;
+
+public:
+    Weever();
+
+    unsigned long long int ExecuteInternal() final;
+    void LoadDataInternal() final override;
+    void RegisterOptions();
+
+    std::vector<dc::Violation> GetViolations() const;
+    size_t GetViolationsSize() const;
+};
+
+}  // namespace algos

--- a/src/core/algorithms/ind/mind/CMakeLists.txt
+++ b/src/core/algorithms/ind/mind/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(
     ${NAME}
     PRIVATE ${DESBORDANTE_PREFIX}::create_algo ${DESBORDANTE_PREFIX}::config
             ${DESBORDANTE_PREFIX}::util spdlog::spdlog_header_only magic_enum::magic_enum
-            Boost::headers
+            Boost::headers roaring
 )

--- a/src/core/config/descriptions.h
+++ b/src/core/config/descriptions.h
@@ -83,6 +83,8 @@ constexpr auto kDMinStructuralZeroesAmount =
 constexpr auto kDOnlySFD = "Don't mine correlations";
 // DC verifier
 constexpr auto kDDenialConstraint = "String representation of a Denial Constraint";
+constexpr auto kDEnableOrdering =
+        "When off violations pairs (a, b) and (b, a) are not distinguishable";
 // DD verifier
 constexpr auto kDDDString = "Differential dependency that needs to be verified";
 constexpr auto kDDDudm = "map, that contains udm for verifying dd";

--- a/src/core/config/names.h
+++ b/src/core/config/names.h
@@ -53,6 +53,7 @@ constexpr auto kMinStructuralZeroesAmount = "min_structural_zeroes_amount";
 constexpr auto kOnlySFD = "only_sfd";
 // DC verifier
 constexpr auto kDenialConstraint = "denial_constraint";
+constexpr auto kEnableOrdering = "enable_ordering";
 // DD verifier
 constexpr auto kDDString = "dd";
 constexpr auto kDDudm = "metrics_map";

--- a/src/core/model/table/dynamic_data/dynamic_table_data.h
+++ b/src/core/model/table/dynamic_data/dynamic_table_data.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cassert>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "core/config/exceptions.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/dynamic_data/row.h"
+#include "core/model/table/dynamic_data/update_strategies/update_strategy.h"
+#include "core/model/types/type.h"
+
+namespace model {
+
+class IUpdateStrategy;
+
+// TODO (Anosov Pavel):
+// table might have strings as values as well, consider using template interface
+
+class IDynamicTableData {
+    std::unique_ptr<IUpdateStrategy> update_strategy_;
+
+protected:
+    std::set<size_t> inserted_;
+    std::map<size_t, Row> updated_;
+    std::map<size_t, Row> deleted_;
+
+public:
+    // using Row = std::vector<std::byte const*>;
+    // using Col = std::vector<std::byte const*>;
+
+    virtual ~IDynamicTableData() = default;
+
+    void SetStrategy(std::unique_ptr<IUpdateStrategy> strategy) {
+        update_strategy_ = std::move(strategy);
+    }
+
+    // On each new Update call previous cached indexes are cleared and new row indexes are inserted
+    void Update() {
+        if (update_strategy_) {
+            inserted_.clear();
+            updated_.clear();
+            deleted_.clear();
+            update_strategy_->Update(this);
+        }
+    }
+
+    std::map<size_t, Row> const& GetUpdated() const noexcept {
+        return updated_;
+    }
+
+    std::map<size_t, Row> const& GetDeleted() const noexcept {
+        return deleted_;
+    }
+
+    std::set<size_t> const& GetInserted() const noexcept {
+        return inserted_;
+    }
+
+    virtual void AppendRow(std::vector<std::string> const& row) = 0;
+    virtual void UpdateRow(size_t index, std::vector<std::string> const& new_row) = 0;
+    virtual void DeleteRow(size_t index) = 0;
+    virtual bool RowExists(size_t row) const = 0;
+
+    virtual std::set<size_t> GetAllIds() const = 0;
+    virtual std::vector<std::byte const*> GetRow(size_t index) const = 0;
+    virtual std::vector<std::byte const*> GetCol(size_t index) const = 0;
+    virtual std::byte const* GetValue(size_t row, size_t col) const = 0;
+    virtual size_t GetNumRows() const = 0;
+    virtual size_t GetNumCols() const = 0;
+};
+
+class ITypedDynamicTableData : public IDynamicTableData {
+public:
+    virtual std::vector<model::Type const*> GetTypes() const = 0;
+};
+
+}  // namespace model

--- a/src/core/model/table/dynamic_data/row.h
+++ b/src/core/model/table/dynamic_data/row.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cassert>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "core/model/types/type.h"
+
+class Row {
+private:
+    std::unique_ptr<std::byte[]> buffer_;
+    std::vector<std::byte const*> data_;
+    size_t size_ = 0;
+
+public:
+    Row(std::vector<std::string> const& values,
+        std::vector<std::shared_ptr<model::Type>> const& types, size_t row_size) {
+        assert(values.size() == types.size());
+
+        size_ = row_size;
+        buffer_ = std::unique_ptr<std::byte[]>(new std::byte[size_]);
+        data_ = std::vector<std::byte const*>(values.size(), nullptr);
+        Update(values, types);
+    }
+
+    Row(std::unique_ptr<std::byte[]> buffer, std::vector<std::byte const*> data) noexcept
+        : buffer_(std::move(buffer)), data_(std::move(data)) {}
+
+    Row(Row const& other) {
+        size_ = other.size_;
+        buffer_ = std::make_unique<std::byte[]>(size_);
+        std::copy(other.buffer_.get(), other.buffer_.get() + size_, buffer_.get());
+        for (std::byte const* ptr : other.data_) {
+            std::ptrdiff_t offset = ptr - other.buffer_.get();
+            data_.push_back(buffer_.get() + offset);
+        }
+    }
+
+    Row& operator=(Row const& other) = delete;
+    Row(Row&& other) noexcept = default;
+    Row& operator=(Row&& other) noexcept = default;
+
+    ~Row() = default;
+
+    void Update(std::vector<std::string> const& values,
+                std::vector<std::shared_ptr<model::Type>> const& types) {
+        assert(values.size() == types.size() and !data_.empty());
+
+        size_t buf_index = 0;
+        std::byte* buf = buffer_.get();
+        for (size_t i = 0; i < values.size(); ++i) {
+            std::shared_ptr<model::Type> const& cur_type = types[i];
+            size_t const value_size = cur_type->GetSize();
+            std::byte* next_val_buf = buf + buf_index;
+            cur_type->ValueFromStr(next_val_buf, values[i]);
+            data_[i] = next_val_buf;
+            buf_index += value_size;
+        }
+    }
+
+    std::vector<std::byte const*> const& GetData() const noexcept {
+        return data_;
+    }
+
+    std::byte const* GetValue(size_t index) const noexcept {
+        return data_[index];
+    }
+
+    size_t GetSize() const noexcept {
+        return data_.size();
+    }
+
+    // std::string ToString() const final {
+    //     return "Data for row " + row_->ToString();
+    // }
+};

--- a/src/core/model/table/dynamic_data/typed_dynamic_row_table_data.h
+++ b/src/core/model/table/dynamic_data/typed_dynamic_row_table_data.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <algorithm>
+#include <bitset>
+#include <cassert>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/regex.hpp>
+
+#include "core/config/exceptions.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/dynamic_data/dynamic_table_data.h"
+#include "core/model/table/dynamic_data/row.h"
+#include "core/model/table/typed_column_data.h"
+#include "core/model/types/create_type.h"
+#include "core/model/types/type_deduction.h"
+#include "core/util/logger.h"
+
+namespace model {
+
+// Should probably be named *RelationData, but in order to avoid misconception stays as is
+// TODO (Anosov Pavel): Create single interface for all types of
+// table data (static, dynamic) and fix naming
+class TypedDynamicRowTableData : public ITypedDynamicTableData
+// , std::enable_shared_from_this<TypedDynamicRowTableData>
+{
+private:
+    std::unordered_map<size_t, Row> rows_;
+    std::vector<std::shared_ptr<Type>> types_;
+    std::set<size_t> all_ids_;
+    size_t num_cols_ = 0;
+    size_t max_row_id_ = 0;
+    size_t row_size_ = 0;
+
+    // TODO (Anosov Pavel): Avoid transforming table to column data
+    void InferTypes(IDatasetStream& input_table) {
+        bool treat_mixed_as_string = true;
+        bool is_null_equal_null = true;
+
+        std::vector<std::vector<std::string>> columns(num_cols_);
+        while (input_table.HasNextRow()) {
+            std::vector<std::string> row = input_table.GetNextRow();
+            if (row.size() != num_cols_) continue;
+            for (size_t col = 0; col < num_cols_; ++col) {
+                columns[col].push_back(std::move(row[col]));
+            }
+        }
+
+        types_.reserve(num_cols_);
+        for (size_t col = 0; col < num_cols_; ++col) {
+            TypeId deduced_type_id = DeduceColumnType(columns[col], treat_mixed_as_string);
+            std::shared_ptr<Type> type = CreateType(deduced_type_id, is_null_equal_null);
+            types_.push_back(std::move(type));
+        }
+
+        row_size_ = [this]() -> size_t {
+            size_t row_size = 0;
+            for (auto const& type : types_) row_size += type->GetSize();
+            return row_size;
+        }();
+    }
+
+    void AppendRow(std::vector<std::string> const& values, bool track_insert) {
+        assert(types_.size() > 0);  // Call only after types are deduced
+        assert(values.size() == num_cols_);
+        assert(!rows_.contains(max_row_id_));
+
+        size_t const row_id = max_row_id_++;
+        Row row = {values, types_, row_size_};
+        rows_.emplace(row_id, std::move(row));
+        if (track_insert) inserted_.insert(row_id);
+        all_ids_.insert(row_id);
+        // LOG_DEBUG("Append row: {}", row_id);
+    }
+
+public:
+    // TODO (Anosov Pavel): Implement mixed type support
+    explicit TypedDynamicRowTableData(IDatasetStream& input_table, size_t init_offset = 0)
+        : num_cols_(input_table.GetNumberOfColumns()), max_row_id_(init_offset) {
+        InferTypes(input_table);
+        input_table.Reset();
+
+        while (input_table.HasNextRow()) {
+            IDatasetStream::Row row = input_table.GetNextRow();
+            AppendRow(row, false);
+        }
+    }
+
+    size_t GetNumRows() const override {
+        return rows_.size();
+    }
+
+    size_t GetNumCols() const override {
+        return num_cols_;
+    }
+
+    bool RowExists(size_t row) const override {
+        return rows_.contains(row);
+    }
+
+    // Return values may invalidate on Update()
+    std::byte const* GetValue(size_t row, size_t col) const override {
+        assert(col < GetNumCols() and rows_.contains(row));
+        return rows_.at(row).GetValue(col);
+    }
+
+    void DeleteRow(size_t row) override {
+        assert(rows_.contains(row));
+        deleted_.emplace(row, std::move(rows_.at(row)));
+        rows_.erase(row);
+        all_ids_.erase(row);
+    }
+
+    void AppendRow(std::vector<std::string> const& values) override {
+        AppendRow(values, true);
+    }
+
+    void UpdateRow(size_t row, std::vector<std::string> const& values) override {
+        assert(rows_.contains(row));
+        assert(!types_.empty());
+        updated_.emplace(row, rows_.at(row));
+        rows_.at(row).Update(values, types_);
+    }
+
+    // Return values may invalidate on Update()
+    std::vector<std::byte const*> GetRow(size_t row) const override {
+        assert(rows_.contains(row));
+        return rows_.at(row).GetData();
+    }
+
+    // Return values may invalidate on Update()
+    std::vector<std::byte const*> GetCol(size_t col) const override {
+        assert(col < GetNumCols());
+        std::vector<std::byte const*> res;
+        for (size_t row : all_ids_) {
+            res.push_back(rows_.at(row).GetValue(col));
+        }
+
+        return res;
+    }
+
+    std::vector<model::Type const*> GetTypes() const override {
+        std::vector<model::Type const*> res;
+        for (auto const& type : types_) res.push_back(type.get());
+        return res;
+    }
+
+    std::set<size_t> GetAllIds() const override {
+        return all_ids_;
+    }
+};
+
+}  // namespace model

--- a/src/core/model/table/dynamic_data/update_strategies/separate_update_strategy.h
+++ b/src/core/model/table/dynamic_data/update_strategies/separate_update_strategy.h
@@ -1,0 +1,65 @@
+#include <ranges>
+#include <unordered_set>
+
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/dynamic_data/dynamic_table_data.h"
+#include "core/model/table/dynamic_data/update_strategies/update_strategy.h"
+#include "core/model/table/idataset_stream.h"
+#include "core/util/logger.h"
+
+namespace model {
+
+class SeparateUpdateStrategy : public IUpdateStrategy {
+private:
+    config::InputTable insert_data_;
+    config::InputTable update_data_;
+    std::unordered_set<size_t> const& delete_data_;
+
+    void ProcessUpdate(IDynamicTableData* table) {
+        if (update_data_ == nullptr) return;
+        while (update_data_->HasNextRow()) {
+            std::vector<std::string> row = update_data_->GetNextRow();
+            if (row.size() != table->GetNumCols() + 1) {
+                LOG_DEBUG("Got update table row with size: {}, skipping...", row.size());
+                continue;
+            }
+            size_t row_id = std::stoull(row.front());
+            std::vector<std::string> new_data(row.begin() + 1, row.end());
+            table->UpdateRow(row_id, new_data);
+        }
+    }
+
+    void ProcessDelete(IDynamicTableData* table) {
+        std::ranges::for_each(delete_data_, [&table](size_t index) { table->DeleteRow(index); });
+    }
+
+    void ProcessInsert(IDynamicTableData* table) {
+        // LOG_DEBUG("Process Inserting");
+        assert(table);
+        if (insert_data_ == nullptr) return;
+        while (insert_data_->HasNextRow()) {
+            // LOG_DEBUG("Inserting row");
+            std::vector<std::string> row = insert_data_->GetNextRow();
+            if (row.size() != table->GetNumCols()) {
+                LOG_DEBUG("Got insert table row with size: {}, skipping...", row.size());
+                continue;
+            }
+            table->AppendRow(row);
+        }
+        // LOG_DEBUG("Inserting Finish");
+    }
+
+public:
+    explicit SeparateUpdateStrategy(config::InputTable insert_data, config::InputTable update_data,
+                                    std::unordered_set<size_t> const& delete_data)
+        : insert_data_(insert_data), update_data_(update_data), delete_data_(delete_data) {}
+
+    void Update(IDynamicTableData* table) override {
+        assert(table);
+        ProcessDelete(table);
+        ProcessInsert(table);
+        ProcessUpdate(table);
+    }
+};
+
+}  // namespace model

--- a/src/core/model/table/dynamic_data/update_strategies/update_strategy.h
+++ b/src/core/model/table/dynamic_data/update_strategies/update_strategy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <memory>
+
+namespace model {
+
+class IDynamicTableData;
+
+// Update strategy for dynamic data
+// TODO (Anosov Pavel): Add git-like diff update strategy with single input table as updated data
+class IUpdateStrategy {
+public:
+    virtual void Update(IDynamicTableData* table) = 0;
+    virtual ~IUpdateStrategy() = default;
+};
+
+}  // namespace model

--- a/src/core/model/table/dynamic_table_data.h
+++ b/src/core/model/table/dynamic_table_data.h
@@ -14,7 +14,7 @@ namespace model {
 struct DynamicTableData {
 private:
     std::vector<std::vector<std::string>> columns_;
-    std::unordered_set<size_t> deleted_rows_{};
+    std::unordered_set<size_t> deleted_rows_;
 
 public:
     DynamicTableData(IDatasetStream& input_table) {

--- a/src/core/model/table/typed_column_data.cpp
+++ b/src/core/model/table/typed_column_data.cpp
@@ -5,6 +5,7 @@
 
 #include "core/model/table/column_layout_typed_relation_data.h"
 #include "core/model/types/create_type.h"
+#include "core/model/types/type_deduction.h"
 
 namespace {
 
@@ -20,74 +21,6 @@ size_t GetNextAlignedOffset(size_t cur_offset, size_t align) {
 }  // namespace
 
 namespace model {
-
-TypeId TypedColumnDataFactory::DeduceColumnType() const {
-    bool is_undefined = true;
-
-    std::bitset<6> candidate_types_bitset("111111");
-    TypeId first_type_id = TypeId::kUndefined;
-    auto matcher_map_iter = kTypeIdToChecker.begin();
-    for (std::size_t i = 0; i != unparsed_.size(); ++i) {
-        if (!kNullCheck(unparsed_[i]) && !kEmptyCheck(unparsed_[i])) {
-            is_undefined = false;
-            if (first_type_id != TypeId::kUndefined) {
-                auto it =
-                        std::find_if(matcher_map_iter, kTypeIdToChecker.end(),
-                                     [&](auto const& pair) { return pair.first == first_type_id; });
-                auto& type_check = it->second;
-                if (type_check(unparsed_[i])) {
-                    // undelimited and delimited dates have different bitsets
-                    if (first_type_id == TypeId::kDate && kDelimitedDateCheck(unparsed_[i])) {
-                        candidate_types_bitset &= kTypeIdToBitset.at(first_type_id);
-                    }
-                    continue;
-                }
-            }
-
-            std::bitset<6> new_candidate_types_bitset("000000");
-            bool matched = false;
-            for (auto const& [type_id, type_check] : kTypeIdToChecker) {
-                if (type_id != first_type_id && type_check(unparsed_[i])) {
-                    if (first_type_id == TypeId::kUndefined && !matched) {
-                        first_type_id = type_id;
-                    }
-                    matched = true;
-                    new_candidate_types_bitset |= kTypeIdToBitset.at(type_id);
-                    // possible value types are known at the first match except for dates
-                    // (undelimited dates could be ints or doubles and delimited couldn't)
-                    if (type_id == TypeId::kDate && kUndelimitedDateCheck(unparsed_[i])) {
-                        new_candidate_types_bitset |= kTypeIdToBitset.at(TypeId::kInt);
-                    }
-                    break;
-                }
-            }
-            if (!matched) {
-                new_candidate_types_bitset = kTypeIdToBitset.at(TypeId::kString);
-            }
-
-            candidate_types_bitset &= new_candidate_types_bitset;
-            if (candidate_types_bitset.none()) {
-                if (treat_mixed_as_string_) {
-                    candidate_types_bitset = kTypeIdToBitset.at(TypeId::kString);
-                } else {
-                    return TypeId::kMixed;
-                }
-            }
-        }
-    }
-
-    if (is_undefined) {
-        return TypeId::kUndefined;
-    }
-
-    for (std::size_t i = 0; i < 6; i++) {
-        if (candidate_types_bitset[i]) {
-            return kAllCandidateTypes[i];
-        }
-    }
-
-    return TypeId::kMixed;
-}
 
 TypedColumnDataFactory::TypeMap TypedColumnDataFactory::CreateTypeMap(TypeId const type_id) const {
     TypeMap type_map;
@@ -251,7 +184,7 @@ TypedColumnData TypedColumnDataFactory::CreateFromTypeMap(std::unique_ptr<Type c
 }
 
 TypedColumnData TypedColumnDataFactory::CreateFrom() {
-    TypeId const type_id = DeduceColumnType();
+    TypeId const type_id = DeduceColumnType(unparsed_, treat_mixed_as_string_);
     TypeMap type_map = CreateTypeMap(type_id);
 
     return CreateFromTypeMap(CreateType(type_id, is_null_equal_null_), std::move(type_map));

--- a/src/core/model/table/typed_column_data.h
+++ b/src/core/model/table/typed_column_data.h
@@ -175,86 +175,10 @@ private:
     bool is_null_equal_null_;
     bool treat_mixed_as_string_;
 
-    inline static std::vector<TypeId> const kAllCandidateTypes = {TypeId::kDate,   TypeId::kInt,
-                                                                  TypeId::kBigInt, TypeId::kDouble,
-                                                                  TypeId::kBool,   TypeId::kString};
-    inline static std::unordered_map<TypeId, boost::regex> const kTypeIdToRegex = {
-            {TypeId::kDate,
-             boost::regex(
-                     R"(^(\d{4})([-.\/]?)(1[0-2]|0[1-9]|[1-9])\2(3[0-1]|0[1-9]|[1-9]|[1-2][0-9])$)")},
-            {TypeId::kBool,
-             boost::regex(R"(^\s*(true|false|0|1)\s*$)", boost::regex_constants::icase)},
-            {TypeId::kDouble,
-             boost::regex(
-                     R"(^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$|)"
-                     R"(^[+-]?(?i)(inf|nan)(?-i)$|)"
-                     R"(^[+-]?0[xX](((\d|[a-f]|[A-F]))+(\.(\d|[a-f]|[A-F])*)?|\.(\d|[a-f]|[A-F])+)([pP][+-]?\d+)?$)")},
-            {TypeId::kBigInt, boost::regex(R"(^(\+|-)?\d{20,}$)")},
-            {TypeId::kInt, boost::regex(R"(^(\+|-)?\d{1,19}$)")},
-            {TypeId::kNull, boost::regex(Null::kValue.data())},
-            {TypeId::kEmpty, boost::regex(R"(^$)")}};
-    inline static auto const kNullCheck = [](std::string const& val) {
-        return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kNull));
-    };
-    inline static auto const kEmptyCheck = [](std::string const& val) {
-        return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kEmpty));
-    };
-    inline static std::function<bool(std::string const&)> const kUndelimitedDateCheck =
-            [](std::string const& val) {
-                bool is_undelimited_date = false;
-                try {
-                    boost::gregorian::from_undelimited_string(val);
-                    is_undelimited_date = true;
-                } catch (...) {
-                }
-                return is_undelimited_date;
-            };
-    inline static std::function<bool(std::string const&)> const kDelimitedDateCheck =
-            [](std::string const& val) {
-                bool is_simple_date = false;
-                try {
-                    boost::gregorian::from_simple_string(val);
-                    is_simple_date = true;
-                } catch (...) {
-                }
-                return is_simple_date;
-            };
-    inline static std::vector<std::pair<TypeId, std::function<bool(std::string const&)>>> const
-            kTypeIdToChecker = {
-                    {TypeId::kDate,
-                     [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDate)) &&
-                                (kDelimitedDateCheck(val) || kUndelimitedDateCheck(val));
-                     }},
-                    {TypeId::kInt,
-                     [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kInt));
-                     }},
-                    {TypeId::kBigInt,
-                     [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kBigInt));
-                     }},
-                    {TypeId::kDouble,
-                     [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kDouble));
-                     }},
-                    {TypeId::kBool, [](std::string const& val) {
-                         return boost::regex_match(val, kTypeIdToRegex.at(TypeId::kBool));
-                     }}};
-    // each 1 represents a possible type from kAllCandidateTypes
-    inline static std::unordered_map<TypeId, std::bitset<6>> const kTypeIdToBitset = {
-            {TypeId::kDate, std::bitset<6>("000001")},  // bitset for delimited dates
-            {TypeId::kInt, std::bitset<6>("011110")},
-            {TypeId::kBigInt, std::bitset<6>("011100")},
-            {TypeId::kDouble, std::bitset<6>("011000")},
-            {TypeId::kBool, std::bitset<6>("010000")},
-            {TypeId::kString, std::bitset<6>("100000")}};
-
     size_t CalculateMixedBufSize(std::vector<TypeId> const& types_layout,
                                  TypeIdToType const& type_id_to_type) const noexcept;
     std::vector<TypeId> GetTypesLayout(TypeMap const& tm) const;
     TypeIdToType MapTypeIdsToTypes(TypeMap const& tm) const;
-    TypeId DeduceColumnType() const;
     TypeMap CreateTypeMap(TypeId const type_id) const;
     TypedColumnData CreateMixedFromTypeMap(std::unique_ptr<Type const> type, TypeMap type_map);
     TypedColumnData CreateConcreteFromTypeMap(std::unique_ptr<Type const> type, TypeMap type_map);

--- a/src/core/model/types/type_deduction.h
+++ b/src/core/model/types/type_deduction.h
@@ -1,0 +1,170 @@
+#include <bitset>
+#include <unordered_map>
+#include <vector>
+
+#include <boost/regex.hpp>
+
+#include "core/model/types/type.h"
+
+namespace model {
+
+inline static std::vector<TypeId> const kAllCandidateTypes = {
+        +TypeId::kDate, +TypeId::kInt, +TypeId::kBigInt, +TypeId::kDouble, +TypeId::kString};
+inline static std::unordered_map<TypeId, boost::regex> const kTypeIdToRegex = {
+        {TypeId::kDate,
+         boost::regex(
+                 R"(^(\d{4})([-.\/]?)(1[0-2]|0[1-9]|[1-9])\2(3[0-1]|0[1-9]|[1-9]|[1-2][0-9])$)")},
+        {TypeId::kDouble,
+         boost::regex(
+                 R"(^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?$|)"
+                 R"(^[+-]?(?i)(inf|nan)(?-i)$|)"
+                 R"(^[+-]?0[xX](((\d|[a-f]|[A-F]))+(\.(\d|[a-f]|[A-F])*)?|\.(\d|[a-f]|[A-F])+)([pP][+-]?\d+)?$)")},
+        {+TypeId::kBigInt, boost::regex(R"(^(\+|-)?\d{20,}$)")},
+        {+TypeId::kInt, boost::regex(R"(^(\+|-)?\d{1,19}$)")},
+        {+TypeId::kNull, boost::regex(Null::kValue.data())},
+        {+TypeId::kEmpty, boost::regex(R"(^$)")}};
+inline static auto const kNullCheck = [](std::string const& val) {
+    return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kNull));
+};
+inline static auto const kEmptyCheck = [](std::string const& val) {
+    return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kEmpty));
+};
+inline static std::function<bool(std::string const&)> const kUndelimitedDateCheck =
+        [](std::string const& val) {
+            bool is_undelimited_date = false;
+            try {
+                boost::gregorian::from_undelimited_string(val);
+                is_undelimited_date = true;
+            } catch (...) {
+            }
+            return is_undelimited_date;
+        };
+inline static std::function<bool(std::string const&)> const kDelimitedDateCheck =
+        [](std::string const& val) {
+            bool is_simple_date = false;
+            try {
+                boost::gregorian::from_simple_string(val);
+                is_simple_date = true;
+            } catch (...) {
+            }
+            return is_simple_date;
+        };
+inline static std::unordered_map<TypeId, std::function<bool(std::string const&)>> const
+        kTypeIdToChecker = {
+                {TypeId::kDouble,
+                 [](std::string const& val) {
+                     return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kDouble));
+                 }},
+                {TypeId::kBigInt,
+                 [](std::string const& val) {
+                     return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kBigInt));
+                 }},
+                {TypeId::kInt,
+                 [](std::string const& val) {
+                     return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kInt));
+                 }},
+                {TypeId::kDate, [](std::string const& val) {
+                     return boost::regex_match(val, kTypeIdToRegex.at(+TypeId::kDate)) &&
+                            (kDelimitedDateCheck(val) || kUndelimitedDateCheck(val));
+                 }}};
+// each 1 represents a possible type from kAllCandidateTypes
+inline static std::unordered_map<TypeId, std::bitset<5>> const kTypeIdToBitset = {
+        {+TypeId::kDate, std::bitset<5>("00001")},  // bitset for delimited dates
+        {+TypeId::kInt, std::bitset<5>("01110")},
+        {+TypeId::kBigInt, std::bitset<5>("01100")},
+        {+TypeId::kDouble, std::bitset<5>("01000")},
+        {+TypeId::kString, std::bitset<5>("10000")}};
+
+/**
+ * @brief Deduces the data type of a column based on its unparsed string values.
+ *
+ * This function analyzes all values in the column to determine their common type.
+ * It uses a bitset-based filtering approach to progressively narrow down candidate types
+ * as each value is examined.
+ *
+ * The algorithm works as follows:
+ * 1. Iterates through all unparsed values in the column, skipping null and empty values.
+ * 2. For the first non-null/non-empty value, determines the initial candidate type.
+ * 3. For subsequent values:
+ *    - If the value matches the first type's checker, it's accepted (with special handling for
+ * dates).
+ *    - Otherwise, finds all matching types and builds a bitset of candidates.
+ *    - Special case: undelimited dates can also be integers or doubles.
+ * 4. Intersects the candidate types bitset with the new candidates using bitwise AND.
+ * 5. If no candidates remain, either defaults to String (if treat_mixed_as_string_ is true)
+ *    or returns Mixed type.
+ *
+ * Special handling:
+ * - Dates are treated specially as undelimited dates have different type possibilities
+ *   than delimited dates.
+ * - Mixed types are returned when values cannot be reconciled to a single type
+ *   (unless treat_mixed_as_string_ is enabled).
+ *
+ * @return TypeId The deduced type of the column (kUndefined, kString, kInt, kDouble,
+ *                kDate, or kMixed).
+ */
+static TypeId DeduceColumnType(std::vector<std::string> const& col, bool treat_mixed_as_string_) {
+    bool is_undefined = true;
+    std::bitset<5> candidate_types_bitset("11111");
+    TypeId first_type_id = +TypeId::kUndefined;
+    for (std::size_t i = 0; i != col.size(); ++i) {
+        std::string const& cur_val = col[i];
+        if (!kNullCheck(cur_val) && !kEmptyCheck(cur_val)) {
+            is_undefined = false;
+            if (first_type_id != +TypeId::kUndefined) {
+                auto& type_check = kTypeIdToChecker.at(first_type_id);
+                if (type_check(cur_val)) {
+                    // undelimited and delimited dates have different bitsets
+                    if (first_type_id == +TypeId::kDate && kDelimitedDateCheck(cur_val)) {
+                        candidate_types_bitset &= kTypeIdToBitset.at(first_type_id);
+                    }
+                    continue;
+                }
+            }
+
+            std::bitset<5> new_candidate_types_bitset("00000");
+            bool matched = false;
+            for (auto const& [type_id, type_check] : kTypeIdToChecker) {
+                if (type_id != first_type_id && type_check(cur_val)) {
+                    if (first_type_id == +TypeId::kUndefined && !matched) {
+                        first_type_id = type_id;
+                    }
+                    matched = true;
+                    new_candidate_types_bitset |= kTypeIdToBitset.at(type_id);
+                    // possible value types are known at the first match except for dates
+                    // (undelimited dates could be ints or doubles and delimited couldn't)
+                    if (type_id == +TypeId::kDate && kUndelimitedDateCheck(cur_val)) {
+                        new_candidate_types_bitset |= kTypeIdToBitset.at(+TypeId::kInt);
+                    }
+                    break;
+                }
+            }
+            if (!matched) {
+                new_candidate_types_bitset = kTypeIdToBitset.at(+TypeId::kString);
+            }
+
+            candidate_types_bitset &= new_candidate_types_bitset;
+            if (candidate_types_bitset.none()) {
+                if (treat_mixed_as_string_) {
+                    candidate_types_bitset = kTypeIdToBitset.at(+TypeId::kString);
+                } else {
+                    return +TypeId::kMixed;
+                }
+            }
+        }
+    }
+
+    if (is_undefined) {
+        return +TypeId::kUndefined;
+    }
+
+    for (std::size_t i = 0; i < 5; i++) {
+        if (candidate_types_bitset[i]) {
+            return kAllCandidateTypes[i];
+        }
+    }
+
+    return +TypeId::kMixed;
+}
+
+}  // namespace model

--- a/src/core/parser/csv_parser/csv_parser.cpp
+++ b/src/core/parser/csv_parser/csv_parser.cpp
@@ -26,6 +26,7 @@ CSVParser::CSVParser(std::filesystem::path const& path, char separator, bool has
       next_line_(),
       number_of_columns_(),
       column_names_(),
+      path_(path),
       relation_name_(path.filename().string()) {
     // Wrong path
     if (!source_) {

--- a/src/core/parser/csv_parser/csv_parser.h
+++ b/src/core/parser/csv_parser/csv_parser.h
@@ -29,6 +29,7 @@ private:
     std::string next_line_;
     int number_of_columns_;
     std::vector<std::string> column_names_;
+    std::filesystem::path path_;
     std::string relation_name_;
     void GetNext();
     void PeekNext();
@@ -67,6 +68,14 @@ public:
 
     std::string GetRelationName() const override {
         return relation_name_;
+    }
+
+    std::filesystem::path const& GetPath() const {
+        return path_;
+    }
+
+    bool HasHeader() const noexcept {
+        return has_header_;
     }
 
     void Reset() override;

--- a/src/core/util/CMakeLists.txt
+++ b/src/core/util/CMakeLists.txt
@@ -1,8 +1,7 @@
 set(NAME util)
 desbordante_add_lib(NAME OBJECT)
 target_sources(
-    ${NAME} PRIVATE convex_hull.cpp create_dd.cpp levenshtein_distance.cpp qgram_vector.cpp
-                    worker_thread_pool.cpp
+    ${NAME} PRIVATE convex_hull.cpp create_dd.cpp levenshtein_distance.cpp qgram_vector.cpp worker_thread_pool.cpp
 )
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only Boost::headers)

--- a/src/core/util/lttree.h
+++ b/src/core/util/lttree.h
@@ -1,0 +1,593 @@
+#include <algorithm>
+#include <cassert>
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <format>
+#include <iterator>
+#include <roaring.hh>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "core/util/logger.h"
+
+namespace utils {
+/* LT-tree node invariant
+// ======================
+
+// Each node stores one distinct value and two id sets:
+
+//         +------------------------------+
+//         | val = x                      |
+//         | {row.id} s.t row.val == x    |
+//         | {row.id} s.t row.val <  x    |
+//         +------------------------------+
+//                   /          \
+//             values < x     values > x
+
+
+Example
+=======
+
+Table:
+index|value
+0|100
+1|50
+2|25
+3|200
+4|50
+5|10
+
+After consecutive insertion of values with according indices the tree looks as follows:
+(tree rebalancing is perfomed according to AVL tree balancing rules)
+
+                        +----------------------+
+                        |    value: 100        |
+                        |    tuple set: {0}    |
+                        |    LT-set: {1,2,4,5} |
+                        +----------------------+
+                             /              \
+                            /                \
+        +----------------------+     +----------------------+
+        |    value: 50         |     |    value: 200        |
+        |    tuple set: {1,4}  |     |    tuple set: {3}    |
+        |    LT-set: {2,5}     |     |    LT-set: {}        |
+        +----------------------+     +----------------------+
+                /
+               /
++----------------------+
+|    value: 25         |
+|    tuple set: {2}    |
+|    LT-set: {}        |
++----------------------+
+
+
+/* @brief Less than tree, represents a balanced binary search
+ * tree with fast lookup for indices which values are less than x
+ * @tparam T type of stored values in tree nodes
+ */
+template <std::totally_ordered T>
+class LTTree {
+    /* @brief LTTree node
+     * @property val current value in the node
+     * @property height the height of the subtree with a root as current node
+     * @property left left child
+     * @property right right child
+     * @property lt_indices indices which values are less than 'val'
+     * @property cur_indices indices which values are equal to 'val'
+     */
+    class Node {
+    public:
+        roaring::Roaring lt_indices;
+        roaring::Roaring cur_indices;
+        T val;
+
+        size_t height = 1;
+        Node* left = nullptr;
+        Node* right = nullptr;
+        Node* parent = nullptr;
+
+        template <typename U>
+        Node(U&& _val, size_t _index, Node* _parent = nullptr)
+            : val(std::forward<U>(_val)), parent(_parent) {
+            cur_indices.add(static_cast<uint32_t>(_index));
+        };
+
+        void Unlink() {
+            left = nullptr;
+            right = nullptr;
+            parent = nullptr;
+        }
+
+        ~Node() {
+            delete left;
+            delete right;
+        }
+
+        void Swap(Node*& other) {
+            std::swap(left, other->left);
+            std::swap(right, other->right);
+            std::swap(parent, other->parent);
+            std::swap(lt_indices, other->lt_indices);
+            std::swap(cur_indices, other->cur_indices);
+        }
+    };
+
+    class NodeView {
+    public:
+        NodeView(Node const* cur) : cur_(cur) {}
+
+        T const& val() const noexcept {
+            return cur_->val;
+        }
+
+        roaring::Roaring const& lt_indices() const noexcept {
+            return cur_->lt_indices;
+        };
+
+        roaring::Roaring const& cur_indices() const noexcept {
+            return cur_->cur_indices;
+        };
+
+        bool operator<(NodeView const& rhs) const noexcept {
+            return cur_->val < rhs.cur_->val;
+        }
+
+    private:
+        Node const* cur_;
+    };
+
+    class Iterator {
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = NodeView;
+        using pointer = NodeView*;
+        using iterator_concept = std::bidirectional_iterator_tag;
+        using iterator_category = std::bidirectional_iterator_tag;
+
+        Iterator(Node* cur, Node* root) : cur_(cur), root_(root) {}
+
+        Iterator& operator++() {
+            if (cur_->right) {
+                cur_ = cur_->right;
+                while (cur_->left) {
+                    cur_ = cur_->left;
+                }
+            } else {
+                Node* child = cur_;
+                cur_ = cur_->parent;
+                while (cur_ != nullptr and cur_->right == child) {
+                    child = cur_;
+                    cur_ = cur_->parent;
+                }
+            }
+            return *this;
+        }
+
+        Iterator operator++(int) {
+            Iterator tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        Iterator& operator--() {
+            if (cur_ == nullptr) {
+                cur_ = root_;
+                while (cur_->right != nullptr) {
+                    cur_ = cur_->right;
+                }
+            } else if (cur_->left) {
+                cur_ = cur_->left;
+                while (cur_->right) {
+                    cur_ = cur_->right;
+                }
+            } else {
+                Node* child = cur_;
+                cur_ = cur_->parent;
+                while (cur_ != nullptr and cur_->left == child) {
+                    child = cur_;
+                    cur_ = cur_->parent;
+                }
+            }
+            return *this;
+        }
+
+        Iterator operator--(int) {
+            Iterator tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        NodeView operator*() const {
+            return {cur_};
+        }
+
+        NodeView* operator->() const {
+            view_ = NodeView(cur_);
+            return &view_;
+        }
+
+        bool operator==(Iterator const& rhs) const noexcept {
+            return cur_ == rhs.cur_;
+        };
+
+        bool operator!=(Iterator const& rhs) const noexcept {
+            return !(cur_ == rhs.cur_);
+        };
+
+        Iterator& operator=(Iterator const& rhs) noexcept {
+            this->cur_ = rhs.cur_;
+            this->root_ = rhs.root_;
+            return *this;
+        }
+
+    private:
+        Node* cur_ = nullptr;
+        Node* root_ = nullptr;
+        mutable NodeView view_ = {nullptr};
+    };
+
+    /* @param val inserted value
+     * @param index index of the according value
+     * @param cur the current node where the insertion occurs
+     */
+    template <typename U>
+    Node* InsertRecursive(U&& val, size_t index, Node* cur);
+
+    bool IsBalancedRecursive(Node const* cur) const noexcept;
+    void FindLessRecursive(T const& val, Node const* cur, roaring::Roaring& res) const;
+    void FindLessOrEqualRecursive(T const& val, Node const* cur, roaring::Roaring& res) const;
+    Node* RemoveRecursive(T const& val, size_t index, Node* cur);
+    bool ContainsRecursive(T const& val, Node const* cur) const noexcept;
+    bool ContainsRecursive(T const& val, size_t index, Node const* cur) const noexcept;
+
+    size_t Height(Node const* cur) const noexcept;
+    int Balance(Node const* cur) const noexcept;
+    void UpdateHeight(Node* cur) noexcept;
+    Node* GetLeftMost(Node* cur) const noexcept;
+
+    bool isConsistent(Node const* cur, Node const* parent) {
+        if (cur == nullptr) return true;
+        return cur->parent == parent and isConsistent(cur->left, cur) and
+               isConsistent(cur->right, cur);
+    }
+
+    /* @brief Rotate appropriate nodes to the left
+     *  (pull the right child up and move 'cur' node down to the left)
+     *  @return Right child of 'cur' as a root
+     */
+    Node* RotateLeft(Node* cur) noexcept;
+
+    /* @brief Rotate appropriate nodes to the right
+     *  (pull the left child up and move 'cur' node down to the right)
+     *  @return Left child of 'cur' as a root
+     */
+    Node* RotateRight(Node* cur) noexcept;
+
+    /* @brief Rebalance the 'cur' Node passed so its balance is either -1, 0 or 1
+     *  @return
+     */
+    Node* Rebalance(Node* cur);
+
+    Node* root_ = nullptr;
+    Node* min_ = nullptr;
+    size_t size_ = 0;
+
+public:
+    LTTree() noexcept {};
+
+    ~LTTree() {
+        delete root_;
+    }
+
+    template <typename U>
+    void Insert(U&& val, size_t index);
+
+    bool IsBalanced() const;
+    void Remove(T const& val, size_t index);
+
+    roaring::Roaring FindLess(T const& val) const {
+        roaring::Roaring res;
+        FindLessRecursive(val, root_, res);
+        return res;
+    }
+
+    roaring::Roaring FindLessOrEqual(T const& val) const {
+        roaring::Roaring res;
+        FindLessOrEqualRecursive(val, root_, res);
+        return res;
+    }
+
+    static std::vector<size_t> RoaringToVector(roaring::Roaring const& rb);
+
+    bool Contains(T const& val) const noexcept {
+        return ContainsRecursive(val, root_);
+    }
+
+    bool Contains(T const& val, size_t index) const noexcept {
+        return ContainsRecursive(val, index, root_);
+    }
+
+    // @return Number of total unique indices in all nodes
+    size_t Size() const noexcept {
+        return size_;
+    }
+
+    size_t Height() const noexcept {
+        return Height(root_);
+    }
+
+    Iterator begin() {
+        return {min_, root_};
+    }
+
+    Iterator end() {
+        return {nullptr, root_};
+    }
+};
+
+template <std::totally_ordered T>
+LTTree<T>::Node* LTTree<T>::GetLeftMost(Node* cur) const noexcept {
+    if (cur == nullptr) return cur;
+    while (cur->left != nullptr) cur = cur->left;
+    return cur;
+}
+
+template <std::totally_ordered T>
+void LTTree<T>::UpdateHeight(Node* cur) noexcept {
+    size_t left_height = Height(cur->left);
+    size_t right_height = Height(cur->right);
+    cur->height = 1 + std::max(left_height, right_height);
+}
+
+template <std::totally_ordered T>
+size_t LTTree<T>::Height(Node const* cur) const noexcept {
+    return cur == nullptr ? 0 : cur->height;
+}
+
+template <std::totally_ordered T>
+int LTTree<T>::Balance(Node const* cur) const noexcept {
+    return static_cast<int>(Height(cur->left)) - static_cast<int>(Height(cur->right));
+}
+
+template <std::totally_ordered T>
+template <typename U>
+void LTTree<T>::Insert(U&& val, size_t index) {
+    root_ = InsertRecursive(std::forward<U>(val), index, root_);
+    assert(root_ != nullptr and isConsistent(root_, nullptr));
+    min_ = GetLeftMost(root_);
+    ++size_;
+}
+
+template <std::totally_ordered T>
+template <typename U>
+LTTree<T>::Node* LTTree<T>::InsertRecursive(U&& val, size_t index, Node* cur) {
+    if (cur == nullptr) {
+        return new Node(std::forward<U>(val), index);
+    }
+
+    if (static_cast<T>(val) < cur->val) {
+        cur->lt_indices.add(static_cast<uint32_t>(index));
+        cur->left = InsertRecursive(std::forward<U>(val), index, cur->left);
+        cur->left->parent = cur;
+
+    } else if (static_cast<T>(val) == cur->val) {
+        cur->cur_indices.add(static_cast<uint32_t>(index));
+
+    } else {
+        cur->right = InsertRecursive(std::forward<U>(val), index, cur->right);
+        cur->right->parent = cur;
+    }
+
+    UpdateHeight(cur);
+    return Rebalance(cur);
+}
+
+// 0 1 2, для нуля не устанавливается родитель при перебалансировке
+template <std::totally_ordered T>
+LTTree<T>::Node* LTTree<T>::Rebalance(Node* cur) {
+    int balance = Balance(cur);
+    // Left side is imbalanced
+    if (balance > 1) {
+        if (Balance(cur->left) < 0) {
+            cur->left = RotateLeft(cur->left);
+            if (cur->left) cur->left->parent = cur;
+        }
+        return RotateRight(cur);
+    }
+    // Right side is imbalanced
+    else if (balance < -1) {
+        if (Balance(cur->right) > 0) {
+            cur->right = RotateRight(cur->right);
+            if (cur->right) cur->right->parent = cur;
+        }
+        return RotateLeft(cur);
+    }
+
+    return cur;
+}
+
+template <std::totally_ordered T>
+std::vector<size_t> LTTree<T>::RoaringToVector(roaring::Roaring const& rb) {
+    std::vector<size_t> result;
+    result.reserve(rb.cardinality());
+    for (uint32_t val : rb) {
+        result.push_back(static_cast<size_t>(val));
+    }
+    return result;
+}
+
+template <std::totally_ordered T>
+LTTree<T>::Node* LTTree<T>::RotateLeft(Node* cur) noexcept {
+    assert(cur != nullptr);
+
+    // Update node's lt sets
+    cur->right->lt_indices |= cur->lt_indices;
+    cur->right->lt_indices |= cur->cur_indices;
+
+    // Update node's links
+    Node* right = cur->right;
+    cur->right = right->left;
+    if (right->left) right->left->parent = cur;
+    right->left = cur;
+    right->parent = cur->parent;
+    cur->parent = right;
+
+    UpdateHeight(cur);
+    UpdateHeight(right);
+
+    return right;
+}
+
+template <std::totally_ordered T>
+LTTree<T>::Node* LTTree<T>::RotateRight(Node* cur) noexcept {
+    assert(cur != nullptr);
+
+    // Update node's lt sets
+    cur->lt_indices -= cur->left->lt_indices;
+    cur->lt_indices -= cur->left->cur_indices;
+
+    // Update node's links
+    Node* left = cur->left;
+    cur->left = left->right;
+    if (left->right) left->right->parent = cur;
+    left->right = cur;
+    left->parent = cur->parent;
+    cur->parent = left;
+
+    UpdateHeight(cur);
+    UpdateHeight(left);
+
+    return left;
+}
+
+template <std::totally_ordered T>
+bool LTTree<T>::IsBalanced() const {
+    return IsBalancedRecursive(root_);
+}
+
+template <std::totally_ordered T>
+bool LTTree<T>::IsBalancedRecursive(Node const* cur) const noexcept {
+    if (cur == nullptr) return true;
+    return std::abs(Balance(cur)) <= 1 and IsBalancedRecursive(cur->left) and
+           IsBalancedRecursive(cur->right);
+}
+
+template <std::totally_ordered T>
+void LTTree<T>::FindLessRecursive(T const& val, Node const* cur, roaring::Roaring& res) const {
+    if (cur == nullptr) return;
+    if (val < cur->val) {
+        return FindLessRecursive(val, cur->left, res);
+    } else if (val > cur->val) {
+        res |= cur->lt_indices;
+        res |= cur->cur_indices;
+        return FindLessRecursive(val, cur->right, res);
+    } else {
+        res |= cur->lt_indices;
+        return;
+    }
+}
+
+template <std::totally_ordered T>
+void LTTree<T>::FindLessOrEqualRecursive(T const& val, Node const* cur,
+                                         roaring::Roaring& res) const {
+    if (cur == nullptr) return;
+    if (val < cur->val) {
+        return FindLessOrEqualRecursive(val, cur->left, res);
+    } else if (val > cur->val) {
+        res |= cur->lt_indices;
+        res |= cur->cur_indices;
+        return FindLessOrEqualRecursive(val, cur->right, res);
+    } else {
+        res |= cur->lt_indices;
+        res |= cur->cur_indices;
+        return;
+    }
+}
+
+template <std::totally_ordered T>
+void LTTree<T>::Remove(T const& val, size_t index) {
+    if (!Contains(val, index)) {
+        throw std::logic_error("[LTTree]: Entry " + std::to_string(index) + " doesn't exist");
+    }
+
+    root_ = RemoveRecursive(val, index, root_);
+    if (root_) root_->parent = nullptr;
+    assert(isConsistent(root_, nullptr));
+    min_ = root_ ? GetLeftMost(root_) : nullptr;
+    --size_;
+}
+
+template <std::totally_ordered T>
+LTTree<T>::Node* LTTree<T>::RemoveRecursive(T const& val, size_t index, Node* cur) {
+    if (val > cur->val) {
+        cur->right = RemoveRecursive(val, index, cur->right);
+        if (cur->right) cur->right->parent = cur;
+    } else if (val < cur->val) {
+        cur->lt_indices.remove(static_cast<uint32_t>(index));
+        cur->left = RemoveRecursive(val, index, cur->left);
+        if (cur->left) cur->left->parent = cur;
+    } else {
+        // if cur_indices is not empty no need to delete node
+        cur->cur_indices.remove(index);
+        if (cur->cur_indices.cardinality() != 0) {
+            return cur;
+        }
+
+        // if node is a leaf simply delete it
+        if (cur->left == nullptr and cur->right == nullptr) {
+            delete cur;
+            return nullptr;
+        }
+
+        // if node has only right subtree delete cur
+        if (cur->left == nullptr) {
+            Node* right = cur->right;
+            cur->Unlink();
+            delete cur;
+            return right;
+        }
+
+        // if node has only left subtree delete cur
+        if (cur->right == nullptr) {
+            Node* left = cur->left;
+            cur->Unlink();
+            delete cur;
+            return left;
+        }
+
+        // Replace current node with in-order successor (leftmost of right subtree).
+        Node* succ = GetLeftMost(cur->right);
+        assert(succ != nullptr);
+        cur->val = succ->val;
+        cur->cur_indices = succ->cur_indices;
+        for (auto idx : cur->cur_indices) {
+            cur->right = RemoveRecursive(succ->val, idx, cur->right);
+            if (cur->right) cur->right->parent = cur;
+        }
+    }
+
+    UpdateHeight(cur);
+    cur = Rebalance(cur);
+    return cur;
+}
+
+template <std::totally_ordered T>
+bool LTTree<T>::ContainsRecursive(T const& val, Node const* cur) const noexcept {
+    if (cur == nullptr) return false;
+    if (val > cur->val) return ContainsRecursive(val, cur->right);
+    if (val < cur->val) return ContainsRecursive(val, cur->left);
+    return true;
+}
+
+template <std::totally_ordered T>
+bool LTTree<T>::ContainsRecursive(T const& val, size_t index, Node const* cur) const noexcept {
+    if (cur == nullptr) return false;
+    if (val > cur->val) return ContainsRecursive(val, cur->right);
+    if (val < cur->val) return ContainsRecursive(val, cur->left);
+    return cur->cur_indices.contains(static_cast<uint32_t>(index));
+}
+
+}  // namespace utils

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
             Boost::headers
             Desbordante.bindlib.util
             Desbordante.bindlib.data
+            roaring
 )
 
 # Uncomment to debug linker issues
@@ -114,6 +115,7 @@ desbordante_add_bind(
     SRCS
     dc/bind_dc_verification.cpp
     dc/bind_fastadc.cpp
+    dc/bind_weever.cpp
     LIBS
     ${DESBORDANTE_PREFIX}::dc::verifier
     ${DESBORDANTE_PREFIX}::dc::fastadc
@@ -121,6 +123,7 @@ desbordante_add_bind(
     ${DESBORDANTE_PREFIX}::bindlib::util
     spdlog::spdlog_header_only
     Boost::headers
+    roaring
 )
 
 desbordante_add_bind(
@@ -181,6 +184,7 @@ desbordante_add_bind(
     magic_enum::magic_enum
     spdlog::spdlog_header_only
     Boost::headers
+    roaring
 )
 
 desbordante_add_bind(

--- a/src/python_bindings/bindings.cpp
+++ b/src/python_bindings/bindings.cpp
@@ -15,6 +15,7 @@
 #include "python_bindings/data/bind_data_types.h"
 #include "python_bindings/dc/bind_dc_verification.h"
 #include "python_bindings/dc/bind_fastadc.h"
+#include "python_bindings/dc/bind_weever.h"
 #include "python_bindings/dd/bind_dd_verification.h"
 #include "python_bindings/dd/bind_split.h"
 #include "python_bindings/dynamic/bind_dynamic_fd_verification.h"
@@ -83,6 +84,7 @@ PYBIND11_MODULE(desbordante, module, pybind11::mod_gil_not_used()) {
                            BindMd,
                            BindMDVerification,
                            BindDCVerification,
+                           BindWeever,
                            BindPfdVerification,
                            BindARVerification,
                            BindFastADC,

--- a/src/python_bindings/dc/bind_weever.cpp
+++ b/src/python_bindings/dc/bind_weever.cpp
@@ -1,0 +1,19 @@
+#include "python_bindings/dc/bind_weever.h"
+
+#include <pybind11/stl.h>
+
+#include "core/algorithms/dc/weever/weever.h"
+#include "python_bindings/py_util/bind_primitive.h"
+
+namespace python_bindings {
+
+namespace py = pybind11;
+
+void BindWeever(py::module_& main_module) {
+    auto weever_module = main_module.def_submodule("weever");
+
+    BindPrimitiveNoBase<algos::Weever>(weever_module, "Weever")
+            .def("get_violations", &algos::Weever::GetViolations);
+}
+
+}  // namespace python_bindings

--- a/src/python_bindings/dc/bind_weever.h
+++ b/src/python_bindings/dc/bind_weever.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+namespace python_bindings {
+void BindWeever(pybind11::module_& main_module);
+}  // namespace python_bindings

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
+add_subdirectory(mock)
 
 if(DESBORDANTE_BUILD_TESTS)
     add_subdirectory(unit)

--- a/src/tests/common/all_csv_configs.cpp
+++ b/src/tests/common/all_csv_configs.cpp
@@ -89,6 +89,7 @@ CSVConfig const kSimpleTypes = CreateCsvConfig("SimpleTypes.csv", ',', true);
 CSVConfig const kSimpleTypes1 = CreateCsvConfig("SimpleTypes1.csv", ',', true);
 CSVConfig const kSimpleTypos = CreateCsvConfig("SimpleTypos.csv", ',', true);
 CSVConfig const kTennis = CreateCsvConfig("cfd_data/tennis.csv", ',', true);
+CSVConfig const kTax = CreateCsvConfig("Tax.csv", ',', true);
 CSVConfig const kTest1 = CreateCsvConfig("Test1.csv", ',', true);
 CSVConfig const kTestCINDEn = CreateCsvConfig("cind/cind_test_en.csv", ',', true);
 CSVConfig const kTestCINDDe = CreateCsvConfig("cind/cind_test_de.csv", ',', true);

--- a/src/tests/common/all_csv_configs.h
+++ b/src/tests/common/all_csv_configs.h
@@ -75,6 +75,7 @@ extern CSVConfig const kRulesSynthetic2;
 extern CSVConfig const kSimpleTypes;
 extern CSVConfig const kSimpleTypes1;
 extern CSVConfig const kSimpleTypos;
+extern CSVConfig const kTax;
 extern CSVConfig const kTennis;
 extern CSVConfig const kTest1;
 extern CSVConfig const kTestCINDEn;

--- a/src/tests/mock/CMakeLists.txt
+++ b/src/tests/mock/CMakeLists.txt
@@ -1,0 +1,2 @@
+set(NAME testlib.mock)
+desbordante_add_lib(NAME INTERFACE)

--- a/src/tests/mock/mock_input_table.h
+++ b/src/tests/mock/mock_input_table.h
@@ -1,0 +1,58 @@
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "core/algorithms/algo_factory.h"
+#include "core/algorithms/dc/weever/weever.h"
+#include "core/config/names.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/idataset_stream.h"
+#include "tests/common/all_csv_configs.h"
+#include "tests/common/csv_config_util.h"
+
+using namespace algos;
+using namespace config::names;
+
+namespace tests {
+
+class MockTable : public model::IDatasetStream {
+    std::string name_;
+    std::vector<std::string> columns_;
+    std::vector<Row> rows_;
+    size_t pos_ = 0;
+
+public:
+    MockTable(std::string name, std::vector<std::string> columns, std::vector<Row> rows)
+        : name_(std::move(name)), columns_(std::move(columns)), rows_(std::move(rows)) {}
+
+    Row GetNextRow() override {
+        return rows_[pos_++];
+    }
+
+    bool HasNextRow() const override {
+        return pos_ < rows_.size();
+    }
+
+    size_t GetNumberOfColumns() const override {
+        return columns_.size();
+    }
+
+    std::string GetColumnName(size_t i) const override {
+        return columns_[i];
+    }
+
+    std::string GetRelationName() const override {
+        return name_;
+    }
+
+    void Reset() override {
+        pos_ = 0;
+    }
+};
+
+}  // namespace tests

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -32,6 +32,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 # --- AR ---
@@ -49,6 +50,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 
 # --- CFD ---
@@ -65,6 +67,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 desbordante_add_test(
@@ -92,6 +95,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 # --- CIND ---
@@ -143,6 +147,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 
 # --- DC ---
@@ -160,6 +165,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     dc.verifier
@@ -167,11 +173,44 @@ desbordante_add_test(
     test_dc_verifier.cpp
     LIBS
     ${DESBORDANTE_PREFIX}::dc::verifier
+    ${DESBORDANTE_PREFIX}::dc::fastadc
+    ${DESBORDANTE_PREFIX}::dc::fastadc::structs
     ${DESBORDANTE_PREFIX}::testlib::common
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
+)
+desbordante_add_test(
+    dc.weever
+    SRCS
+    test_weever.cpp
+    LIBS
+    ${DESBORDANTE_PREFIX}::dc::weever
+    ${DESBORDANTE_PREFIX}::dc::verifier
+    ${DESBORDANTE_PREFIX}::testlib::common
+    ${DESBORDANTE_PREFIX}::testlib::mock
+    ${DESBORDANTE_PREFIX}::parser::csv
+    spdlog::spdlog_header_only
+    Boost::headers
+    gmock
+    roaring
+)
+desbordante_add_test(
+    dc.weever.benchmark
+    SRCS
+    benchmark_weever.cpp
+    LIBS
+    ${DESBORDANTE_PREFIX}::dc::weever
+    ${DESBORDANTE_PREFIX}::dc::verifier
+    ${DESBORDANTE_PREFIX}::testlib::common
+    ${DESBORDANTE_PREFIX}::testlib::mock
+    ${DESBORDANTE_PREFIX}::parser::csv
+    spdlog::spdlog_header_only
+    Boost::headers
+    gmock
+    roaring
 )
 
 # --- DD ---
@@ -185,6 +224,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     dd.split
@@ -196,6 +236,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 # --- DES ---
@@ -213,6 +254,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 # --- FD ---
@@ -239,6 +281,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.approx
@@ -256,6 +299,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.mine
@@ -273,6 +317,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.tane.pfd
@@ -288,6 +333,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.pfd_verifier
@@ -300,6 +346,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.sfd.cords
@@ -313,6 +360,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.tane
@@ -328,6 +376,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.verifier.dynamic
@@ -342,6 +391,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     fd.verifier
@@ -417,6 +467,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     gmock
     Boost::headers
+    roaring
 )
 
 # --- GFD ---
@@ -431,6 +482,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     gfd.validator
@@ -458,6 +510,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 
 # --- IND ---
@@ -477,6 +530,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     ind.faida
@@ -490,6 +544,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     ind.verifier
@@ -502,6 +557,7 @@ desbordante_add_test(
     spdlog::spdlog_header_only
     magic_enum::magic_enum
     Boost::headers
+    roaring
 )
 
 # --- Model ---
@@ -536,6 +592,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     gmock
     Boost::headers
+    roaring
 )
 desbordante_add_test(
     model.table
@@ -548,6 +605,16 @@ desbordante_add_test(
     ${DESBORDANTE_PREFIX}::parser::csv
     magic_enum::magic_enum
     Boost::headers
+)
+desbordante_add_test(
+    model.dynamic_row_table
+    SRCS
+    test_typed_dynamic_row_table_data.cpp
+    LIBS
+    ${DESBORDANTE_PREFIX}::model::types
+    ${DESBORDANTE_PREFIX}::util
+    Boost::headers
+    spdlog::spdlog_header_only
 )
 
 # --- ND ---
@@ -562,6 +629,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 
 # --- MD ---
@@ -577,6 +645,7 @@ desbordante_add_test(
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::table
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 desbordante_add_test(
     md.metrics
@@ -589,6 +658,7 @@ desbordante_add_test(
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::table
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 desbordante_add_test(
     md.verifier
@@ -602,6 +672,7 @@ desbordante_add_test(
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::table
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 
 # --- Metric ---
@@ -616,6 +687,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 
 # --- OD ---
@@ -630,6 +702,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 desbordante_add_test(
     od.order
@@ -642,6 +715,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 desbordante_add_test(
     od.set_based_aod_verifier
@@ -655,6 +729,7 @@ desbordante_add_test(
     magic_enum::magic_enum
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
+    roaring
 )
 
 # --- PAC ---
@@ -696,6 +771,7 @@ desbordante_add_test(
     gmock
     Boost::headers
     ${DESBORDANTE_PREFIX}::fd::hy::model
+    roaring
 )
 desbordante_add_test(
     ucc.verifier
@@ -711,6 +787,7 @@ desbordante_add_test(
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::types
     ${DESBORDANTE_PREFIX}::fd::hy::model
+    roaring
 )
 
 # --- SD ---
@@ -738,4 +815,14 @@ desbordante_add_test(
     Boost::headers
     ${DESBORDANTE_PREFIX}::model::table
     ${DESBORDANTE_PREFIX}::model::types
+)
+
+desbordante_add_test(
+    lttree
+    SRCS
+    test_lttree.cpp
+    LIBS
+    gmock
+    roaring
+    spdlog
 )

--- a/src/tests/unit/benchmark_weever.cpp
+++ b/src/tests/unit/benchmark_weever.cpp
@@ -1,0 +1,346 @@
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <random>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "core/algorithms/algo_factory.h"
+#include "core/algorithms/dc/verifier/dc_verifier.h"
+#include "core/algorithms/dc/weever/weever.h"
+#include "core/config/names.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/idataset_stream.h"
+#include "core/parser/csv_parser/csv_parser.h"
+#include "tests/common/all_csv_configs.h"
+#include "tests/mock/mock_input_table.h"
+
+namespace tests {
+
+using namespace algos;
+using namespace config::names;
+
+namespace {
+
+// ── DC and schema shared by all tests ────────────────────────────────────────
+
+static std::string const kStrictDC =
+        "!(s.State == t.State and s.Salary < t.Salary and s.FedTaxRate > t.FedTaxRate)";
+
+static std::vector<std::string> const kColumns = {"State", "Salary", "FedTaxRate"};
+
+// ── Utility: convert integer k to a 3-decimal tax-rate string ────────────────
+// FormatTax(1)    → "0.001"
+// FormatTax(1000) → "1.000"
+static std::string FormatTax(size_t k) {
+    std::string s = std::to_string(k);
+    while (s.size() < 4) s = "0" + s;
+    return s.substr(0, s.size() - 3) + "." + s.substr(s.size() - 3);
+}
+
+// ── Utility: apply one Execute() cycle with the given CRUD payload ────────────
+static void ApplyAndExecute(Weever& weever, config::InputTable inserts = {},
+                            std::unordered_set<size_t> deletes = {},
+                            config::InputTable updates = {}) {
+    weever.SetOption(kInsertStatements, std::move(inserts));
+    weever.SetOption(kDeleteStatements, std::move(deletes));
+    weever.SetOption(kUpdateStatements, std::move(updates));
+    weever.Execute();
+}
+
+}  // namespace
+
+TEST(WeeeverBenchmark, EmptyInsert) {
+    static constexpr size_t kNumTuples = 50'000;
+    static constexpr size_t kStep = 5'000;
+
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kStrictDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+
+    // TestDC1 with strict inequalities has no violations.
+    ApplyAndExecute(*weever, {}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    ASSERT_TRUE(weever->GetViolations().empty()) << "Table must be empty before benchmark starts";
+
+    std::printf("step,weever_batch_us\n");
+    std::fflush(stdout);
+
+    for (size_t batch = 0; batch < kNumTuples / kStep; ++batch) {
+        size_t k = (batch + 1) * kStep;
+
+        std::vector<model::IDatasetStream::Row> batchRows;
+        batchRows.reserve(kStep);
+        for (size_t j = 1; j <= kStep; ++j) {
+            size_t rowNum = batch * kStep + j;
+            batchRows.push_back({"Texas", std::to_string(kNumTuples - rowNum), FormatTax(rowNum)});
+        }
+
+        auto insertTable = std::make_shared<MockTable>("insert", kColumns, batchRows);
+        auto t1 = std::chrono::steady_clock::now();
+        ApplyAndExecute(*weever, std::move(insertTable));
+        auto t2 = std::chrono::steady_clock::now();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+
+        auto v_size = weever->GetViolationsSize();
+        std::printf("table size: %zu, time: %ld ms, v_size: %ld\n", k, ms.count(), v_size);
+        std::fflush(stdout);
+    }
+}
+
+TEST(DCVerifierBenchmark, EmptyInsert) {
+    static constexpr size_t kStep = 1'000;
+    static constexpr size_t kMaxRows = 10'000;
+
+    std::printf("step,dcverifier_us\n");
+    std::fflush(stdout);
+
+    std::vector<model::IDatasetStream::Row> currentRows;
+    currentRows.reserve(kMaxRows);
+
+    for (size_t k = kStep; k <= kMaxRows; k += kStep) {
+        size_t prevSize = currentRows.size();
+        for (size_t rowNum = prevSize + 1; rowNum <= k; ++rowNum) {
+            currentRows.push_back({"Texas", std::to_string(kMaxRows - rowNum), FormatTax(rowNum)});
+        }
+
+        auto table = std::make_shared<MockTable>("table", kColumns, currentRows);
+        config::InputTable tInput = table;
+        algos::StdParamsMap dcParams = {
+                {kTable, tInput},
+                {kDenialConstraint, kStrictDC},
+                {kDoCollectViolations, true},
+        };
+        auto verifier = algos::CreateAndLoadAlgorithm<DCVerifier>(dcParams);
+
+        auto t1 = std::chrono::steady_clock::now();
+        verifier->Execute();
+        auto t2 = std::chrono::steady_clock::now();
+        long long dcv_us = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
+
+        auto v_size = 0l;
+        std::printf("table size: %zu, time: %lld ms, v_size: %ld\n", k, dcv_us, v_size);
+        std::fflush(stdout);
+    }
+}
+
+class WeeverTaxBenchmark : public ::testing::Test {
+public:
+    std::string const phi1 = "!(s.State == t.State and s.Salary > t.Salary and s.Rate < t.Rate)";
+    std::string const phi2 =
+            "!(s.AreaCode == t.AreaCode and s.Phone == t.Phone and s.Salary > t.Salary)";
+    std::string const phi3 =
+            "!(s.FName == t.FName and s.LName == t.LName and s.Gender != t.Gender)";
+
+    std::string const dc = phi2;
+
+    std::vector<std::string> const tax_cols = {
+            "FName",  "LName", "Gender",      "AreaCode",      "Phone",
+            "City",   "State", "Zip",         "MaritalStatus", "HasChild",
+            "Salary", "Rate",  "SingleExemp", "MarriedExemp",  "ChildExemp"};
+
+    // std::vector<std::string> const tax_cols = {"State", "Zip"};
+    size_t index_offset = 2;
+    size_t batch_size = 1'000;
+    size_t num_batches = 1'000;
+    std::unique_ptr<Weever> weever;
+    std::vector<model::IDatasetStream::Row> tax_rows;
+
+    void SetUp() {
+        algos::StdParamsMap params = {
+                {kCsvConfig, kTax},
+                {kDenialConstraint, dc},
+        };
+
+        std::printf("# DC: %s\n", dc.c_str());
+        std::printf("# batch_size=%zu  num_batches=%zu\n\n", batch_size, num_batches);
+        std::fflush(stdout);
+
+        // Load Tax rows for use as insert/update data source
+        auto parser = std::make_shared<CSVParser>(kTax);
+        while (parser->HasNextRow()) tax_rows.push_back(parser->GetNextRow());
+
+        weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+        std::cout << "Load finished" << std::endl;
+
+        auto t0 = std::chrono::steady_clock::now();
+
+        weever->Execute();  // initial load of Tax
+        long long ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               std::chrono::steady_clock::now() - t0)
+                               .count();
+        // for (auto const& [f, s] : weever->GetViolations()) {
+        //     LOG_INFO("({}, {})", f, s);
+        // }
+        std::printf("time: %lld ms, init vc size: %ld\n", ms, weever->GetViolationsSize());
+        std::fflush(stdout);
+    }
+};
+
+TEST_F(WeeverTaxBenchmark, BatchInsert) {
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<size_t> row_dist(0, tax_rows.size() - 1);
+
+    std::printf("\n# Tax batch insert benchmark\n");
+    std::fflush(stdout);
+    for (size_t b = 0; b < num_batches; ++b) {
+        std::vector<model::IDatasetStream::Row> rows;
+        rows.reserve(batch_size);
+        for (size_t i = 0; i < batch_size; ++i) {
+            rows.push_back(tax_rows[row_dist(rng)]);
+        }
+        auto ins_tbl = std::make_shared<MockTable>("epic_batch", tax_cols, std::move(rows));
+
+        weever->SetOption(kInsertStatements, config::InputTable(std::move(ins_tbl)));
+        weever->SetOption(kDeleteStatements, std::unordered_set<size_t>{});
+        weever->SetOption(kUpdateStatements, config::InputTable{});
+
+        auto t0 = std::chrono::steady_clock::now();
+        weever->Execute();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0);
+
+        if ((b + 1) % 5 == 0) {
+            std::printf("(%zu, %ld) ", b + 1, ms.count());
+        }
+        if ((b + 1) % 25 == 0) {
+            std::cout << std::endl;
+        }
+    }
+}
+
+TEST_F(WeeverTaxBenchmark, BatchDelete) {
+    std::printf("\n# Tax batch delete benchmark\n");
+    std::fflush(stdout);
+
+    for (size_t b = 0; b < num_batches; ++b) {
+        std::unordered_set<size_t> del_ids;
+        del_ids.reserve(batch_size);
+        size_t const first = index_offset + b * batch_size;
+        for (size_t i = 0; i < batch_size; ++i) del_ids.insert(first + i);
+
+        weever->SetOption(kDeleteStatements, std::move(del_ids));
+        weever->SetOption(kInsertStatements, {});
+        weever->SetOption(kUpdateStatements, {});
+
+        auto t0 = std::chrono::steady_clock::now();
+        weever->Execute();
+        auto mcs = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::steady_clock::now() - t0);
+
+        size_t vc = weever->GetViolationsSize();
+        if ((b + 1) % 5 == 0) {
+            auto mcs_str = std::format("{:.3g}", (double)mcs.count() / 1000);
+            std::printf("(%zu, %s) ", b + 1, mcs_str.c_str());
+            // std::printf("vc: %ld", vc);
+        }
+        if ((b + 1) % 25 == 0) {
+            std::cout << std::endl;
+        }
+    }
+}
+
+TEST_F(WeeverTaxBenchmark, BatchUpdate) {
+    std::printf("\n# Tax batch update benchmark\n");
+    std::fflush(stdout);
+
+    for (size_t b = 0; b < num_batches; ++b) {
+        std::vector<model::IDatasetStream::Row> upd_rows;
+        upd_rows.reserve(batch_size);
+        for (size_t i = 0; i < batch_size; ++i) {
+            size_t const tax_idx = b * batch_size + i;
+            model::IDatasetStream::Row src = tax_rows[tax_idx];
+            src.insert(src.begin(), std::to_string(index_offset + tax_idx));
+            upd_rows.push_back(std::move(src));
+        }
+        auto upd_tbl = std::make_shared<MockTable>("epic_upd", tax_cols, std::move(upd_rows));
+
+        weever->SetOption(kInsertStatements, config::InputTable{});
+        weever->SetOption(kDeleteStatements, std::unordered_set<size_t>{});
+        weever->SetOption(kUpdateStatements, config::InputTable(std::move(upd_tbl)));
+
+        auto t0 = std::chrono::steady_clock::now();
+        weever->Execute();
+        auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0);
+
+        if ((b + 1) % 5 == 0) {
+            std::printf("(%zu, %ld) ", b + 1, ms.count());
+        }
+        if ((b + 1) % 25 == 0) {
+            std::cout << std::endl;
+            // std::printf("vc: %ld\n", weever->GetViolationsSize());
+        }
+    }
+}
+
+TEST(WeeverBatchSizeBenchmark, TaxBatchComparison) {
+    static constexpr size_t kBatchSize = 100;
+    static constexpr size_t kBatchesPerMeasurement = 10;
+    static constexpr size_t kNumMeasurements = 1000;
+
+    std::string const dc = "!(s.State == t.State and s.Salary > t.Salary and s.Rate < t.Rate)";
+    std::vector<std::string> const tax_cols = {
+            "FName",  "LName", "Gender",      "AreaCode",      "Phone",
+            "City",   "State", "Zip",         "MaritalStatus", "HasChild",
+            "Salary", "Rate",  "SingleExemp", "MarriedExemp",  "ChildExemp"};
+
+    std::vector<model::IDatasetStream::Row> all_tax_rows;
+    {
+        auto parser = std::make_shared<CSVParser>(kTax);
+        while (parser->HasNextRow()) all_tax_rows.push_back(parser->GetNextRow());
+    }
+
+    std::mt19937_64 rng(42);
+    std::uniform_int_distribution<size_t> dist(0, all_tax_rows.size() - 1);
+
+    auto empty_table = std::make_shared<MockTable>("tax_empty", tax_cols,
+                                                   std::vector<model::IDatasetStream::Row>{});
+    algos::StdParamsMap params = {
+            {kTable, config::InputTable(empty_table)},
+            {kDenialConstraint, dc},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    // weever->Execute();
+    std::fprintf(stderr, "Starting inserts into empty table\n");
+
+    std::printf("\\addplot coordinates {\n");
+
+    size_t total_rows = 0;
+    for (size_t m = 0; m < kNumMeasurements; ++m) {
+        auto t0 = std::chrono::steady_clock::now();
+
+        for (size_t b = 0; b < kBatchesPerMeasurement; ++b) {
+            std::vector<model::IDatasetStream::Row> batch;
+            batch.reserve(kBatchSize);
+            for (size_t i = 0; i < kBatchSize; ++i) {
+                batch.push_back(all_tax_rows[dist(rng)]);
+            }
+            auto ins_tbl = std::make_shared<MockTable>("ins", tax_cols, std::move(batch));
+
+            weever->SetOption(kInsertStatements, config::InputTable(std::move(ins_tbl)));
+            weever->SetOption(kDeleteStatements, std::unordered_set<size_t>{});
+            weever->SetOption(kUpdateStatements, config::InputTable{});
+            weever->Execute();
+        }
+
+        long long const ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now() - t0)
+                                     .count();
+
+        total_rows += kBatchesPerMeasurement * kBatchSize;
+        std::printf("(%zu, %lld) ", total_rows, ms);
+        if ((m + 1) % 5 == 0) std::printf("\n");
+    }
+
+    std::printf("};\n");
+    std::fflush(stdout);
+}
+
+}  // namespace tests

--- a/src/tests/unit/test_lttree.cpp
+++ b/src/tests/unit/test_lttree.cpp
@@ -1,0 +1,238 @@
+#include <numeric>
+
+#include <gtest/gtest.h>
+
+#include "core/util/lttree.h"
+
+class LTTreeTest : public ::testing::Test {
+protected:
+    utils::LTTree<int> tree;
+};
+
+TEST_F(LTTreeTest, Insert) {
+    tree.Insert(10, 0);
+    tree.Insert(20, 1);
+    tree.Insert(5, 2);
+
+    EXPECT_EQ(tree.Size(), 3);  // 5 и 10 должны быть меньше 15
+}
+
+TEST_F(LTTreeTest, Size) {
+    EXPECT_EQ(tree.Size(), 0);
+    tree.Insert(10, 0);
+    EXPECT_EQ(tree.Size(), 1);
+    tree.Insert(20, 1);
+    EXPECT_EQ(tree.Size(), 2);
+}
+
+// Тест вставки элементов
+TEST_F(LTTreeTest, InsertAndSize) {
+    EXPECT_EQ(tree.Size(), 0);
+
+    tree.Insert(10, 0);
+    EXPECT_EQ(tree.Size(), 1);
+
+    tree.Insert(5, 1);
+    EXPECT_EQ(tree.Size(), 2);
+
+    tree.Insert(15, 2);
+    EXPECT_EQ(tree.Size(), 3);
+
+    tree.Insert(10, 3);  // Вставляем еще один элемент с тем же значением
+    EXPECT_EQ(tree.Size(), 4);
+}
+
+// Тест поиска элементов
+TEST_F(LTTreeTest, FindLess) {
+    tree.Insert(10, 0);
+    tree.Insert(5, 1);
+    tree.Insert(15, 2);
+    tree.Insert(3, 3);
+    tree.Insert(7, 4);
+    tree.Insert(12, 5);
+    tree.Insert(20, 6);
+
+    roaring::Roaring result = tree.FindLess(8);
+    EXPECT_TRUE(result.cardinality() > 0);
+}
+
+// Тест баланса дерева
+TEST_F(LTTreeTest, IsBalanced) {
+    tree.Insert(10, 0);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(5, 1);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(15, 2);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(3, 3);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(7, 4);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(12, 5);
+    EXPECT_TRUE(tree.IsBalanced());
+
+    tree.Insert(20, 6);
+    EXPECT_TRUE(tree.IsBalanced());
+}
+
+TEST_F(LTTreeTest, Height) {
+    int const DATA_SIZE = 6;
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    size_t height = tree.Height();
+    EXPECT_EQ(height, 3);
+}
+
+// Тест вставки дубликатов
+TEST_F(LTTreeTest, DuplicateInsert) {
+    tree.Insert(10, 0);
+    tree.Insert(10, 1);
+    tree.Insert(10, 2);
+
+    EXPECT_EQ(tree.Size(), 3);
+
+    // Все индексы должны быть связаны с одним значением
+    roaring::Roaring vec = tree.FindLess(11);
+    EXPECT_EQ(vec.cardinality(), 3);
+}
+
+TEST_F(LTTreeTest, FindLessEquivalent) {
+    for (size_t i = 0; i < 20; ++i) {
+        tree.Insert(i, i);
+    }
+
+    roaring::Roaring result_less = tree.FindLess(10);
+    EXPECT_TRUE(result_less.cardinality() > 0);
+
+    roaring::Roaring result_eq = tree.FindLess(15);
+    EXPECT_TRUE(result_eq.cardinality() - result_less.cardinality() > 0);
+}
+
+TEST_F(LTTreeTest, Contains) {
+    int const DATA_SIZE = 100;
+
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    for (int i = DATA_SIZE - 1; i >= 0; --i) {
+        EXPECT_TRUE(tree.Contains(i));
+        EXPECT_FALSE(tree.Contains(i + DATA_SIZE));
+    }
+}
+
+TEST_F(LTTreeTest, Remove) {
+    int const DATA_SIZE = 100;
+
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    std::vector<size_t> expected_indices(DATA_SIZE);
+    std::iota(expected_indices.begin(), expected_indices.end(), 0);
+
+    for (int i = DATA_SIZE - 1; i >= 0; --i) {
+        tree.Remove(i, i);
+        EXPECT_TRUE(tree.IsBalanced());
+        EXPECT_FALSE(tree.Contains(i, i));
+        EXPECT_EQ(tree.Size(), i);
+
+        for (int j = 0; j < i; ++j) {
+            EXPECT_TRUE(tree.Contains(j, j));
+        }
+
+        expected_indices.pop_back();
+        auto indices = utils::LTTree<int>::RoaringToVector(tree.FindLess(DATA_SIZE));
+
+        EXPECT_EQ(indices, expected_indices);
+    }
+}
+
+TEST_F(LTTreeTest, IteratorEmpty) {
+    auto it = tree.begin();
+    EXPECT_EQ(it, tree.end());
+}
+
+TEST_F(LTTreeTest, IteratorForward) {
+    int const DATA_SIZE = 6;
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    std::vector<size_t> res;
+    for (auto it = tree.begin(); it != tree.end(); ++it) {
+        res.push_back(it->val());
+    }
+
+    std::vector<size_t> expected_indices(DATA_SIZE);
+    std::iota(expected_indices.begin(), expected_indices.end(), 0);
+    EXPECT_EQ(res, expected_indices);
+}
+
+TEST_F(LTTreeTest, IteratorBackward) {
+    int const DATA_SIZE = 100;
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    std::vector<size_t> res;
+    auto it = std::prev(tree.end());
+    for (; it != tree.begin(); --it) {
+        res.push_back(it->val());
+    }
+    res.push_back(it->val());
+
+    std::vector<size_t> expected_indices;
+    for (int i = DATA_SIZE - 1; i >= 0; --i) {
+        expected_indices.push_back(static_cast<size_t>(i));
+    }
+    EXPECT_EQ(res, expected_indices);
+}
+
+TEST_F(LTTreeTest, IteratorSorted) {
+    int const DATA_SIZE = 100;
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i, i);
+    }
+
+    EXPECT_TRUE(std::is_sorted(tree.begin(), tree.end()));
+}
+
+TEST_F(LTTreeTest, IteratorDuplicates) {
+    int const DATA_SIZE = 100;
+    for (int i = 0; i < DATA_SIZE; ++i) {
+        tree.Insert(i % 50, i);
+    }
+
+    std::vector<int> values;
+    for (auto it = tree.begin(); it != tree.end(); ++it) {
+        values.push_back(it->val());
+    }
+
+    EXPECT_EQ(values.size(), DATA_SIZE / 2);
+}
+
+TEST_F(LTTreeTest, Salaries) {
+    std::vector<int> salaries = {3000, 4000, 5000, 5000, 6000, 4000, 1000, 2000, 3000, 3000};
+    size_t index = 2;
+    for (auto x : salaries) {
+        tree.Insert(x, index++);
+    }
+    auto res = tree.FindLess(3100);
+    roaring::Roaring expected = {2, 8, 9, 10, 11};
+    EXPECT_EQ(res, expected);
+
+    tree.Remove(3000, 11);
+    tree.Insert(3100, 11);
+
+    res = tree.FindLess(3100);
+    expected = {2, 8, 9, 10};
+    EXPECT_EQ(res, expected);
+}

--- a/src/tests/unit/test_typed_dynamic_row_table_data.cpp
+++ b/src/tests/unit/test_typed_dynamic_row_table_data.cpp
@@ -1,0 +1,689 @@
+// Tests for TypedDynamicRowTableData.
+//
+// NOTE: All tables in this file use the same 3-column schema {Int, Double, String}.
+// This is required to work around the static row_size bug in AppendRow: the row buffer
+// size is computed once from the first AppendRow call and reused across all instances,
+// so mixing schemas in a single test run would corrupt memory.
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "core/model/table/dynamic_data/typed_dynamic_row_table_data.h"
+#include "core/model/table/idataset_stream.h"
+#include "core/model/types/builtin.h"
+#include "core/model/types/type.h"
+
+namespace tests {
+namespace {
+
+class MockDatasetStream : public model::IDatasetStream {
+public:
+    MockDatasetStream(std::vector<std::string> col_names,
+                      std::vector<std::vector<std::string>> rows)
+        : col_names_(std::move(col_names)), rows_(std::move(rows)), pos_(0) {}
+
+    Row GetNextRow() override {
+        return rows_[pos_++];
+    }
+
+    bool HasNextRow() const override {
+        return pos_ < rows_.size();
+    }
+
+    size_t GetNumberOfColumns() const override {
+        return col_names_.size();
+    }
+
+    std::string GetColumnName(size_t index) const override {
+        return col_names_.at(index);
+    }
+
+    std::string GetRelationName() const override {
+        return "test";
+    }
+
+    void Reset() override {
+        pos_ = 0;
+    }
+
+private:
+    std::vector<std::string> col_names_;
+    std::vector<std::vector<std::string>> rows_;
+    size_t pos_;
+};
+
+// Standard 3-column schema used by all tests: {Int, Double, String}.
+static std::vector<std::string> const kCols{"id", "score", "label"};
+static std::vector<std::vector<std::string>> const kRows{
+        {"1", "1.5", "alice"},
+        {"2", "2.5", "bob"},
+        {"3", "3.5", "charlie"},
+};
+static std::vector<std::string> const kNewRow{"4", "4.5", "dave"};
+static std::vector<std::string> const kUpdatedRow{"99", "9.9", "zara"};
+
+// Helper: returns the single ID present in `after` but not in `before`.
+size_t FindNewId(std::set<size_t> const& before, std::set<size_t> const& after) {
+    for (size_t id : after) {
+        if (!before.count(id)) return id;
+    }
+    // Should never happen in a well-behaved test.
+    return std::numeric_limits<size_t>::max();
+}
+
+}  // namespace
+
+// ====================== CONSTRUCTION ======================
+
+TEST(TypedDynamicRowTableData, GetNumCols) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetNumCols(), 3u);
+}
+
+TEST(TypedDynamicRowTableData, GetNumRows_AfterConstruction) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetNumRows(), 3u);
+}
+
+// ====================== EMPTY TABLE ======================
+
+TEST(TypedDynamicRowTableData, EmptyTable_ZeroRows) {
+    MockDatasetStream stream(kCols, {});
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetNumRows(), 0u);
+}
+
+TEST(TypedDynamicRowTableData, EmptyTable_ColumnCountPreserved) {
+    MockDatasetStream stream(kCols, {});
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetNumCols(), 3u);
+}
+
+TEST(TypedDynamicRowTableData, EmptyTable_AllIdsIsEmpty) {
+    MockDatasetStream stream(kCols, {});
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_TRUE(table.GetAllIds().empty());
+}
+
+TEST(TypedDynamicRowTableData, EmptyTable_TrackingSetsAreEmpty) {
+    MockDatasetStream stream(kCols, {});
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_TRUE(table.GetInserted().empty());
+    EXPECT_TRUE(table.GetUpdated().empty());
+    EXPECT_TRUE(table.GetDeleted().empty());
+}
+
+// ====================== TYPE INFERENCE ======================
+
+TEST(TypedDynamicRowTableData, GetTypes_ReturnsThreeTypes) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetTypes().size(), 3u);
+}
+
+TEST(TypedDynamicRowTableData, TypeInference_IntColumn) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetTypes()[0]->GetTypeId(), +model::TypeId::kInt);
+}
+
+TEST(TypedDynamicRowTableData, TypeInference_DoubleColumn) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetTypes()[1]->GetTypeId(), +model::TypeId::kDouble);
+}
+
+TEST(TypedDynamicRowTableData, TypeInference_StringColumn) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetTypes()[2]->GetTypeId(), +model::TypeId::kString);
+}
+
+// ====================== ROW EXISTS ======================
+
+TEST(TypedDynamicRowTableData, RowExists_TrueForAllInitialRows) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    for (size_t i = 0; i < kRows.size(); ++i) {
+        EXPECT_TRUE(table.RowExists(i)) << "Expected row " << i << " to exist";
+    }
+}
+
+TEST(TypedDynamicRowTableData, RowExists_FalseForOutOfRangeId) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_FALSE(table.RowExists(100));
+}
+
+// ====================== GET ALL IDs ======================
+
+TEST(TypedDynamicRowTableData, GetAllIds_ContainsAllInitialRowIds) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    std::set<size_t> const expected{0, 1, 2};
+    EXPECT_EQ(table.GetAllIds(), expected);
+}
+
+// ====================== INITIAL TRACKING SETS ======================
+
+TEST(TypedDynamicRowTableData, InitialTrackingSets_AreAllEmpty) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_TRUE(table.GetInserted().empty());
+    EXPECT_TRUE(table.GetUpdated().empty());
+    EXPECT_TRUE(table.GetDeleted().empty());
+}
+
+// ====================== GET VALUE ======================
+
+TEST(TypedDynamicRowTableData, GetValue_IntColumnFirstRow) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    std::byte const* val = table.GetValue(0, 0);
+    EXPECT_EQ(model::Type::GetValue<model::Int>(val), 1);
+}
+
+TEST(TypedDynamicRowTableData, GetValue_DoubleColumnFirstRow) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    std::byte const* val = table.GetValue(0, 1);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(val), 1.5);
+}
+
+TEST(TypedDynamicRowTableData, GetValue_StringColumnFirstRow) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    std::byte const* val = table.GetValue(0, 2);
+    EXPECT_EQ(model::Type::GetValue<model::String>(val), "alice");
+}
+
+TEST(TypedDynamicRowTableData, GetValue_IntColumnAllRows) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    for (size_t r = 0; r < kRows.size(); ++r) {
+        auto val = model::Type::GetValue<model::Int>(table.GetValue(r, 0));
+        EXPECT_EQ(val, static_cast<model::Int>(r + 1)) << "Row " << r;
+    }
+}
+
+TEST(TypedDynamicRowTableData, GetValue_StringColumnAllRows) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    std::vector<std::string> const expected_names{"alice", "bob", "charlie"};
+    for (size_t r = 0; r < kRows.size(); ++r) {
+        auto val = model::Type::GetValue<model::String>(table.GetValue(r, 2));
+        EXPECT_EQ(val, expected_names[r]) << "Row " << r;
+    }
+}
+
+// ====================== GET ROW ======================
+
+TEST(TypedDynamicRowTableData, GetRow_ReturnsCorrectNumberOfValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetRow(0).size(), 3u);
+}
+
+TEST(TypedDynamicRowTableData, GetRow_ValuesMatchGetValue) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const row = table.GetRow(1);
+    ASSERT_EQ(row.size(), 3u);
+    EXPECT_EQ(row[0], table.GetValue(1, 0));
+    EXPECT_EQ(row[1], table.GetValue(1, 1));
+    EXPECT_EQ(row[2], table.GetValue(1, 2));
+}
+
+TEST(TypedDynamicRowTableData, GetRow_CorrectTypedValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const row = table.GetRow(2);
+    EXPECT_EQ(model::Type::GetValue<model::Int>(row[0]), 3);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(row[1]), 3.5);
+    EXPECT_EQ(model::Type::GetValue<model::String>(row[2]), "charlie");
+}
+
+// ====================== GET COL ======================
+
+TEST(TypedDynamicRowTableData, GetCol_ReturnsCorrectSize) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    EXPECT_EQ(table.GetCol(0).size(), kRows.size());
+    EXPECT_EQ(table.GetCol(1).size(), kRows.size());
+    EXPECT_EQ(table.GetCol(2).size(), kRows.size());
+}
+
+TEST(TypedDynamicRowTableData, GetCol_IntColumnValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const col = table.GetCol(0);
+    ASSERT_EQ(col.size(), 3u);
+    // Column contains IDs 1, 2, 3 (in all_ids_ order = 0, 1, 2 → values 1, 2, 3).
+    std::vector<model::Int> actual;
+    for (std::byte const* p : col) actual.push_back(model::Type::GetValue<model::Int>(p));
+    std::sort(actual.begin(), actual.end());
+    EXPECT_EQ(actual, (std::vector<model::Int>{1, 2, 3}));
+}
+
+TEST(TypedDynamicRowTableData, GetCol_DoubleColumnValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const col = table.GetCol(1);
+    ASSERT_EQ(col.size(), 3u);
+    std::vector<model::Double> actual;
+    for (std::byte const* p : col) actual.push_back(model::Type::GetValue<model::Double>(p));
+    std::sort(actual.begin(), actual.end());
+    EXPECT_EQ(actual, (std::vector<model::Double>{1.5, 2.5, 3.5}));
+}
+
+TEST(TypedDynamicRowTableData, GetCol_StringColumnValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const col = table.GetCol(2);
+    ASSERT_EQ(col.size(), 3u);
+    std::vector<std::string> actual;
+    for (std::byte const* p : col) actual.push_back(model::Type::GetValue<model::String>(p));
+    std::sort(actual.begin(), actual.end());
+    EXPECT_EQ(actual, (std::vector<std::string>{"alice", "bob", "charlie"}));
+}
+
+TEST(TypedDynamicRowTableData, GetCol_AfterDelete_SizeDecreases) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    EXPECT_EQ(table.GetCol(0).size(), 2u);
+}
+
+TEST(TypedDynamicRowTableData, GetCol_AfterDelete_RemovedValueAbsent) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);  // removes row with id=2, score=2.5, label="bob"
+    auto const col = table.GetCol(0);
+    for (std::byte const* p : col) {
+        EXPECT_NE(model::Type::GetValue<model::Int>(p), 2) << "Deleted row value still in column";
+    }
+}
+
+// ====================== DELETE ROW ======================
+
+TEST(TypedDynamicRowTableData, DeleteRow_RowNoLongerExists) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    EXPECT_FALSE(table.RowExists(1));
+}
+
+TEST(TypedDynamicRowTableData, DeleteRow_OtherRowsStillExist) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    EXPECT_TRUE(table.RowExists(0));
+    EXPECT_TRUE(table.RowExists(2));
+}
+
+TEST(TypedDynamicRowTableData, DeleteRow_DecreasesRowCount) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    size_t const before = table.GetNumRows();
+    table.DeleteRow(0);
+    EXPECT_EQ(table.GetNumRows(), before - 1);
+}
+
+TEST(TypedDynamicRowTableData, DeleteRow_AddsToDeletedSet) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(2);
+    EXPECT_EQ(table.GetDeleted().count(2), 1u);
+}
+
+TEST(TypedDynamicRowTableData, DeleteRow_DoesNotAffectInsertedOrUpdatedSets) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    EXPECT_TRUE(table.GetInserted().empty());
+    EXPECT_TRUE(table.GetUpdated().empty());
+}
+
+TEST(TypedDynamicRowTableData, DeleteRow_RemovesFromAllIds) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    auto const ids = table.GetAllIds();
+    EXPECT_EQ(ids.count(1), 0u);
+    EXPECT_EQ(ids.size(), 2u);
+}
+
+TEST(TypedDynamicRowTableData, MultipleDeletes_ReduceRowCountCorrectly) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    table.DeleteRow(2);
+    EXPECT_EQ(table.GetNumRows(), 1u);
+}
+
+TEST(TypedDynamicRowTableData, MultipleDeletes_AllDeletedIdsTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    table.DeleteRow(1);
+    auto const& deleted = table.GetDeleted();
+    EXPECT_EQ(deleted.count(0), 1u);
+    EXPECT_EQ(deleted.count(1), 1u);
+}
+
+TEST(TypedDynamicRowTableData, DeleteAllRows_EmptiesTable) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    table.DeleteRow(1);
+    table.DeleteRow(2);
+    EXPECT_EQ(table.GetNumRows(), 0u);
+    EXPECT_TRUE(table.GetAllIds().empty());
+}
+
+TEST(TypedDynamicRowTableData, DeleteAllRows_AllIdsTrackedAsDeleted) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    for (size_t i = 0; i < kRows.size(); ++i) table.DeleteRow(i);
+    auto const& deleted = table.GetDeleted();
+    for (size_t i = 0; i < kRows.size(); ++i) {
+        EXPECT_EQ(deleted.count(i), 1u) << "Row " << i << " not in deleted set";
+    }
+}
+
+// ====================== APPEND ROW ======================
+
+TEST(TypedDynamicRowTableData, AppendRow_IncreasesRowCount) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    size_t const before = table.GetNumRows();
+    table.AppendRow(kNewRow);
+    EXPECT_EQ(table.GetNumRows(), before + 1);
+}
+
+TEST(TypedDynamicRowTableData, AppendRow_NewRowExists) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+    EXPECT_TRUE(table.RowExists(new_id));
+}
+
+TEST(TypedDynamicRowTableData, AppendRow_AddsToInsertedSet) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+    EXPECT_EQ(table.GetInserted().count(new_id), 1u);
+}
+
+TEST(TypedDynamicRowTableData, AppendRow_AddsToAllIds) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+    EXPECT_EQ(table.GetAllIds().count(new_id), 1u);
+}
+
+TEST(TypedDynamicRowTableData, AppendRow_ValuesAreCorrect) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(new_id, 0)), 4);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(table.GetValue(new_id, 1)), 4.5);
+    EXPECT_EQ(model::Type::GetValue<model::String>(table.GetValue(new_id, 2)), "dave");
+}
+
+TEST(TypedDynamicRowTableData, AppendRow_DoesNotAffectUpdatedOrDeletedSets) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.AppendRow(kNewRow);
+    EXPECT_TRUE(table.GetUpdated().empty());
+    EXPECT_TRUE(table.GetDeleted().empty());
+}
+
+TEST(TypedDynamicRowTableData, MultipleAppends_RowCountGrowsCorrectly) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.AppendRow({"4", "4.5", "dave"});
+    table.AppendRow({"5", "5.5", "eve"});
+    EXPECT_EQ(table.GetNumRows(), kRows.size() + 2);
+}
+
+TEST(TypedDynamicRowTableData, MultipleAppends_IdsAreDistinct) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow({"4", "4.5", "dave"});
+    size_t const id1 = FindNewId(ids_before, table.GetAllIds());
+    auto const ids_mid = table.GetAllIds();
+    table.AppendRow({"5", "5.5", "eve"});
+    size_t const id2 = FindNewId(ids_mid, table.GetAllIds());
+    EXPECT_NE(id1, id2);
+    EXPECT_TRUE(table.RowExists(id1));
+    EXPECT_TRUE(table.RowExists(id2));
+}
+
+TEST(TypedDynamicRowTableData, MultipleAppends_AllInsertedIdsTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow({"4", "4.5", "dave"});
+    size_t const id1 = FindNewId(ids_before, table.GetAllIds());
+    auto const ids_mid = table.GetAllIds();
+    table.AppendRow({"5", "5.5", "eve"});
+    size_t const id2 = FindNewId(ids_mid, table.GetAllIds());
+    auto const& inserted = table.GetInserted();
+    EXPECT_EQ(inserted.count(id1), 1u);
+    EXPECT_EQ(inserted.count(id2), 1u);
+}
+
+// ====================== UPDATE ROW ======================
+
+TEST(TypedDynamicRowTableData, UpdateRow_ChangesIntValue) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(0, 0)), 99);
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_ChangesDoubleValue) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(table.GetValue(0, 1)), 9.9);
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_ChangesStringValue) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    EXPECT_EQ(model::Type::GetValue<model::String>(table.GetValue(0, 2)), "zara");
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_AddsToUpdatedSet) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(1, kUpdatedRow);
+    EXPECT_EQ(table.GetUpdated().count(1), 1u);
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_RowStillExists) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(2, kUpdatedRow);
+    EXPECT_TRUE(table.RowExists(2));
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_DoesNotChangeRowCount) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    size_t const before = table.GetNumRows();
+    table.UpdateRow(0, kUpdatedRow);
+    EXPECT_EQ(table.GetNumRows(), before);
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_DoesNotAffectInsertedOrDeletedSets) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    EXPECT_TRUE(table.GetInserted().empty());
+    EXPECT_TRUE(table.GetDeleted().empty());
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_GetRowReflectsNewValues) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(2, kUpdatedRow);
+    auto const row = table.GetRow(2);
+    ASSERT_EQ(row.size(), 3u);
+    EXPECT_EQ(model::Type::GetValue<model::Int>(row[0]), 99);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(row[1]), 9.9);
+    EXPECT_EQ(model::Type::GetValue<model::String>(row[2]), "zara");
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_GetColReflectsNewValue) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);  // id column: 1 → 99
+    auto const col = table.GetCol(0);
+    bool found = false;
+    for (std::byte const* p : col) {
+        if (model::Type::GetValue<model::Int>(p) == 99) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "Updated value not reflected in GetCol";
+}
+
+TEST(TypedDynamicRowTableData, MultipleUpdates_AllUpdatedIdsTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    table.UpdateRow(2, kUpdatedRow);
+    auto const& updated = table.GetUpdated();
+    EXPECT_EQ(updated.count(0), 1u);
+    EXPECT_EQ(updated.count(2), 1u);
+}
+
+TEST(TypedDynamicRowTableData, UpdateRow_DoesNotAffectOtherRows) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    // Row 1 should still have original values.
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(1, 0)), 2);
+    EXPECT_DOUBLE_EQ(model::Type::GetValue<model::Double>(table.GetValue(1, 1)), 2.5);
+    EXPECT_EQ(model::Type::GetValue<model::String>(table.GetValue(1, 2)), "bob");
+}
+
+// ====================== COMPLEX SCENARIOS ======================
+
+TEST(TypedDynamicRowTableData, DeleteThenAppend_IdsAreDistinctFromDeleted) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    EXPECT_EQ(table.GetNumRows(), 2u);
+
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+
+    EXPECT_TRUE(table.RowExists(new_id));
+    EXPECT_FALSE(table.RowExists(0));
+    EXPECT_EQ(table.GetNumRows(), 3u);
+}
+
+TEST(TypedDynamicRowTableData, DeleteThenAppend_BothSetsTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+
+    EXPECT_EQ(table.GetDeleted().count(1), 1u);
+    EXPECT_EQ(table.GetInserted().count(new_id), 1u);
+}
+
+TEST(TypedDynamicRowTableData, UpdateThenDelete_BothSetsTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.UpdateRow(0, kUpdatedRow);
+    table.DeleteRow(0);
+
+    EXPECT_FALSE(table.RowExists(0));
+    EXPECT_EQ(table.GetUpdated().count(0), 1u);
+    EXPECT_EQ(table.GetDeleted().count(0), 1u);
+}
+
+TEST(TypedDynamicRowTableData, AppendThenUpdate_InsertAndUpdateBothTracked) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+    table.UpdateRow(new_id, kUpdatedRow);
+
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(new_id, 0)), 99);
+    EXPECT_EQ(table.GetInserted().count(new_id), 1u);
+    EXPECT_EQ(table.GetUpdated().count(new_id), 1u);
+}
+
+TEST(TypedDynamicRowTableData, GetAllIds_AfterMixedOperations) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    // initial: {0, 1, 2}
+    table.DeleteRow(0);  // {1, 2}
+    auto const ids_before = table.GetAllIds();
+    table.AppendRow(kNewRow);  // {1, 2, new_id}
+    size_t const new_id = FindNewId(ids_before, table.GetAllIds());
+
+    std::set<size_t> const expected{1, 2, new_id};
+    EXPECT_EQ(table.GetAllIds(), expected);
+}
+
+TEST(TypedDynamicRowTableData, DeleteAndUpdateSeparateRows_BothSetsIndependent) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(0);
+    table.UpdateRow(2, kUpdatedRow);
+
+    EXPECT_EQ(table.GetDeleted().count(0), 1u);
+    EXPECT_EQ(table.GetUpdated().count(2), 1u);
+    EXPECT_EQ(table.GetDeleted().count(2), 0u);
+    EXPECT_EQ(table.GetUpdated().count(0), 0u);
+}
+
+TEST(TypedDynamicRowTableData, AppendMultiple_RowCountGrowsCorrectly) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.AppendRow({"4", "4.5", "dave"});
+    table.AppendRow({"5", "5.5", "eve"});
+    table.AppendRow({"6", "6.5", "frank"});
+    EXPECT_EQ(table.GetNumRows(), kRows.size() + 3);
+}
+
+TEST(TypedDynamicRowTableData, DeleteMiddle_RemainingRowValuesUnchanged) {
+    MockDatasetStream stream(kCols, kRows);
+    model::TypedDynamicRowTableData table(stream);
+    table.DeleteRow(1);
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(0, 0)), 1);
+    EXPECT_EQ(model::Type::GetValue<model::String>(table.GetValue(0, 2)), "alice");
+    EXPECT_EQ(model::Type::GetValue<model::Int>(table.GetValue(2, 0)), 3);
+    EXPECT_EQ(model::Type::GetValue<model::String>(table.GetValue(2, 2)), "charlie");
+}
+
+}  // namespace tests

--- a/src/tests/unit/test_weever.cpp
+++ b/src/tests/unit/test_weever.cpp
@@ -1,0 +1,350 @@
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "core/algorithms/algo_factory.h"
+#include "core/algorithms/dc/weever/weever.h"
+#include "core/config/names.h"
+#include "core/config/tabular_data/input_table_type.h"
+#include "core/model/table/idataset_stream.h"
+#include "tests/common/all_csv_configs.h"
+#include "tests/common/csv_config_util.h"
+#include "tests/mock/mock_input_table.h"
+
+namespace tests {
+
+using namespace algos;
+using namespace config::names;
+
+// DC: no two same-state tuples where lower salary has higher tax rate.
+static std::string const kSalaryDC =
+        "!(s.State == t.State and s.Salary <= t.Salary and s.FedTaxRate >= t.FedTaxRate)";
+
+static std::vector<std::string> const kSalaryColumns = {"State", "Salary", "FedTaxRate"};
+
+static void ApplyAndExecute(Weever& weever, config::InputTable inserts = {},
+                            std::unordered_set<size_t> deletes = {},
+                            config::InputTable updates = {}) {
+    weever.SetOption(kInsertStatements, std::move(inserts));
+    weever.SetOption(kDeleteStatements, std::move(deletes));
+    weever.SetOption(kUpdateStatements, std::move(updates));
+    weever.Execute();
+}
+
+TEST(Weever, Delete) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC5},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_TRUE(!weever->GetViolations().empty());
+
+    ApplyAndExecute(*weever, {}, {5, 10, 15});
+    std::vector<dc::Violation> expected = {{8, 6}, {8, 7}, {8, 9}, {14, 13}};
+    auto actual = weever->GetViolations();
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(actual));
+
+    ApplyAndExecute(*weever, {}, {8, 13});
+    EXPECT_TRUE(weever->GetViolations().empty());
+}
+
+TEST(Weever, Insert) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    ApplyAndExecute(*weever, {}, {11});
+
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kWeeverInsertRows = {{"Texas", "5000", "0.05"}};
+    config::InputTable input_table =
+            std::make_shared<MockTable>("insert", kSalaryColumns, kWeeverInsertRows);
+    ApplyAndExecute(*weever, input_table, {});
+    std::vector<dc::Violation> expected = {{10, 12}, {9, 12}, {8, 12}};
+    auto actual = weever->GetViolations();
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(actual));
+}
+
+TEST(Weever, DeleteInsert) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_TRUE(!weever->GetViolations().empty());
+
+    ApplyAndExecute(*weever, {}, {11});
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kWeeverInsertRows = {{"Texas", "3000", "0.31"}};
+    config::InputTable input_table =
+            std::make_shared<MockTable>("insert", kSalaryColumns, kWeeverInsertRows);
+    ApplyAndExecute(*weever, input_table, {});
+    std::vector<dc::Violation> expected = {{12, 10}};
+    auto actual = weever->GetViolations();
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(actual));
+}
+
+TEST(Weever, Update) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    std::vector<dc::Violation> expected = {{11, 10}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    std::vector<model::IDatasetStream::Row> const kWeeverUpdateRows = {
+            {"11", "Texas", "3100", "0.31"}};
+    auto update_table = std::make_shared<MockTable>("update", kSalaryColumns, kWeeverUpdateRows);
+    ApplyAndExecute(*weever, {}, {}, update_table);
+
+    EXPECT_TRUE(weever->GetViolations().empty());
+}
+
+TEST(Weever, UpdateMultiple) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC5},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_FALSE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kWeeverUpdateRows = {
+            {"5", "NewYork", "6000", "0.4"},
+            {"8", "Wisconsin", "7000", "0.3"},
+            {"10", "Texas", "5000", "0.5"},
+            {"14", "Texas", "3100", "0.31"},
+            {"15", "Texas", "4000", "0.4"}};
+    config::InputTable update_table =
+            std::make_shared<MockTable>("update", kSalaryColumns, kWeeverUpdateRows);
+    ApplyAndExecute(*weever, {}, {}, update_table);
+    EXPECT_TRUE(weever->GetViolations().empty());
+}
+
+TEST(Weever, InsertEqual) {
+    std::string const dc = "!(s.State == t.State and s.Salary == t.Salary)";
+    algos::StdParamsMap params = {{kCsvConfig, kTestDC4}, {kDenialConstraint, dc}};
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kWeeverInsertRows = {{"NewYork", "3000", "0.4"},
+                                                                       {"Texas", "5000", "0.1"}};
+    config::InputTable insert_table =
+            std::make_shared<MockTable>("insert", kSalaryColumns, kWeeverInsertRows);
+    ApplyAndExecute(*weever, insert_table);
+
+    std::vector<dc::Violation> expected = {{2, 13}, {13, 2}, {14, 9}, {9, 14}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, IncrementalInsertsAllViolate) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_TRUE(!weever->GetViolations().empty());
+
+    // Delete all rows
+    ApplyAndExecute(*weever, {}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    // Convert k (1..1000) to a 3-decimal fixed-point string: 1→"0.001", 1000→"1.000"
+    auto FormatTax = [](size_t k) -> std::string {
+        std::string s = std::to_string(k);
+        while (s.size() < 4) s = "0" + s;
+        return s.substr(0, s.size() - 3) + "." + s.substr(s.size() - 3);
+    };
+
+    size_t kFirstId = 12;
+    size_t kNumTuples = 1000;
+
+    std::vector<model::IDatasetStream::Row> rows;
+    rows.reserve(kNumTuples);
+    for (size_t k = 1; k <= kNumTuples; ++k) {
+        rows.push_back({"Texas", std::to_string(kNumTuples - k), FormatTax(k)});
+    }
+    auto insertTable = std::make_shared<MockTable>("insert", kSalaryColumns, rows);
+    ApplyAndExecute(*weever, insertTable);
+
+    std::vector<dc::Violation> expected;
+    expected.reserve(kNumTuples * (kNumTuples - 1) / 2);
+    for (size_t j = kFirstId + 1; j < kFirstId + kNumTuples; ++j) {
+        for (size_t i = kFirstId; i < j; ++i) {
+            expected.push_back({j, i});
+        }
+    }
+
+    auto actual = weever->GetViolations();
+    std::sort(actual.begin(), actual.end());
+    ASSERT_THAT(expected, actual);
+}
+
+TEST(Weever, UpdateCreatesViolation) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    std::vector<dc::Violation> initial = {{11, 10}};
+    ASSERT_THAT(initial, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    std::vector<model::IDatasetStream::Row> const kUpdateRows = {{"9", "Texas", "3001", "0.29"}};
+    auto updateTable = std::make_shared<MockTable>("update", kSalaryColumns, kUpdateRows);
+    ApplyAndExecute(*weever, {}, {}, updateTable);
+
+    std::vector<dc::Violation> expected = {{10, 9}, {11, 9}, {11, 10}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, InsertNoViolation) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_FALSE(weever->GetViolations().empty());
+
+    ApplyAndExecute(*weever, {}, {10, 11});
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kInsertRows = {{"Texas", "500", "0.10"}};
+    auto insertTable = std::make_shared<MockTable>("insert", kSalaryColumns, kInsertRows);
+    ApplyAndExecute(*weever, insertTable);
+    EXPECT_TRUE(weever->GetViolations().empty());
+}
+
+TEST(Weever, IdempotentExecute) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    std::vector<dc::Violation> expected = {{11, 10}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    ApplyAndExecute(*weever);
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    ApplyAndExecute(*weever);
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, DeleteAllRows) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC5},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_FALSE(weever->GetViolations().empty());
+
+    ApplyAndExecute(*weever, {}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15});
+    EXPECT_TRUE(weever->GetViolations().empty());
+}
+
+TEST(Weever, CombinedOps) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    std::vector<dc::Violation> initial = {{11, 10}};
+    ASSERT_THAT(initial, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    std::vector<model::IDatasetStream::Row> const kInsertRows = {{"Texas", "3000", "0.50"}};
+    auto insertTable = std::make_shared<MockTable>("insert", kSalaryColumns, kInsertRows);
+    std::vector<model::IDatasetStream::Row> const kUpdateRows = {{"9", "Texas", "2100", "0.26"}};
+    auto updateTable = std::make_shared<MockTable>("update", kSalaryColumns, kUpdateRows);
+    ApplyAndExecute(*weever, insertTable, {11}, updateTable);
+
+    std::vector<dc::Violation> expected = {{12, 10}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, DeleteThenReinsert) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    EXPECT_FALSE(weever->GetViolations().empty());
+
+    ApplyAndExecute(*weever, {}, {10, 11});
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kInsertRows = {{"Texas", "3000", "0.30"},
+                                                                 {"Texas", "3000", "0.31"}};
+    auto insertTable = std::make_shared<MockTable>("insert", kSalaryColumns, kInsertRows);
+    ApplyAndExecute(*weever, insertTable);
+
+    std::vector<dc::Violation> expected = {{13, 12}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, SequentialUpdates) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+    std::vector<dc::Violation> initial = {{11, 10}};
+    ASSERT_THAT(initial, testing::UnorderedElementsAreArray(weever->GetViolations()));
+
+    std::vector<model::IDatasetStream::Row> const kUpdateResolve = {
+            {"11", "Texas", "3200", "0.35"}};
+    auto resolveTable = std::make_shared<MockTable>("update", kSalaryColumns, kUpdateResolve);
+    ApplyAndExecute(*weever, {}, {}, resolveTable);
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kUpdateRevert = {{"11", "Texas", "3000", "0.31"}};
+    auto revertTable = std::make_shared<MockTable>("update", kSalaryColumns, kUpdateRevert);
+    ApplyAndExecute(*weever, {}, {}, revertTable);
+    std::vector<dc::Violation> expected = {{11, 10}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+TEST(Weever, InsertIntoEmptyState) {
+    algos::StdParamsMap params = {
+            {kCsvConfig, kTestDC1},
+            {kDenialConstraint, kSalaryDC},
+    };
+    auto weever = algos::CreateAndLoadAlgorithm<Weever>(params);
+    weever->Execute();
+
+    ApplyAndExecute(*weever, {}, {2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    EXPECT_TRUE(weever->GetViolations().empty());
+
+    std::vector<model::IDatasetStream::Row> const kInsertRows = {
+            {"Texas", "3000", "0.30"},
+            {"Texas", "2000", "0.40"},
+            {"Texas", "1000", "0.50"},
+    };
+    auto insertTable = std::make_shared<MockTable>("insert", kSalaryColumns, kInsertRows);
+    ApplyAndExecute(*weever, insertTable);
+
+    std::vector<dc::Violation> expected = {{13, 12}, {14, 12}, {14, 13}};
+    ASSERT_THAT(expected, testing::UnorderedElementsAreArray(weever->GetViolations()));
+}
+
+}  // namespace tests


### PR DESCRIPTION
Implement Weever: incremental Denial Constraint verifier

Adds the first incremental DC verifier to Desbordante, based on Weever (Kaminsky et al., VLDB 2024).

Implemented the Weever algorithm with full CRUD support (insert/delete/update) — violations are maintained incrementally without restarting from scratch.
Implemented the LT-tree data structure based on AVL-tree for efficient inequality predicate evaluation.
Extended dynamic table infrastructure with type inference.

Benchmarked against static DCVerifier: Weever is significantly faster on both incremental and static workloads.