### PR TITLE
Do not force -O1 with sanitizers

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -72,8 +72,8 @@ jobs:
         cfg:
           - { BUILD_TYPE: Release }
           - { BUILD_TYPE: Debug }
-          - { BUILD_TYPE: Debug, SANITIZER : ADDRESS }
-          - { BUILD_TYPE: Debug, SANITIZER : UB }
+          - { BUILD_TYPE: Debug, SANITIZER : ADDRESS, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1"' }
+          - { BUILD_TYPE: Debug, SANITIZER : UB, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1"' }
 
     runs-on: ${{ matrix.system.os }}
     steps:
@@ -89,7 +89,8 @@ jobs:
           export ${{ matrix.system.env }}
 
           if [[ "${{matrix.cfg.BUILD_TYPE}}" == "Debug" ]]; then
-            ./build.sh --debug --sanitizer=${{ matrix.cfg.SANITIZER }}
+            ./build.sh --debug --sanitizer=${{ matrix.cfg.SANITIZER }} \
+              --cmake-opt='${{ matrix.cfg.CMAKE_OPTS }}'
           else
             ./build.sh
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ if(POLICY CMP0175)
     cmake_policy(SET CMP0175 NEW)
 endif()
 
+# ---- Default flags ----
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-O0")
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "-O3")
+
 # ---- Project ----
 
 project(
@@ -118,9 +122,7 @@ if(DESBORDANTE_BUILD_NATIVE)
     string(JOIN ";" BUILD_OPTS "${BUILD_OPTS}" "-march=native")
 endif()
 
-# RELEASE build options
-string(JOIN ";" RELEASE_BUILD_OPTS "${BUILD_OPTS}" "-O3")
-
+set(RELEASE_BUILD_OPTS ${BUILD_OPTS})
 set(DEBUG_BUILD_OPTS "${BUILD_OPTS}")
 
 # Set common DEBUG build options
@@ -169,7 +171,6 @@ if(ASAN)
         ";"
         DEBUG_BUILD_OPTS
         "${DEBUG_BUILD_OPTS}"
-        "-O1"
         "-Wno-error" # Use of -Werror is discouraged with sanitizers
         # See https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dbuiltin
         "${ASAN_OPTS}"
@@ -196,11 +197,8 @@ elseif(UBSAN)
                "-fsanitize-ignorelist=${CMAKE_SOURCE_DIR}/ub_sanitizer_ignore_list.txt"
         )
     endif()
-    string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}" "-O1" "${UBSAN_OPTS}")
+    string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}" "${UBSAN_OPTS}")
     set(DEBUG_LINK_OPTS "${UBSAN_OPTS}")
-else()
-    # No sanitizer, just debug build
-    string(JOIN ";" DEBUG_BUILD_OPTS "${DEBUG_BUILD_OPTS}" "-O0")
 endif()
 
 if(DESBORDANTE_GDB_SYMBOLS)


### PR DESCRIPTION
Let user select the optimization level even when building with sanitizers, instead of forcing `-O1`
Explicitly set `-O1` with sanitizers in CI