### PR TITLE
Fix ThreadPool race condition that fails only on MacOS

### DIFF
--- a/src/core/util/worker_thread_pool.h
+++ b/src/core/util/worker_thread_pool.h
@@ -162,6 +162,12 @@ public:
 
     ~WorkerThreadPool() {
         Terminate();
+        // Join workers before any other member is destroyed. Members are
+        // destroyed in reverse declaration order, so worker_threads_ would
+        // otherwise be destroyed AFTER working_mutex_/working_var_, allowing
+        // a worker that is still inside its unique_lock dtor to touch a
+        // destroyed mutex.
+        worker_threads_.clear();
     }
 };
 }  // namespace util

--- a/src/tests/unit/CMakeLists.txt
+++ b/src/tests/unit/CMakeLists.txt
@@ -428,6 +428,15 @@ desbordante_add_test(
     model.bitset SRCS test_bitset.cpp LIBS spdlog::spdlog_header_only Boost::headers
 )
 desbordante_add_test(
+    util.worker_thread_pool
+    SRCS
+    test_worker_thread_pool.cpp
+    LIBS
+    ${DESBORDANTE_PREFIX}::util
+    spdlog::spdlog_header_only
+    Boost::headers
+)
+desbordante_add_test(
     model.types.numeric_type_cast SRCS test_numerictype_cast.cpp LIBS better-enums Boost::headers
 )
 desbordante_add_test(

--- a/src/tests/unit/test_worker_thread_pool.cpp
+++ b/src/tests/unit/test_worker_thread_pool.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+
+#include "core/util/worker_thread_pool.h"
+
+namespace tests {
+
+TEST(WorkerThreadPool, ConstructAndDestroyWithoutWork) {
+    util::WorkerThreadPool pool{4};
+}
+
+TEST(WorkerThreadPool, RepeatedConstructAndDestroyWithoutWork) {
+    for (int i = 0; i < 100; ++i) {
+        util::WorkerThreadPool pool{4};
+    }
+}
+
+}  // namespace tests


### PR DESCRIPTION
The pool's std::mutex and std::condition_variable are declared
after worker_threads_ in the class body, so they are destroyed
before the worker JThreads are joined as members destruct in
reverse declaration order.

If a worker is still inside its unique_lock dtor when
~WorkerThreadPool returns and member destruction begins,
the worker touches a destroyed mutex. pthread_mutex_unlock on a
destroyed mutex returns EINVAL on macOS, which libc++'s
std::mutex translates into a system_error and aborts:

  libc++abi: terminating due to uncaught exception of type
  std::__1::system_error: mutex lock failed: Invalid argument

Explicitly clear worker_threads_ at the end of the dtor body.
Reordering the member declarations would also work but IMHO
current fix is better