### PR TITLE
Fix CI: add libicu for manylinux and macOS

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -142,8 +142,9 @@ jobs:
         with:
           only: ${{ matrix.only }}
         env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0
+          MACOSX_DEPLOYMENT_TARGET: 15.0
           CIBW_BEFORE_ALL_LINUX: >
+            yum install -y libicu-devel &&
             cd lib/boost &&
             ./bootstrap.sh --with-libraries=container,thread,graph &&
             ./b2 install -j4 --prefix=/usr &&

--- a/README.md
+++ b/README.md
@@ -170,16 +170,16 @@ To install Desbordante type:
 $ pip install desbordante
 ```
 
-However, as Desbordante core uses C++, additional requirements on the machine are imposed. Therefore this installation option may not work for everyone. Currently, only manylinux2014 (Ubuntu 20.04+, or any other linux distribution with gcc 10+) and macOS 11.0+ (arm64, x86_64) is supported. If the above does not work for you consider building from sources.
+However, as Desbordante core uses C++, additional requirements on the machine are imposed. Therefore this installation option may not work for everyone. Currently, only manylinux2014 (Ubuntu 20.04+, or any other linux distribution with gcc 10+) and macOS 15.0+ (arm64, x86_64) is supported. If the above does not work for you consider building from sources.
 
 ## Build instructions
 
 ### Ubuntu and macOS
-The following instructions were tested on Ubuntu 20.04+ LTS and macOS Sonoma 14.7+ (Apple Silicon).
+The following instructions were tested on Ubuntu 20.04+ LTS and macOS Sequoia 15.0+ (Apple Silicon).
 ### Dependencies
 Prior to cloning the repository and attempting to build the project, ensure that you have the following software:
 
-- GNU GCC, version 10+, LLVM Clang, version 16+, or Apple Clang, version 15+
+- GNU GCC, version 10+, LLVM Clang, version 16+, or Apple Clang, version 16+
 - CMake, version 3.25+
 - Boost library built with compiler you're going to use (GCC or Clang), version 1.85-1.86, 1.88+
 


### PR DESCRIPTION
The GitHub runner macos-latest runs macOS 15, and Homebrew cannot fetch ICU bottles targeted at macOS 11 on that runner. Bumping the macOS deployment target to 15.0 and ensuring ICU is installed fixes ICU-related failures in wheel builds.