### PR TITLE
Enable safe vertical hashing by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ option(DESBORDANTE_GDB_SYMBOLS "Include debug information for use by GDB" OFF)
 # - Enabled for wide datasets (>32 columns) with potential performance penalty
 option(DESBORDANTE_SAFE_VERTICAL_HASHING
        "Enable safe vertical hashing mode. Allows processing wide datasets (>32 columns) \
-    at the cost of reduced performance. Recommended for exploratory data analysis." OFF
+       at the cost of reduced performance. Recommended for exploratory data analysis." ON
 )
 option(DESBORDANTE_UNPACK_DATASETS "Unpack datasets" ON)
 option(DESBORDANTE_USE_LTO "Build using interprocedural optimization" OFF)


### PR DESCRIPTION
There are many datasets with more than 64 columns. It's unexpected that they would fail to be processed by default, especially in the pip package. This did make sense when Desbordante was a benchmarking tool where any issues like that would be handled by recompiling but not when it tries to pose as a proper library.