### PR TITLE
Make DataFrame reader take table name from .attrs

### DIFF
--- a/examples/basic/mining_ind.py
+++ b/examples/basic/mining_ind.py
@@ -37,3 +37,5 @@ print_table('examples/datasets/ind_datasets/course.csv')
 print()
 print('department.csv:\n')
 print_table('examples/datasets/ind_datasets/department.csv')
+
+print('See also examples/datasets/mining_ind_dataframes.py for usage with pandas DataFrames')

--- a/examples/basic/mining_ind_dataframes.py
+++ b/examples/basic/mining_ind_dataframes.py
@@ -1,0 +1,32 @@
+import csv
+
+import desbordante
+import pandas as pd
+
+
+def make_named_df(name):
+    df = pd.read_csv(f'examples/datasets/ind_datasets/{name}.csv', sep=',', header=0)
+    df.attrs['name'] = name
+    return df
+
+
+TABLES = [make_named_df(table_name) for table_name in
+          ['course', 'department', 'instructor', 'student', 'teaches']]
+
+algo = desbordante.ind.algorithms.Default()
+algo.load_data(tables=TABLES)
+algo.execute()
+inds = algo.get_inds()
+print('Found inclusion dependencies (-> means "is included in"):\n')
+for ind in inds:
+    print(ind)
+print()
+
+print('Tables for first IND:')
+print()
+first_ind = inds[0]
+for i in first_ind.get_lhs().table_index, first_ind.get_rhs().table_index:
+    df = TABLES[i]
+    print(df.attrs['name'])
+    print(TABLES[i])
+    print()

--- a/examples/test_examples/snapshots/snap_test_examples_pytest.py
+++ b/examples/test_examples/snapshots/snap_test_examples_pytest.py
@@ -2363,6 +2363,41 @@ Faculty of Sociology                  29C University st.
 Faculty of Physics                    10 Academic av.      
 Institute of Chemistry                11 Academic av.      
 Graduate School of Managemment        49 Science sq.       
+See also examples/datasets/mining_ind_dataframes.py for usage with pandas DataFrames
+'''
+
+snapshots['test_example[basic/mining_ind_dataframes.py-None-mining_ind_dataframes_output] mining_ind_dataframes_output'] = '''Found inclusion dependencies (-> means "is included in"):
+
+(course, [Department name]) -> (department, [Department name])
+(instructor, [Department name]) -> (department, [Department name])
+(student, [Department name]) -> (department, [Department name])
+(teaches, [Instructor ID]) -> (instructor, [ID])
+(teaches, [Course ID]) -> (course, [Course ID])
+
+Tables for first IND:
+
+course
+  Course ID             Title                      Department name
+0      IT-1  Computer Science  Institute of Information Technology
+1      MM-3           Algebra    Mathematics and Mechanics Faculty
+2       H-1           History                 Institute of History
+3      FL-2           English         Faculty of Foreign Languages
+4      IT-2       Programming  Institute of Information Technology
+5       S-5        Philosophy                 Faculty of Sociology
+6       P-2           Physics                   Faculty of Physics
+7       C-8         Chemistry               Institute of Chemistry
+
+department
+                       Department name            Building
+0  Institute of Information Technology      5 Academic av.
+1    Mathematics and Mechanics Faculty      3 Academic av.
+2                 Institute of History  29A University st.
+3         Faculty of Foreign Languages      10 Science sq.
+4                 Faculty of Sociology  29C University st.
+5                   Faculty of Physics     10 Academic av.
+6               Institute of Chemistry     11 Academic av.
+7       Graduate School of Managemment      49 Science sq.
+
 '''
 
 snapshots['test_example[basic/mining_list_od.py-None-mining_list_od_output] mining_list_od_output'] = '''

--- a/src/python_bindings/py_util/create_dataframe_reader.cpp
+++ b/src/python_bindings/py_util/create_dataframe_reader.cpp
@@ -24,9 +24,17 @@ static bool AllColumnsAreStrings(py::handle dataframe) {
     return dtypes[dtypes.attr("__ne__")(py::str{"string"})].attr("empty").cast<bool>();
 }
 
-config::InputTable CreateDataFrameReader(py::handle dataframe, std::string name) {
+config::InputTable CreateDataFrameReader(py::handle dataframe) {
     if (!IsDataFrame(dataframe))
         throw config::ConfigurationError("Passed object is not a dataframe");
+    std::string name = [&]() -> std::string {
+        try {
+            return py::str(dataframe.attr("attrs")["name"]);
+        } catch (py::error_already_set& e) {
+            if (!(e.matches(PyExc_KeyError) || e.matches(PyExc_AttributeError))) throw;
+            return "Pandas dataframe";
+        };
+    }();
     if (AllColumnsAreStrings(dataframe)) {
         return std::make_shared<StringDataframeReader>(dataframe, std::move(name));
     } else {

--- a/src/python_bindings/py_util/create_dataframe_reader.h
+++ b/src/python_bindings/py_util/create_dataframe_reader.h
@@ -5,6 +5,5 @@
 #include "core/config/tabular_data/input_table_type.h"
 
 namespace python_bindings {
-config::InputTable CreateDataFrameReader(pybind11::handle dataframe,
-                                         std::string name = "Pandas dataframe");
+config::InputTable CreateDataFrameReader(pybind11::handle dataframe);
 }  // namespace python_bindings


### PR DESCRIPTION
DataFrames do not have a dedicated attribute to specify their name, so there is nothing to pass to Desbordante that pattern objects can use. Before, every DataFrame was using "Pandas dataframe" as its name internally, which made it difficult to disambigulate tables in patterns that are defined on several tables, like INDs. For an example where it matters see https://groups.google.com/g/desbordante/c/BqpE5dK0EXo.

The attrs attribute on DataFrames is specifically designated for custom metadata like that. Creating a separate class just for this as in https://pandas.pydata.org/pandas-docs/stable/development/extending.html#define-original-properties would be excessive.

See also
https://github.com/pandas-dev/pandas/issues/447#issuecomment-868822049
https://github.com/pandas-dev/pandas/issues/2485
https://github.com/pandas-dev/pandas/issues/52166