### PR TITLE
Add missing link_libraries in algorithms' CMakeLists

### DIFF
--- a/src/core/algorithms/CMakeLists.txt
+++ b/src/core/algorithms/CMakeLists.txt
@@ -76,6 +76,8 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE algo_factory.cpp algorithm.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::util ${DESBORDANTE_PREFIX}::config
-                    ${DESBORDANTE_PREFIX}::parser::csv spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::model::types
+    PRIVATE ${DESBORDANTE_PREFIX}::util ${DESBORDANTE_PREFIX}::config
+            ${DESBORDANTE_PREFIX}::parser::csv spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/algebraic_constraints/CMakeLists.txt
+++ b/src/core/algorithms/algebraic_constraints/CMakeLists.txt
@@ -3,6 +3,8 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE ac_algorithm.cpp ac_exception_finder.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types
-                    spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::algos Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types
+            ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::config spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/ar/CMakeLists.txt
+++ b/src/core/algorithms/ar/CMakeLists.txt
@@ -5,6 +5,8 @@ set(NAME ar)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE ar_algorithm.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::transaction ${DESBORDANTE_PREFIX}::algos
-                    magic_enum::magic_enum spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::model::transaction ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/ar/ar_verifier/CMakeLists.txt
+++ b/src/core/algorithms/ar/ar_verifier/CMakeLists.txt
@@ -2,6 +2,7 @@ set(NAME ar.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE ar_verifier.cpp ar_stats_calculator.cpp model/rule_coverage.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::ar ${DESBORDANTE_PREFIX}::algos
-                    spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::ar ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/cfd/CMakeLists.txt
+++ b/src/core/algorithms/cfd/CMakeLists.txt
@@ -23,6 +23,9 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cfd_discovery.cpp fd_first_algorithm.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::cfd::model ${DESBORDANTE_PREFIX}::cfd::util
-                    ${DESBORDANTE_PREFIX}::algos spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::cfd::model ${DESBORDANTE_PREFIX}::cfd::util
+            ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::util spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/cfd/cfd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/cfd/cfd_verifier/CMakeLists.txt
@@ -3,7 +3,12 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cfd_stats_calculator.cpp cfd_verifier.cpp)
 target_link_libraries(
     ${NAME}
-    PRIVATE ${DESBORDANTE_PREFIX}::cfd::util ${DESBORDANTE_PREFIX}::cfd::model
-            ${DESBORDANTE_PREFIX}::algos spdlog::spdlog_header_only magic_enum::magic_enum
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::cfd::util
+            ${DESBORDANTE_PREFIX}::cfd::model
+            ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only
+            magic_enum::magic_enum
             Boost::headers
 )

--- a/src/core/algorithms/cind/CMakeLists.txt
+++ b/src/core/algorithms/cind/CMakeLists.txt
@@ -5,6 +5,9 @@ set(NAME cind)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cind_algorithm.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::cind::miners ${DESBORDANTE_PREFIX}::ind::spider
-                    magic_enum::magic_enum spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::cind::miners ${DESBORDANTE_PREFIX}::ind::spider
+            ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/cind/cind_verifier/CMakeLists.txt
+++ b/src/core/algorithms/cind/cind_verifier/CMakeLists.txt
@@ -2,5 +2,8 @@ set(NAME cind.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cind_verifier.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE magic_enum::magic_enum spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/cind/condition_miners/CMakeLists.txt
+++ b/src/core/algorithms/cind/condition_miners/CMakeLists.txt
@@ -2,5 +2,8 @@ set(NAME cind.miners)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cinderella.cpp cind_miner.cpp pli_cind.cpp position_lists_set.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE magic_enum::magic_enum spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum spdlog::spdlog_header_only
+            Boost::headers
 )

--- a/src/core/algorithms/dc/CMakeLists.txt
+++ b/src/core/algorithms/dc/CMakeLists.txt
@@ -13,5 +13,7 @@ set(NAME dc.parser)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE parser/dc_parser.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::model::table
+    PRIVATE spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/dc/FastADC/CMakeLists.txt
+++ b/src/core/algorithms/dc/FastADC/CMakeLists.txt
@@ -24,6 +24,8 @@ set(NAME dc.fastadc)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE fastadc.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::dc::fastadc::structs spdlog::spdlog_header_only
-                    magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::model::table
+    PRIVATE ${DESBORDANTE_PREFIX}::dc::fastadc::structs spdlog::spdlog_header_only
+            magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/dc/verifier/CMakeLists.txt
+++ b/src/core/algorithms/dc/verifier/CMakeLists.txt
@@ -3,6 +3,7 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE dc_verifier.cpp)
 target_link_libraries(
     ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
     PRIVATE ${DESBORDANTE_PREFIX}::model::table
             ${DESBORDANTE_PREFIX}::model::types
             ${DESBORDANTE_PREFIX}::dc::model

--- a/src/core/algorithms/dc/verifier/dc_verifier.cpp
+++ b/src/core/algorithms/dc/verifier/dc_verifier.cpp
@@ -428,7 +428,7 @@ std::pair<util::Rect<Point>, util::Rect<Point>> DCVerifier::SearchRanges(
 
 bool DCVerifier::Eval(std::vector<std::byte const*> row, std::vector<dc::Predicate> preds) const {
     dc::Component left_comp, right_comp;
-    std::byte const* left_val;
+    std::byte const* left_val = nullptr;
     std::byte const* right_val;
     for (auto const& pred : preds) {
         dc::ColumnOperand left_op = pred.GetLeftOperand();

--- a/src/core/algorithms/dd/dd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/dd/dd_verifier/CMakeLists.txt
@@ -3,11 +3,13 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE dd_verifier.cpp)
 target_link_libraries(
     ${NAME}
-    PRIVATE ${DESBORDANTE_PREFIX}::dd
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::dd
             ${DESBORDANTE_PREFIX}::model::table
             ${DESBORDANTE_PREFIX}::model::types
+            ${DESBORDANTE_PREFIX}::util
             spdlog::spdlog_header_only
-            ${DESBORDANTE_PREFIX}::algos
             magic_enum::magic_enum
             Boost::headers
 )

--- a/src/core/algorithms/dd/split/CMakeLists.txt
+++ b/src/core/algorithms/dd/split/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${NAME} PRIVATE split.cpp model/distance_position_list_index.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
     ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
     PRIVATE ${DESBORDANTE_PREFIX}::dd ${DESBORDANTE_PREFIX}::model::table
             ${DESBORDANTE_PREFIX}::model::types spdlog::spdlog_header_only
             ${DESBORDANTE_PREFIX}::algos Boost::headers

--- a/src/core/algorithms/fd/CMakeLists.txt
+++ b/src/core/algorithms/fd/CMakeLists.txt
@@ -27,11 +27,15 @@ set(NAME fd)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE fd.cpp fd_algorithm.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos Boost::headers
 )
 
 # --- PliBasedFD ---
 set(NAME fd.pli)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE pli_based_fd_algorithm.cpp)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd ${DESBORDANTE_PREFIX}::util Boost::headers
+)

--- a/src/core/algorithms/fd/afd_metric/CMakeLists.txt
+++ b/src/core/algorithms/fd/afd_metric/CMakeLists.txt
@@ -4,6 +4,6 @@ desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE afd_metric_calculator.cpp)
 target_link_libraries(
     ${NAME}
-    PUBLIC magic_enum::magic_enum
-    PRIVATE Boost::headers
+    PUBLIC ${DESBORDANTE_PREFIX}::config magic_enum::magic_enum
+    PRIVATE ${DESBORDANTE_PREFIX}::util Boost::headers
 )

--- a/src/core/algorithms/fd/aidfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/aidfd/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(NAME fd.aid)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE aid.cpp search_tree.cpp)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers
+)

--- a/src/core/algorithms/fd/eulerfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/eulerfd/CMakeLists.txt
@@ -1,4 +1,8 @@
 set(NAME fd.euler)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE cluster.cpp eulerfd.cpp mlfq.cpp search_tree.cpp)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::fd Boost::headers
+)

--- a/src/core/algorithms/fd/fd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/fd/fd_verifier/CMakeLists.txt
@@ -2,8 +2,10 @@ set(NAME fd.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE fd_verifier.cpp stats_calculator.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::model::table
-                    magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum
+            Boost::headers
 )
 
 set(NAME fd.verifier.dynamic)

--- a/src/core/algorithms/fd/fdep/CMakeLists.txt
+++ b/src/core/algorithms/fd/fdep/CMakeLists.txt
@@ -2,5 +2,7 @@ set(NAME fd.fdep)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE fdep.cpp fd_tree_element.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::fd spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/fd/hycommon/CMakeLists.txt
+++ b/src/core/algorithms/fd/hycommon/CMakeLists.txt
@@ -4,5 +4,7 @@ target_sources(
     ${NAME} PRIVATE all_column_combinations.cpp preprocessor.cpp sampler.cpp validator_helpers.cpp
 )
 target_link_libraries(
-    ${NAME} PRIVATE Boost::thread ${DESBORDANTE_PREFIX}::fd::hy::model spdlog::spdlog_header_only
+    ${NAME}
+    PUBLIC Boost::headers
+    PRIVATE Boost::thread ${DESBORDANTE_PREFIX}::fd::hy::model spdlog::spdlog_header_only
 )

--- a/src/core/algorithms/fd/hyfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/hyfd/CMakeLists.txt
@@ -8,6 +8,7 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE hyfd.cpp inductor.cpp validator.cpp)
 target_link_libraries(
     ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
     PRIVATE ${DESBORDANTE_PREFIX}::fd::hy::common ${DESBORDANTE_PREFIX}::fd::hy::model
             ${DESBORDANTE_PREFIX}::fd::pli spdlog::spdlog_header_only magic_enum::magic_enum
             Boost::headers

--- a/src/core/algorithms/fd/pfd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/fd/pfd_verifier/CMakeLists.txt
@@ -2,5 +2,7 @@ set(NAME fd.pfd_verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE pfd_verifier.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/fd/sfd/CMakeLists.txt
+++ b/src/core/algorithms/fd/sfd/CMakeLists.txt
@@ -2,5 +2,7 @@ set(NAME fd.sfd.cords)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE contingency_table.cpp cords.cpp frequency_handler.cpp sample.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::fd magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::model::table
+    PRIVATE ${DESBORDANTE_PREFIX}::fd magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/fsm/gspan/CMakeLists.txt
+++ b/src/core/algorithms/fsm/gspan/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(
     PUBLIC FILE_SET HEADERS BASE_DIRS "${PROJECT_SOURCE_DIR}/src"
 )
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::algos spdlog::spdlog_header_only magic_enum::magic_enum
-                    Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/gfd/CMakeLists.txt
+++ b/src/core/algorithms/gfd/CMakeLists.txt
@@ -4,4 +4,6 @@ add_subdirectory(gfd_validator)
 set(NAME gfd)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE comparator.cpp gfd.cpp)
-target_link_libraries(${NAME} PRIVATE Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::util Boost::headers
+)

--- a/src/core/algorithms/gfd/gfd_miner/CMakeLists.txt
+++ b/src/core/algorithms/gfd/gfd_miner/CMakeLists.txt
@@ -3,7 +3,12 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE gfd_miner.cpp)
 target_link_libraries(
     ${NAME}
-    PRIVATE ${DESBORDANTE_PREFIX}::parser::graph ${DESBORDANTE_PREFIX}::gfd
-            ${DESBORDANTE_PREFIX}::algos spdlog::spdlog_header_only magic_enum::magic_enum
+    PRIVATE ${DESBORDANTE_PREFIX}::config
+            ${DESBORDANTE_PREFIX}::parser::graph
+            ${DESBORDANTE_PREFIX}::gfd
+            ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only
+            magic_enum::magic_enum
             Boost::headers
 )

--- a/src/core/algorithms/gfd/gfd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gfd/gfd_validator/CMakeLists.txt
@@ -6,7 +6,11 @@ target_sources(
 )
 target_link_libraries(
     ${NAME}
-    PRIVATE ${DESBORDANTE_PREFIX}::parser::graph spdlog::spdlog_header_only
-            ${DESBORDANTE_PREFIX}::gfd ${DESBORDANTE_PREFIX}::algos magic_enum::magic_enum
+    PRIVATE ${DESBORDANTE_PREFIX}::config
+            ${DESBORDANTE_PREFIX}::parser::graph
+            spdlog::spdlog_header_only
+            ${DESBORDANTE_PREFIX}::gfd
+            ${DESBORDANTE_PREFIX}::algos
+            magic_enum::magic_enum
             Boost::headers
 )

--- a/src/core/algorithms/ind/CMakeLists.txt
+++ b/src/core/algorithms/ind/CMakeLists.txt
@@ -7,6 +7,8 @@ set(NAME ind)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE ind.cpp ind_algorithm.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
-                    magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/ind/ind_verifier/CMakeLists.txt
+++ b/src/core/algorithms/ind/ind_verifier/CMakeLists.txt
@@ -1,4 +1,9 @@
 set(NAME ind.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE ind_verifier.cpp)
-target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only Boost::headers
+)

--- a/src/core/algorithms/ind/mind/CMakeLists.txt
+++ b/src/core/algorithms/ind/mind/CMakeLists.txt
@@ -2,6 +2,8 @@ set(NAME ind.mind)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE mind.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::create_algo spdlog::spdlog_header_only
-                    magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PRIVATE ${DESBORDANTE_PREFIX}::create_algo ${DESBORDANTE_PREFIX}::config
+            ${DESBORDANTE_PREFIX}::util spdlog::spdlog_header_only magic_enum::magic_enum
+            Boost::headers
 )

--- a/src/core/algorithms/ind/spider/CMakeLists.txt
+++ b/src/core/algorithms/ind/spider/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(NAME ind.spider)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE spider.cpp attribute.cpp)
-target_link_libraries(${NAME} PRIVATE magic_enum::magic_enum Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::util magic_enum::magic_enum Boost::headers
+)

--- a/src/core/algorithms/md/CMakeLists.txt
+++ b/src/core/algorithms/md/CMakeLists.txt
@@ -4,4 +4,9 @@ add_subdirectory(md_verifier)
 set(NAME md)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE md.cpp)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::algos Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::model::table
+            ${DESBORDANTE_PREFIX}::util Boost::headers
+)

--- a/src/core/algorithms/md/hymd/CMakeLists.txt
+++ b/src/core/algorithms/md/hymd/CMakeLists.txt
@@ -33,6 +33,8 @@ target_sources(
             preprocessing/column_matches/smith_waterman_gotoh.cpp
 )
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only
-                    magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only magic_enum::magic_enum
+            Boost::headers
 )

--- a/src/core/algorithms/md/md_verifier/CMakeLists.txt
+++ b/src/core/algorithms/md/md_verifier/CMakeLists.txt
@@ -2,6 +2,8 @@ set(NAME md.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE validation/validation.cpp md_verifier.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::md::hy ${DESBORDANTE_PREFIX}::md
-                    spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::md::hy ${DESBORDANTE_PREFIX}::md ${DESBORDANTE_PREFIX}::util
+            spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/metric/CMakeLists.txt
+++ b/src/core/algorithms/metric/CMakeLists.txt
@@ -3,6 +3,8 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE highlight_calculator.cpp metric_verifier.cpp points_calculator.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
-                    spdlog::spdlog_header_only Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
+            spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/nar/CMakeLists.txt
+++ b/src/core/algorithms/nar/CMakeLists.txt
@@ -4,5 +4,7 @@ set(NAME nar)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE nar.cpp nar_algorithm.cpp value_range.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/nar/des/CMakeLists.txt
+++ b/src/core/algorithms/nar/des/CMakeLists.txt
@@ -4,4 +4,6 @@ target_sources(
     ${NAME} PRIVATE des.cpp differential_functions.cpp encoded_nar.cpp encoded_value_range.cpp
 )
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::nar Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::nar Boost::headers
+)

--- a/src/core/algorithms/nd/CMakeLists.txt
+++ b/src/core/algorithms/nd/CMakeLists.txt
@@ -3,4 +3,8 @@ add_subdirectory(nd_verifier)
 set(NAME nd)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE nd.cpp util/get_vertical_names.cpp)
-target_link_libraries(${NAME} PRIVATE Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::model::table
+    PRIVATE ${DESBORDANTE_PREFIX}::util Boost::headers
+)

--- a/src/core/algorithms/nd/nd_verifier/CMakeLists.txt
+++ b/src/core/algorithms/nd/nd_verifier/CMakeLists.txt
@@ -5,6 +5,9 @@ target_sources(
                     util/value_combination.cpp
 )
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
-                    spdlog::spdlog_header_only magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::algos
+            ${DESBORDANTE_PREFIX}::util spdlog::spdlog_header_only magic_enum::magic_enum
+            Boost::headers
 )

--- a/src/core/algorithms/od/fastod/CMakeLists.txt
+++ b/src/core/algorithms/od/fastod/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(
 )
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only
-                    ${DESBORDANTE_PREFIX}::algos Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::algos ${DESBORDANTE_PREFIX}::model::table
+            ${DESBORDANTE_PREFIX}::util spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/od/order/CMakeLists.txt
+++ b/src/core/algorithms/od/order/CMakeLists.txt
@@ -6,6 +6,6 @@ target_sources(
 )
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table spdlog::spdlog_header_only
-                    ${DESBORDANTE_PREFIX}::algos Boost::headers
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::model::table
+                    spdlog::spdlog_header_only ${DESBORDANTE_PREFIX}::algos Boost::headers
 )

--- a/src/core/algorithms/od/set_based_verifier/CMakeLists.txt
+++ b/src/core/algorithms/od/set_based_verifier/CMakeLists.txt
@@ -2,4 +2,7 @@ set(NAME od.set_based_aod_verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE verifier.cpp)
 target_link_libraries(${NAME} PUBLIC magic_enum::magic_enum)
-target_link_libraries(${NAME} PRIVATE spdlog::spdlog_header_only Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::util
+                    spdlog::spdlog_header_only Boost::headers
+)

--- a/src/core/algorithms/statistics/CMakeLists.txt
+++ b/src/core/algorithms/statistics/CMakeLists.txt
@@ -2,6 +2,8 @@ set(NAME datastats)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE data_stats.cpp statistic.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types
-                    ${DESBORDANTE_PREFIX}::algos magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table ${DESBORDANTE_PREFIX}::model::types
+            ${DESBORDANTE_PREFIX}::algos magic_enum::magic_enum Boost::headers
 )

--- a/src/core/algorithms/ucc/CMakeLists.txt
+++ b/src/core/algorithms/ucc/CMakeLists.txt
@@ -6,4 +6,8 @@ add_subdirectory(ucc_verifier)
 set(NAME ucc)
 desbordante_add_lib(NAME OBJECT)
 target_sources(${NAME} PRIVATE ucc_algorithm.cpp)
-target_link_libraries(${NAME} PRIVATE Boost::headers)
+target_link_libraries(
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE Boost::headers
+)

--- a/src/core/algorithms/ucc/ucc_verifier/CMakeLists.txt
+++ b/src/core/algorithms/ucc/ucc_verifier/CMakeLists.txt
@@ -2,5 +2,7 @@ set(NAME ucc.verifier)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE ucc_verifier.cpp)
 target_link_libraries(
-    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
+    ${NAME}
+    PUBLIC ${DESBORDANTE_PREFIX}::config
+    PRIVATE ${DESBORDANTE_PREFIX}::model::table magic_enum::magic_enum Boost::headers
 )


### PR DESCRIPTION
Fix compiler warnings and linker errors:
- Add missing `target_link_libraries` to CMakeLists.txt (dependency resolution aided by [CMake helper](https://gist.github.com/py-cyber/3e54a1afeefeff4aa531cc7927caf0fc)).
- Initialize `left_var` to silence warnings.  
