### PR TITLE
Add WCOJ backend, pattern grouping and parallel execution to GDD verification

### DIFF
--- a/src/core/algorithms/gdd/gdd.cpp
+++ b/src/core/algorithms/gdd/gdd.cpp
@@ -116,8 +116,8 @@ std::optional<gdd::vertex_t> Gdd::FindPatternVertexById(std::size_t id) const {
     return it == verts.end() ? std::nullopt : std::optional{*it};
 }
 
-std::optional<gdd::vertex_t> Gdd::ResolveGraphVertex(
-        std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map, std::size_t pv_id) const {
+std::optional<gdd::vertex_t> Gdd::ResolveGraphVertex(gdd::detail::MappingT const& pg_map,
+                                                     std::size_t pv_id) const {
     if (auto const pv = FindPatternVertexById(pv_id); pv) {
         auto const gv_it = pg_map.find(*pv);
         if (gv_it == pg_map.end()) {
@@ -158,7 +158,7 @@ std::unordered_set<gdd::vertex_t> Gdd::CollectRelationTargets(gdd::graph_t const
 }
 
 std::optional<gdd::detail::ConstValue> Gdd::ResolveScalar(
-        gdd::graph_t const& g, std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
+        gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
         gdd::detail::DistanceOperand const& op) const {
     using namespace gdd::detail;
 
@@ -191,10 +191,9 @@ std::optional<gdd::detail::ConstValue> Gdd::ResolveScalar(
     return it->second;
 }
 
-bool Gdd::SatisfiesRelationConstraint(
-        gdd::graph_t const& g, std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
-        std::pair<std::size_t, std::string> const& lhs_rel,
-        gdd::detail::DistanceOperand const& rhs) const {
+bool Gdd::SatisfiesRelationConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
+                                      std::pair<std::size_t, std::string> const& lhs_rel,
+                                      gdd::detail::DistanceOperand const& rhs) const {
     using namespace gdd::detail;
 
     auto const& [lhs_pid, lhs_relname] = lhs_rel;
@@ -235,9 +234,8 @@ bool Gdd::SatisfiesRelationConstraint(
     return false;
 }
 
-bool Gdd::SatisfiesAttributeConstraint(
-        gdd::graph_t const& g, std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
-        gdd::detail::DistanceConstraint const& constraint) const {
+bool Gdd::SatisfiesAttributeConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
+                                       gdd::detail::DistanceConstraint const& constraint) const {
     auto const lhs_scalar = ResolveScalar(g, pg_map, constraint.lhs);
     auto const rhs_scalar = ResolveScalar(g, pg_map, constraint.rhs);
 
@@ -249,8 +247,7 @@ bool Gdd::SatisfiesAttributeConstraint(
     return CompareDistance(dist, constraint.op, constraint.threshold);
 }
 
-bool Gdd::SatisfiesConstraint(gdd::graph_t const& g,
-                              std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
+bool Gdd::SatisfiesConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
                               gdd::detail::DistanceConstraint const& constraint) const {
     if (auto const lhs_rel = TokenAsRelation(constraint.lhs)) {
         return SatisfiesRelationConstraint(g, pg_map, *lhs_rel, constraint.rhs);
@@ -258,9 +255,8 @@ bool Gdd::SatisfiesConstraint(gdd::graph_t const& g,
     return SatisfiesAttributeConstraint(g, pg_map, constraint);
 }
 
-GddCounterexample BuildCounterexample(
-        gdd::graph_t const& pattern, gdd::graph_t const& graph,
-        std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& mapping) {
+GddCounterexample BuildCounterexample(gdd::graph_t const& pattern, gdd::graph_t const& graph,
+                                      gdd::detail::MappingT const& mapping) {
     GddCounterexample ce{};
     ce.match.reserve(mapping.size());
 

--- a/src/core/algorithms/gdd/gdd.h
+++ b/src/core/algorithms/gdd/gdd.h
@@ -8,6 +8,8 @@
 #include <utility>
 #include <variant>
 
+#include <boost/container/flat_map.hpp>
+
 #include "core/algorithms/gdd/gdd_graph_description.h"
 #include "core/util/export.h"
 
@@ -59,6 +61,11 @@ struct DistanceConstraint {
 
 bool IsSubgraph(gdd::graph_t const& query, gdd::graph_t const& graph);
 
+using VertexT = model::gdd::vertex_t;
+using EdgeT = model::gdd::edge_t;
+using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
+using MappingT = boost::container::flat_map<VertexT, VertexT>;
+
 }  // namespace gdd::detail
 
 class DESBORDANTE_EXPORT Gdd {
@@ -81,29 +88,24 @@ private:
 
     std::optional<gdd::vertex_t> FindPatternVertexById(std::size_t id) const;
 
-    std::optional<gdd::vertex_t> ResolveGraphVertex(
-            std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
-            std::size_t pv_id) const;
+    std::optional<gdd::vertex_t> ResolveGraphVertex(gdd::detail::MappingT const& pg_map,
+                                                    std::size_t pv_id) const;
 
     std::optional<gdd::detail::ConstValue> ResolveScalar(
-            gdd::graph_t const& g, std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
+            gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
             gdd::detail::DistanceOperand const& op) const;
 
-    bool SatisfiesRelationConstraint(gdd::graph_t const& g,
-                                     std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
+    bool SatisfiesRelationConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
                                      std::pair<std::size_t, std::string> const& lhs_rel,
                                      gdd::detail::DistanceOperand const& rhs) const;
 
-    bool SatisfiesAttributeConstraint(
-            gdd::graph_t const& g, std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
-            gdd::detail::DistanceConstraint const& constraint) const;
+    bool SatisfiesAttributeConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
+                                      gdd::detail::DistanceConstraint const& constraint) const;
 
-    bool SatisfiesConstraint(gdd::graph_t const& g,
-                             std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& pg_map,
+    bool SatisfiesConstraint(gdd::graph_t const& g, gdd::detail::MappingT const& pg_map,
                              gdd::detail::DistanceConstraint const& constraint) const;
 
-    bool SatisfiesPhi(gdd::graph_t const& g,
-                      std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& map,
+    bool SatisfiesPhi(gdd::graph_t const& g, gdd::detail::MappingT const& map,
                       Phi const& phi) const {
         return std::ranges::all_of(phi, [this, &g, &map](gdd::detail::DistanceConstraint const& c) {
             return SatisfiesConstraint(g, map, c);
@@ -146,7 +148,7 @@ public:
     }
 
     bool Satisfies(gdd::graph_t const& graph,
-                   std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& map) const {
+                   gdd::detail::MappingT const& map) const {
         if (SatisfiesPhi(graph, map, lhs_)) {
             return SatisfiesPhi(graph, map, rhs_);
         }
@@ -168,8 +170,7 @@ struct GddCounterexample {
     std::vector<GddCounterexampleVertex> match;
 };
 
-GddCounterexample BuildCounterexample(
-        gdd::graph_t const& pattern, gdd::graph_t const& graph,
-        std::unordered_map<gdd::vertex_t, gdd::vertex_t> const& mapping);
+GddCounterexample BuildCounterexample(gdd::graph_t const& pattern, gdd::graph_t const& graph,
+                                      gdd::detail::MappingT const& mapping);
 
 }  // namespace model

--- a/src/core/algorithms/gdd/gdd.h
+++ b/src/core/algorithms/gdd/gdd.h
@@ -147,8 +147,7 @@ public:
                gdd::detail::IsSubgraph(other.pattern_, pattern_);
     }
 
-    bool Satisfies(gdd::graph_t const& graph,
-                   gdd::detail::MappingT const& map) const {
+    bool Satisfies(gdd::graph_t const& graph, gdd::detail::MappingT const& map) const {
         if (SatisfiesPhi(graph, map, lhs_)) {
             return SatisfiesPhi(graph, map, rhs_);
         }

--- a/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(NAME gdd.validator)
 desbordante_add_lib(NAME)
-target_sources(${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp)
+target_sources(${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::parser::graph spdlog::spdlog_header_only
                     ${DESBORDANTE_PREFIX}::gdd ${DESBORDANTE_PREFIX}::algos Boost::headers

--- a/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(NAME gdd.validator)
 desbordante_add_lib(NAME)
-target_sources(${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp bfs_qvo_strategy.cpp cost_based_qvo_strategy.cpp)
+target_sources(
+    ${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp
+                    bfs_qvo_strategy.cpp cost_based_qvo_strategy.cpp
+)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::parser::graph spdlog::spdlog_header_only
                     ${DESBORDANTE_PREFIX}::gdd ${DESBORDANTE_PREFIX}::algos Boost::headers

--- a/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(NAME gdd.validator)
 desbordante_add_lib(NAME)
-target_sources(${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp)
+target_sources(${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp bfs_qvo_strategy.cpp cost_based_qvo_strategy.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::parser::graph spdlog::spdlog_header_only
                     ${DESBORDANTE_PREFIX}::gdd ${DESBORDANTE_PREFIX}::algos Boost::headers

--- a/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
+++ b/src/core/algorithms/gdd/gdd_validator/CMakeLists.txt
@@ -1,8 +1,14 @@
 set(NAME gdd.validator)
 desbordante_add_lib(NAME)
 target_sources(
-    ${NAME} PRIVATE gdd_validator.cpp naive_gdd_validator.cpp wcoj_gdd_validator.cpp
-                    bfs_qvo_strategy.cpp cost_based_qvo_strategy.cpp
+    ${NAME}
+    PRIVATE gdd_validator.cpp
+            naive_gdd_validator.cpp
+            wcoj_gdd_validator.cpp
+            bfs_qvo_strategy.cpp
+            cost_based_qvo_strategy.cpp
+            gdd_validation_executor.cpp
+            gdd_pattern_grouping.cpp
 )
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::parser::graph spdlog::spdlog_header_only

--- a/src/core/algorithms/gdd/gdd_validator/bfs_qvo_strategy.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/bfs_qvo_strategy.cpp
@@ -1,0 +1,106 @@
+#include "qvo_strategies.h"
+
+namespace algos {
+
+std::size_t BfsQvoStrategy::GetDomainSize(VertexT pattern_vertex) const {
+    auto const it = domain_.find(pattern_vertex);
+    if (it == domain_.end()) {
+        return 0;
+    }
+    return it->second.size();
+}
+
+std::size_t BfsQvoStrategy::GetPatternDegree(VertexT vertex) const {
+    return boost::out_degree(vertex, pattern_) + boost::in_degree(vertex, pattern_);
+}
+
+bool BfsQvoStrategy::IsBetterRoot(VertexT lhs, VertexT rhs) const {
+    std::size_t const lhs_domain_size = GetDomainSize(lhs);
+    std::size_t const rhs_domain_size = GetDomainSize(rhs);
+
+    if (lhs_domain_size != rhs_domain_size) {
+        return lhs_domain_size < rhs_domain_size;
+    }
+
+    std::size_t const lhs_degree = GetPatternDegree(lhs);
+    std::size_t const rhs_degree = GetPatternDegree(rhs);
+
+    if (lhs_degree != rhs_degree) {
+        return lhs_degree > rhs_degree;
+    }
+
+    return pattern_[lhs].id < pattern_[rhs].id;
+}
+
+BfsQvoStrategy::VertexT BfsQvoStrategy::ChooseNextRoot() const {
+    bool found = false;
+    VertexT best{};
+
+    for (auto const vertex : boost::make_iterator_range(boost::vertices(pattern_))) {
+        if (visited_.contains(vertex)) {
+            continue;
+        }
+
+        if (!found || IsBetterRoot(vertex, best)) {
+            best = vertex;
+            found = true;
+        }
+    }
+
+    if (!found) {
+        throw std::logic_error("BuildQueryVertexOrder called with no unvisited vertices left");
+    }
+
+    return best;
+}
+
+void BfsQvoStrategy::EnqueueIfNeeded(VertexT vertex) {
+    if (!visited_.contains(vertex) && queued_.emplace(vertex).second) {
+        queue_.push_back(vertex);
+    }
+}
+
+void BfsQvoStrategy::EnqueueUndirectedNeighbors(VertexT vertex) {
+    for (auto const edge : boost::make_iterator_range(boost::out_edges(vertex, pattern_))) {
+        EnqueueIfNeeded(boost::target(edge, pattern_));
+    }
+
+    for (auto const edge : boost::make_iterator_range(boost::in_edges(vertex, pattern_))) {
+        EnqueueIfNeeded(boost::source(edge, pattern_));
+    }
+}
+
+void BfsQvoStrategy::VisitNext() {
+    VertexT const current = queue_.front();
+    queue_.pop_front();
+    queued_.erase(current);
+
+    if (!visited_.emplace(current).second) {
+        return;
+    }
+
+    qvo_.push_back(current);
+    EnqueueUndirectedNeighbors(current);
+}
+
+std::vector<BfsQvoStrategy::VertexT> BfsQvoStrategy::Order() {
+    qvo_.clear();
+    visited_.clear();
+    queued_.clear();
+    queue_.clear();
+
+    std::size_t const vertex_count = boost::num_vertices(pattern_);
+    qvo_.reserve(vertex_count);
+
+    while (qvo_.size() != vertex_count) {
+        if (queue_.empty()) {
+            EnqueueIfNeeded(ChooseNextRoot());
+        }
+
+        VisitNext();
+    }
+
+    return qvo_;
+}
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/cost_based_qvo_strategy.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/cost_based_qvo_strategy.cpp
@@ -1,0 +1,275 @@
+#include "core/util/logger.h"
+#include "qvo_strategies.h"
+
+namespace algos {
+
+void CostBasedQvoStrategy::ComputeAvgListSizes() {
+    struct Acc {
+        std::uint64_t sum = 0;
+        std::size_t count = 0;
+    };
+
+    std::unordered_map<std::string, Acc> out_acc;
+    std::unordered_map<std::string, Acc> in_acc;
+
+    for (auto const gv : boost::make_iterator_range(boost::vertices(graph_))) {
+        std::unordered_map<std::string, std::size_t> out_by_label;
+        std::unordered_map<std::string, std::size_t> in_by_label;
+
+        for (auto const edge : boost::make_iterator_range(boost::out_edges(gv, graph_))) {
+            ++out_by_label[graph_[edge].label];
+        }
+        for (auto const edge : boost::make_iterator_range(boost::in_edges(gv, graph_))) {
+            ++in_by_label[graph_[edge].label];
+        }
+
+        for (auto const &[label, n] : out_by_label) {
+            auto &[sum, count] = out_acc[label];
+            sum += n;
+            ++count;
+        }
+        for (auto const &[label, n] : in_by_label) {
+            auto &[sum, count] = in_acc[label];
+            sum += n;
+            ++count;
+        }
+    }
+
+    for (auto const &[label, a] : out_acc) {
+        avg_out_size_[label] = a.count ? a.sum / static_cast<double>(a.count) : 1.0;
+    }
+    for (auto const &[label, a] : in_acc) {
+        avg_in_size_[label] = a.count ? a.sum / static_cast<double>(a.count) : 1.0;
+    }
+}
+
+std::size_t CostBasedQvoStrategy::VertexDomainSize(VertexT pattern_vertex) const {
+    auto const it = domain_.find(pattern_vertex);
+    return it == domain_.end() ? 0 : it->second.size();
+}
+
+double CostBasedQvoStrategy::AvgListSize(std::string const &edge_label, Direction direction) const {
+    auto const &table = direction == Direction::kIn ? avg_in_size_ : avg_out_size_;
+    auto const it = table.find(edge_label);
+    return it == table.end() ? 1.0 : it->second;
+}
+
+bool CostBasedQvoStrategy::ConnectsToPlaced(
+        VertexT vertex, std::unordered_map<VertexT, std::size_t> const &placed) const {
+    for (auto const edge : boost::make_iterator_range(boost::out_edges(vertex, pattern_))) {
+        if (placed.contains(boost::target(edge, pattern_))) {
+            return true;
+        }
+    }
+    for (auto const edge : boost::make_iterator_range(boost::in_edges(vertex, pattern_))) {
+        if (placed.contains(boost::source(edge, pattern_))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<CostBasedQvoStrategy::ExtensionListDescriptor> CostBasedQvoStrategy::ExtensionListsFor(
+        VertexT to, std::unordered_map<VertexT, std::size_t> const &placed) const {
+    std::vector<ExtensionListDescriptor> lists;
+
+    for (auto const edge : boost::make_iterator_range(boost::in_edges(to, pattern_))) {
+        if (VertexT const from = boost::source(edge, pattern_); placed.contains(from)) {
+            lists.push_back(ExtensionListDescriptor{
+                    .from = from,
+                    .direction = Direction::kOut,
+                    .edge_label = pattern_[edge].label,
+            });
+        }
+    }
+
+    for (auto const edge : boost::make_iterator_range(boost::out_edges(to, pattern_))) {
+        if (VertexT const from = boost::target(edge, pattern_); placed.contains(from)) {
+            lists.push_back(ExtensionListDescriptor{
+                    .from = from,
+                    .direction = Direction::kIn,
+                    .edge_label = pattern_[edge].label,
+            });
+        }
+    }
+    return lists;
+}
+
+double CostBasedQvoStrategy::StepCost(VertexT next, std::size_t level,
+                                      std::unordered_map<VertexT, std::size_t> const &placed,
+                                      std::vector<double> const &card_by_level,
+                                      double &match_estimate) const {
+    std::vector<ExtensionListDescriptor> const &lists = ExtensionListsFor(next, placed);
+
+    double const domain_size = static_cast<double>(VertexDomainSize(next));
+
+    if (lists.empty()) {
+        match_estimate *= std::max(1.0, domain_size);
+        return 0.0;
+    }
+
+    double min_list = std::numeric_limits<double>::infinity();
+
+    std::size_t earliest_pos = level;  // nothing earlier than level
+    for (auto const &[from, direction, edge_label] : lists) {
+        earliest_pos = std::min(earliest_pos, placed.at(from));
+    }
+    bool const cache_usable = lists.size() >= 2 && earliest_pos < level - 1;
+
+    double const cache_card = cache_usable && earliest_pos < card_by_level.size()
+                                      ? card_by_level[earliest_pos]
+                                      : match_estimate;
+
+    double cost = 0.0;
+    for (auto const &[from, direction, edge_label] : lists) {
+        double const list_size = AvgListSize(edge_label, direction);
+        min_list = std::min(min_list, list_size);
+
+        std::size_t const pos = placed.at(from);
+        bool const list_cached = cache_usable && pos <= earliest_pos;
+        double const charge_card = list_cached ? cache_card : match_estimate;
+        cost += charge_card * list_size;
+    }
+
+    double const label_fraction =
+            domain_size > 0.0 ? std::min(1.0, domain_size / std::max(1.0, min_list)) : 0.0;
+    double const mu_extension = (min_list == std::numeric_limits<double>::infinity())
+                                        ? domain_size
+                                        : min_list * label_fraction;
+
+    match_estimate *= std::max(std::numeric_limits<double>::epsilon(), mu_extension);
+
+    return cost;
+}
+
+std::vector<CostBasedQvoStrategy::VertexT> CostBasedQvoStrategy::OrderExhaustive() const {
+    std::vector pattern_vertices(boost::vertices(pattern_).first, boost::vertices(pattern_).second);
+    std::ranges::sort(pattern_vertices, pattern_vertices_comparator_);
+
+    std::vector<VertexT> best;
+    double best_cost = std::numeric_limits<double>::infinity();
+
+    do {
+        std::unordered_map<VertexT, std::size_t> placed;
+        std::vector<double> card_by_level;
+        card_by_level.reserve(pattern_vertices.size());
+
+        double cost = 0.0;
+        double match_estimate = 0.0;
+        bool valid = true;
+
+        for (std::size_t level = 0; level < pattern_vertices.size(); ++level) {
+            VertexT const pv = pattern_vertices[level];
+
+            if (level == 0) {
+                match_estimate = static_cast<double>(VertexDomainSize(pv));
+            } else if (!ConnectsToPlaced(pv, placed)) {
+                valid = false;  // disconnected prefix -> not a WCO plan
+                break;
+            } else {
+                cost += StepCost(pv, level, placed, card_by_level, match_estimate);
+            }
+
+            placed.emplace(pv, level);
+            card_by_level.push_back(match_estimate);
+        }
+
+        if (valid && cost < best_cost) {
+            best_cost = cost;
+            best = pattern_vertices;
+        }
+    } while (std::ranges::next_permutation(pattern_vertices, pattern_vertices_comparator_).found);
+
+    if (best.empty()) {
+        LOG_WARN("Disconnected pattern passed to cost-based qvo strategy. Fall back to id order");
+        best = pattern_vertices;
+    }
+    return best;
+}
+
+std::vector<CostBasedQvoStrategy::VertexT> CostBasedQvoStrategy::OrderGreedy() const {
+    std::vector const pattern_vertices(boost::vertices(pattern_).first,
+                                       boost::vertices(pattern_).second);
+    if (pattern_vertices.empty()) {
+        return {};
+    }
+
+    std::vector<VertexT> order;
+    order.reserve(pattern_vertices.size());
+    std::unordered_map<VertexT, std::size_t> placed;
+
+    // greedy choose first vertex
+    VertexT root = pattern_vertices.front();
+    for (VertexT const pv : pattern_vertices) {
+        std::size_t const pv_size = VertexDomainSize(pv);
+        std::size_t const root_size = VertexDomainSize(root);
+
+        if (pv_size < root_size) {
+            root = pv;
+        } else if (pv_size == root_size) {
+            std::size_t const deg_v =
+                    boost::out_degree(pv, pattern_) + boost::in_degree(pv, pattern_);
+            std::size_t const deg_r =
+                    boost::out_degree(root, pattern_) + boost::in_degree(root, pattern_);
+            if (deg_v > deg_r) {
+                root = pv;
+            }
+        }
+    }
+
+    double match_estimate = static_cast<double>(VertexDomainSize(root));
+    order.push_back(root);
+    placed.emplace(root, 0);
+    std::vector<double> card_by_level;
+    card_by_level.reserve(pattern_vertices.size());
+    card_by_level.push_back(match_estimate);
+
+    // minimize plan cost greedy as well
+    while (order.size() < pattern_vertices.size()) {
+        bool found = false;
+        VertexT best{};
+        double best_cost = std::numeric_limits<double>::infinity();
+        double best_estimate_after = match_estimate;
+
+        for (VertexT pv : pattern_vertices) {
+            if (placed.contains(pv) || !ConnectsToPlaced(pv, placed)) {
+                continue;
+            }
+            double estimate = match_estimate;
+            double const cost = StepCost(pv, order.size(), placed, card_by_level, estimate);
+            if (!found || cost < best_cost) {
+                found = true;
+                best = pv;
+                best_cost = cost;
+                best_estimate_after = estimate;
+            }
+        }
+
+        if (!found) {
+            LOG_WARN(
+                    "Disconnected pattern passed to cost-based qvo strategy. Fall back to id "
+                    "order");
+            std::vector<VertexT> rest;
+            for (VertexT v : pattern_vertices) {
+                if (!placed.contains(v)) {
+                    rest.push_back(v);
+                }
+            }
+            std::ranges::sort(rest, pattern_vertices_comparator_);
+            for (VertexT v : rest) {
+                order.push_back(v);
+                placed.emplace(v, order.size() - 1);
+            }
+            break;
+        }
+
+        match_estimate = best_estimate_after;
+        order.push_back(best);
+        placed.emplace(best, order.size() - 1);
+        card_by_level.push_back(match_estimate);
+    }
+
+    return order;
+}
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/cost_based_qvo_strategy.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/cost_based_qvo_strategy.cpp
@@ -23,22 +23,22 @@ void CostBasedQvoStrategy::ComputeAvgListSizes() {
             ++in_by_label[graph_[edge].label];
         }
 
-        for (auto const &[label, n] : out_by_label) {
-            auto &[sum, count] = out_acc[label];
+        for (auto const& [label, n] : out_by_label) {
+            auto& [sum, count] = out_acc[label];
             sum += n;
             ++count;
         }
-        for (auto const &[label, n] : in_by_label) {
-            auto &[sum, count] = in_acc[label];
+        for (auto const& [label, n] : in_by_label) {
+            auto& [sum, count] = in_acc[label];
             sum += n;
             ++count;
         }
     }
 
-    for (auto const &[label, a] : out_acc) {
+    for (auto const& [label, a] : out_acc) {
         avg_out_size_[label] = a.count ? a.sum / static_cast<double>(a.count) : 1.0;
     }
-    for (auto const &[label, a] : in_acc) {
+    for (auto const& [label, a] : in_acc) {
         avg_in_size_[label] = a.count ? a.sum / static_cast<double>(a.count) : 1.0;
     }
 }
@@ -48,14 +48,14 @@ std::size_t CostBasedQvoStrategy::VertexDomainSize(VertexT pattern_vertex) const
     return it == domain_.end() ? 0 : it->second.size();
 }
 
-double CostBasedQvoStrategy::AvgListSize(std::string const &edge_label, Direction direction) const {
-    auto const &table = direction == Direction::kIn ? avg_in_size_ : avg_out_size_;
+double CostBasedQvoStrategy::AvgListSize(std::string const& edge_label, Direction direction) const {
+    auto const& table = direction == Direction::kIn ? avg_in_size_ : avg_out_size_;
     auto const it = table.find(edge_label);
     return it == table.end() ? 1.0 : it->second;
 }
 
 bool CostBasedQvoStrategy::ConnectsToPlaced(
-        VertexT vertex, std::unordered_map<VertexT, std::size_t> const &placed) const {
+        VertexT vertex, std::unordered_map<VertexT, std::size_t> const& placed) const {
     for (auto const edge : boost::make_iterator_range(boost::out_edges(vertex, pattern_))) {
         if (placed.contains(boost::target(edge, pattern_))) {
             return true;
@@ -70,7 +70,7 @@ bool CostBasedQvoStrategy::ConnectsToPlaced(
 }
 
 std::vector<CostBasedQvoStrategy::ExtensionListDescriptor> CostBasedQvoStrategy::ExtensionListsFor(
-        VertexT to, std::unordered_map<VertexT, std::size_t> const &placed) const {
+        VertexT to, std::unordered_map<VertexT, std::size_t> const& placed) const {
     std::vector<ExtensionListDescriptor> lists;
 
     for (auto const edge : boost::make_iterator_range(boost::in_edges(to, pattern_))) {
@@ -96,10 +96,10 @@ std::vector<CostBasedQvoStrategy::ExtensionListDescriptor> CostBasedQvoStrategy:
 }
 
 double CostBasedQvoStrategy::StepCost(VertexT next, std::size_t level,
-                                      std::unordered_map<VertexT, std::size_t> const &placed,
-                                      std::vector<double> const &card_by_level,
-                                      double &match_estimate) const {
-    std::vector<ExtensionListDescriptor> const &lists = ExtensionListsFor(next, placed);
+                                      std::unordered_map<VertexT, std::size_t> const& placed,
+                                      std::vector<double> const& card_by_level,
+                                      double& match_estimate) const {
+    std::vector<ExtensionListDescriptor> const& lists = ExtensionListsFor(next, placed);
 
     double const domain_size = static_cast<double>(VertexDomainSize(next));
 
@@ -111,7 +111,7 @@ double CostBasedQvoStrategy::StepCost(VertexT next, std::size_t level,
     double min_list = std::numeric_limits<double>::infinity();
 
     std::size_t earliest_pos = level;  // nothing earlier than level
-    for (auto const &[from, direction, edge_label] : lists) {
+    for (auto const& [from, direction, edge_label] : lists) {
         earliest_pos = std::min(earliest_pos, placed.at(from));
     }
     bool const cache_usable = lists.size() >= 2 && earliest_pos < level - 1;
@@ -121,7 +121,7 @@ double CostBasedQvoStrategy::StepCost(VertexT next, std::size_t level,
                                       : match_estimate;
 
     double cost = 0.0;
-    for (auto const &[from, direction, edge_label] : lists) {
+    for (auto const& [from, direction, edge_label] : lists) {
         double const list_size = AvgListSize(edge_label, direction);
         min_list = std::min(min_list, list_size);
 

--- a/src/core/algorithms/gdd/gdd_validator/gdd_pattern_grouping.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_pattern_grouping.cpp
@@ -1,0 +1,67 @@
+#include "gdd_pattern_grouping.h"
+
+namespace algos {
+
+namespace {
+
+bool SamePattern(model::gdd::graph_t const& a, model::gdd::graph_t const& b) {
+    if (boost::num_vertices(a) != boost::num_vertices(b) ||
+        boost::num_edges(a) != boost::num_edges(b)) {
+        return false;
+    }
+
+    for (std::size_t v = 0; v < boost::num_vertices(a); ++v) {
+        if (a[v].id != b[v].id || a[v].label != b[v].label) {
+            return false;
+        }
+    }
+
+    auto edges = [](model::gdd::graph_t const& g) {
+        std::vector<std::tuple<std::size_t, std::size_t, std::string>> result;
+        result.reserve(boost::num_edges(g));
+        for (auto const e : boost::make_iterator_range(boost::edges(g))) {
+            result.emplace_back(boost::source(e, g), boost::target(e, g), g[e].label);
+        }
+        std::ranges::sort(result);
+        return result;
+    };
+
+    return edges(a) == edges(b);
+}
+
+}  // namespace
+
+GddValidator::PatternGrouping GddValidator::PatternGrouping::GroupByPattern(
+        std::vector<model::Gdd> const& gdds) {
+    std::vector<std::vector<std::size_t>> buckets;
+
+    for (std::size_t i = 0; i < gdds.size(); ++i) {
+        auto const bucket = std::ranges::find_if(buckets, [&gdds, i](auto const& indices) {
+            return SamePattern(gdds[indices.front()].GetPattern(), gdds[i].GetPattern());
+        });
+
+        if (bucket == buckets.end()) {
+            buckets.push_back({i});
+        } else {
+            bucket->push_back(i);
+        }
+    }
+
+    PatternGrouping grouping;
+    grouping.gdds.reserve(gdds.size());
+    grouping.origin.reserve(gdds.size());
+    grouping.starts.reserve(buckets.size() + 1);
+    grouping.starts.push_back(0);
+
+    for (auto const& indices : buckets) {
+        for (std::size_t const index : indices) {
+            grouping.gdds.push_back(&gdds[index]);
+            grouping.origin.push_back(index);
+        }
+        grouping.starts.push_back(grouping.gdds.size());
+    }
+
+    return grouping;
+}
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/gdd_pattern_grouping.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_pattern_grouping.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "gdd_validator.h"
+
+namespace algos {
+
+struct GddValidator::PatternGrouping {
+    std::vector<model::Gdd const*> gdds;
+    // gdds[i] was passed to the algorithm at index origin[i], we want to restore the initial order
+    // of users gdds
+    std::vector<std::size_t> origin;
+    // group "g" occupies [starts[g], starts[g + 1]) in gdds
+    std::vector<std::size_t> starts;
+
+    std::size_t GroupCount() const noexcept {
+        return starts.size() - 1;
+    }
+
+    static PatternGrouping GroupByPattern(std::vector<model::Gdd> const& gdds);
+};
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validation_executor.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validation_executor.cpp
@@ -1,0 +1,44 @@
+#include "gdd_validation_executor.h"
+
+#include "gdd_pattern_grouping.h"
+
+namespace algos {
+
+void GddValidator::SequentialValidationExecutor::Execute(GddValidator& validator,
+                                                         PatternGrouping const& grouping,
+                                                         std::size_t first_group,
+                                                         std::size_t last_group,
+                                                         model::gdd::graph_t const& graph,
+                                                         std::span<GddHoldsResult> output) const {
+    assert(last_group <= grouping.GroupCount());
+    assert(grouping.gdds.size() == output.size());
+
+    for (std::size_t group = first_group; group < last_group; ++group) {
+        std::size_t const begin = grouping.starts[group];
+        std::size_t const size = grouping.starts[group + 1] - begin;
+
+        validator.HoldsGroup(std::span{grouping.gdds}.subspan(begin, size), graph,
+                             output.subspan(begin, size));
+    }
+}
+
+void GddValidator::ParallelValidationExecutor::Execute(GddValidator& validator,
+                                                       PatternGrouping const& grouping,
+                                                       std::size_t first_group,
+                                                       std::size_t last_group,
+                                                       model::gdd::graph_t const& graph,
+                                                       std::span<GddHoldsResult> output) const {
+    assert(last_group <= grouping.GroupCount());
+    assert(last_group - first_group >= threads_);
+
+    util::WorkerThreadPool pool{threads_};
+    pool.ExecIndexWithResource(
+            [this, &grouping, first_group, &graph, output](
+                    model::Index index, std::unique_ptr<GddValidator> const& worker) {
+                std::size_t const group = first_group + index;
+                inner_->Execute(*worker, grouping, group, group + 1, graph, output);
+            },
+            [&validator] { return validator.CreateWorker(); }, last_group - first_group);
+}
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validation_executor.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validation_executor.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstddef>
+#include <span>
+
+#include "core/util/worker_thread_pool.h"
+#include "gdd_validator.h"
+
+namespace algos {
+
+struct GddValidator::ValidationExecutor {
+    virtual void Execute(GddValidator& validator, PatternGrouping const& grouping,
+                         std::size_t first_group, std::size_t last_group,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const = 0;
+
+    virtual ~ValidationExecutor() = default;
+};
+
+struct GddValidator::SequentialValidationExecutor : ValidationExecutor {
+    virtual void Execute(GddValidator& validator, PatternGrouping const& grouping,
+                         std::size_t first_group, std::size_t last_group,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const final;
+};
+
+struct GddValidator::ParallelValidationExecutor : ValidationExecutor {
+private:
+    std::unique_ptr<ValidationExecutor> inner_;
+    std::size_t threads_;
+
+public:
+    ParallelValidationExecutor(std::unique_ptr<ValidationExecutor> inner, std::size_t threads)
+        : inner_(std::move(inner)), threads_(threads) {
+        assert(inner_ != nullptr);
+        assert(threads_ > 1);
+    }
+
+    virtual void Execute(GddValidator& validator, PatternGrouping const& grouping,
+                         std::size_t first_group, std::size_t last_group,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const final;
+};
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
@@ -1,12 +1,68 @@
 #include "core/algorithms/gdd/gdd_validator/gdd_validator.h"
 
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <span>
+
 #include "core/algorithms/algorithm.h"
 #include "core/algorithms/gdd/gdd.h"
 #include "core/config/names_and_descriptions.h"
 #include "core/config/option_using.h"
+#include "core/config/thread_number/option.h"
 #include "core/parser/graph_parser/graph_parser.h"
+#include "core/util/worker_thread_pool.h"
 
 namespace algos {
+
+struct GddValidator::ValidationExecutor {
+    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const = 0;
+
+    virtual ~ValidationExecutor() = default;
+};
+
+struct GddValidator::SequentialValidationExecutor : ValidationExecutor {
+    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const final {
+        assert(gdds.size() == output.size());
+        for (std::size_t i = 0; i < gdds.size(); ++i) {
+            output[i] = validator.Holds(gdds[i], graph);
+        }
+    }
+};
+
+// decorator on top of another executor
+struct GddValidator::ParallelValidationExecutor : ValidationExecutor {
+private:
+    std::unique_ptr<ValidationExecutor> inner_;
+    std::size_t threads_;
+
+public:
+    ParallelValidationExecutor(std::unique_ptr<ValidationExecutor> inner, std::size_t threads)
+        : inner_(std::move(inner)), threads_(threads) {
+        assert(inner_ != nullptr);
+        assert(threads_ > 1);
+    }
+
+    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
+                         model::gdd::graph_t const& graph,
+                         std::span<GddHoldsResult> output) const final {
+        assert(gdds.size() == output.size());
+        assert(gdds.size() >= threads_);
+
+        util::WorkerThreadPool pool{threads_};
+        pool.ExecIndexWithResource(
+                [this, gdds, &graph, output](model::Index index,
+                                             std::unique_ptr<GddValidator> const& worker) {
+                    inner_->Execute(*worker, gdds.subspan(index, 1), graph,
+                                    output.subspan(index, 1));
+                },
+                [&validator]() { return validator.CreateWorker(); }, gdds.size());
+    }
+};
 
 void GddValidator::ResetState() {
     result_.clear();
@@ -20,6 +76,7 @@ void GddValidator::RegisterOptions() {
 
     RegisterOption(Option{&graph_path_, kGraphData, kDGraphData});
     RegisterOption(Option{&gdds_, kGddData, kDGddData});
+    RegisterOption(config::kThreadNumberOpt(&threads_));
     MakeOptionsAvailable({kGraphData, kGddData});
 }
 
@@ -31,23 +88,32 @@ void GddValidator::LoadDataInternal() {
     graph_ = parser::graph_parser::gdd::ReadGraph(graph_path_);
 }
 
-void GddValidator::ExecuteInternal() {
-    ResetState();
+void GddValidator::MakeExecuteOptsAvailable() {
+    MakeOptionsAvailable({config::names::kThreads});
+}
 
-    std::size_t gdd_index = 0;
-    std::ranges::copy_if(gdds_, std::back_inserter(result_),
-                         [this, &gdd_index](model::Gdd const& gdd) {
-                             auto [ce, match_count] = Holds(gdd, graph_);
-                             matches_count_.push_back(match_count);
-                             if (ce.has_value()) {
-                                 ce->gdd_index = gdd_index;
-                                 counterexamples_.emplace_back(std::move(*ce));
-                                 ++gdd_index;
-                                 return false;
-                             }
-                             ++gdd_index;
-                             return true;
-                         });
+void GddValidator::ExecuteInternal() {
+    std::vector<GddHoldsResult> check_results(gdds_.size());
+
+    std::unique_ptr<ValidationExecutor> executor = std::make_unique<SequentialValidationExecutor>();
+    if (std::size_t const actual_threads = std::min<std::size_t>(threads_, gdds_.size());
+        actual_threads > 1) {
+        executor =
+                std::make_unique<ParallelValidationExecutor>(std::move(executor), actual_threads);
+    }
+    executor->Execute(*this, gdds_, graph_, check_results);
+
+    result_.reserve(gdds_.size());
+    for (std::size_t gdd_index = 0; gdd_index < gdds_.size(); ++gdd_index) {
+        auto& [ce, match_count] = check_results[gdd_index];
+        matches_count_.push_back(match_count);
+        if (ce.has_value()) {
+            ce->gdd_index = gdd_index;
+            counterexamples_.emplace_back(std::move(*ce));
+        } else {
+            result_.push_back(gdds_[gdd_index]);
+        }
+    }
 }
 
 GddValidator::DomainT GddValidator::BuildDomain(model::gdd::graph_t const& pattern,

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
@@ -11,6 +11,8 @@ namespace algos {
 void GddValidator::ResetState() {
     result_.clear();
     counterexamples_.clear();
+    matches_count_.clear();
+    matches_count_.reserve(gdds_.size());
 }
 
 void GddValidator::RegisterOptions() {
@@ -35,7 +37,9 @@ void GddValidator::ExecuteInternal() {
     std::size_t gdd_index = 0;
     std::ranges::copy_if(gdds_, std::back_inserter(result_),
                          [this, &gdd_index](model::Gdd const& gdd) {
-                             if (auto ce = Holds(gdd, graph_); ce.has_value()) {
+                             auto [ce, match_count] = Holds(gdd, graph_);
+                             matches_count_.push_back(match_count);
+                             if (ce.has_value()) {
                                  ce->gdd_index = gdd_index;
                                  counterexamples_.emplace_back(std::move(*ce));
                                  ++gdd_index;

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
@@ -46,4 +46,19 @@ void GddValidator::ExecuteInternal() {
                          });
 }
 
+GddValidator::DomainT GddValidator::BuildDomain(model::gdd::graph_t const& pattern,
+                                                model::gdd::graph_t const& graph) {
+    DomainT dom;
+
+    for (auto [pv, pend] = boost::vertices(pattern); pv != pend; ++pv) {
+        for (auto [gv, gend] = boost::vertices(graph); gv != gend; ++gv) {
+            if (LabelsMatch(pattern[*pv].label, graph[*gv].label)) {
+                dom[*pv].emplace_back(*gv);
+            }
+        }
+    }
+
+    return dom;
+}
+
 }  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
-#include <span>
+#include <vector>
 
 #include "core/algorithms/algorithm.h"
 #include "core/algorithms/gdd/gdd.h"
@@ -11,58 +11,10 @@
 #include "core/config/option_using.h"
 #include "core/config/thread_number/option.h"
 #include "core/parser/graph_parser/graph_parser.h"
-#include "core/util/worker_thread_pool.h"
+#include "gdd_pattern_grouping.h"
+#include "gdd_validation_executor.h"
 
 namespace algos {
-
-struct GddValidator::ValidationExecutor {
-    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
-                         model::gdd::graph_t const& graph,
-                         std::span<GddHoldsResult> output) const = 0;
-
-    virtual ~ValidationExecutor() = default;
-};
-
-struct GddValidator::SequentialValidationExecutor : ValidationExecutor {
-    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
-                         model::gdd::graph_t const& graph,
-                         std::span<GddHoldsResult> output) const final {
-        assert(gdds.size() == output.size());
-        for (std::size_t i = 0; i < gdds.size(); ++i) {
-            output[i] = validator.Holds(gdds[i], graph);
-        }
-    }
-};
-
-// decorator on top of another executor
-struct GddValidator::ParallelValidationExecutor : ValidationExecutor {
-private:
-    std::unique_ptr<ValidationExecutor> inner_;
-    std::size_t threads_;
-
-public:
-    ParallelValidationExecutor(std::unique_ptr<ValidationExecutor> inner, std::size_t threads)
-        : inner_(std::move(inner)), threads_(threads) {
-        assert(inner_ != nullptr);
-        assert(threads_ > 1);
-    }
-
-    virtual void Execute(GddValidator& validator, std::span<model::Gdd const> gdds,
-                         model::gdd::graph_t const& graph,
-                         std::span<GddHoldsResult> output) const final {
-        assert(gdds.size() == output.size());
-        assert(gdds.size() >= threads_);
-
-        util::WorkerThreadPool pool{threads_};
-        pool.ExecIndexWithResource(
-                [this, gdds, &graph, output](model::Index index,
-                                             std::unique_ptr<GddValidator> const& worker) {
-                    inner_->Execute(*worker, gdds.subspan(index, 1), graph,
-                                    output.subspan(index, 1));
-                },
-                [&validator]() { return validator.CreateWorker(); }, gdds.size());
-    }
-};
 
 void GddValidator::ResetState() {
     result_.clear();
@@ -93,19 +45,28 @@ void GddValidator::MakeExecuteOptsAvailable() {
 }
 
 void GddValidator::ExecuteInternal() {
-    std::vector<GddHoldsResult> check_results(gdds_.size());
+    PatternGrouping const grouping = PatternGrouping::GroupByPattern(gdds_);
+    std::size_t const group_count = grouping.GroupCount();
+
+    std::vector<GddHoldsResult> grouped_results(gdds_.size());
 
     std::unique_ptr<ValidationExecutor> executor = std::make_unique<SequentialValidationExecutor>();
-    if (std::size_t const actual_threads = std::min<std::size_t>(threads_, gdds_.size());
+    if (std::size_t const actual_threads = std::min<std::size_t>(threads_, group_count);
         actual_threads > 1) {
         executor =
                 std::make_unique<ParallelValidationExecutor>(std::move(executor), actual_threads);
     }
-    executor->Execute(*this, gdds_, graph_, check_results);
+    executor->Execute(*this, grouping, 0, group_count, graph_, grouped_results);
+
+    // undo the reordering done by the grouping: results are reported in input order
+    std::vector<GddHoldsResult> ordered_results(gdds_.size());
+    for (std::size_t i = 0; i < grouping.origin.size(); ++i) {
+        ordered_results[grouping.origin[i]] = std::move(grouped_results[i]);
+    }
 
     result_.reserve(gdds_.size());
     for (std::size_t gdd_index = 0; gdd_index < gdds_.size(); ++gdd_index) {
-        auto& [ce, match_count] = check_results[gdd_index];
+        auto& [ce, match_count] = ordered_results[gdd_index];
         matches_count_.push_back(match_count);
         if (ce.has_value()) {
             ce->gdd_index = gdd_index;

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
@@ -30,10 +30,10 @@ private:
     virtual void LoadDataInternal() final;
 
 protected:
-    using VertexT = model::gdd::vertex_t;
-    using EdgeT = model::gdd::edge_t;
-    using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
-    using MappingT = std::unordered_map<VertexT, VertexT>;
+    using VertexT = model::gdd::detail::VertexT;
+    using EdgeT = model::gdd::detail::EdgeT;
+    using DomainT = model::gdd::detail::DomainT;
+    using MappingT = model::gdd::detail::MappingT;
 
     static DomainT BuildDomain(model::gdd::graph_t const& pattern,
                                model::gdd::graph_t const& graph);

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
@@ -14,6 +14,7 @@ private:
     model::gdd::graph_t graph_;
     std::vector<model::Gdd> gdds_;
     std::vector<model::Gdd> result_;
+    std::vector<std::size_t> matches_count_;
 
 protected:
     using GddCounterexample = model::GddCounterexample;
@@ -50,8 +51,12 @@ protected:
         return gdds_;
     }
 
-    virtual std::optional<GddCounterexample> Holds(model::Gdd const& gdd,
-                                                   model::gdd::graph_t const& graph) = 0;
+    struct GddHoldsResult {
+        std::optional<GddCounterexample> ce;
+        std::size_t match_count;
+    };
+
+    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) = 0;
 
 public:
     GddValidator();
@@ -62,6 +67,10 @@ public:
 
     std::vector<GddCounterexample> const& GetCounterexamples() const noexcept {
         return counterexamples_;
+    }
+
+    std::vector<std::size_t> GetMatchesCount() const {
+        return matches_count_;
     }
 
     GddValidator(GddValidator const&) = delete;

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <filesystem>
+#include <memory>
 
 #include "core/algorithms/algorithm.h"
 #include "core/algorithms/gdd/gdd.h"
 #include "core/algorithms/gdd/gdd_graph_description.h"
+#include "core/config/thread_number/type.h"
 
 namespace algos {
 
@@ -15,6 +17,11 @@ private:
     std::vector<model::Gdd> gdds_;
     std::vector<model::Gdd> result_;
     std::vector<std::size_t> matches_count_;
+    config::ThreadNumType threads_ = 1;
+
+    struct ValidationExecutor;
+    struct SequentialValidationExecutor;
+    struct ParallelValidationExecutor;
 
 protected:
     using GddCounterexample = model::GddCounterexample;
@@ -29,6 +36,8 @@ private:
     virtual void ResetState() final;
 
     virtual void LoadDataInternal() final;
+
+    virtual void MakeExecuteOptsAvailable() final;
 
 protected:
     using VertexT = model::gdd::detail::VertexT;
@@ -53,10 +62,12 @@ protected:
 
     struct GddHoldsResult {
         std::optional<GddCounterexample> ce;
-        std::size_t match_count;
+        std::size_t match_count = 0;
     };
 
     virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) = 0;
+
+    virtual std::unique_ptr<GddValidator> CreateWorker() const = 0;
 
 public:
     GddValidator();

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
@@ -10,12 +10,15 @@ namespace algos {
 
 class GddValidator : public Algorithm {
 private:
-    using GddCounterexample = model::GddCounterexample;
-
     std::filesystem::path graph_path_;
     model::gdd::graph_t graph_;
     std::vector<model::Gdd> gdds_;
     std::vector<model::Gdd> result_;
+
+protected:
+    using GddCounterexample = model::GddCounterexample;
+
+private:
     std::vector<GddCounterexample> counterexamples_;
 
     void RegisterOptions();
@@ -27,6 +30,18 @@ private:
     virtual void LoadDataInternal() final;
 
 protected:
+    using VertexT = model::gdd::vertex_t;
+    using EdgeT = model::gdd::edge_t;
+    using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
+    using MappingT = std::unordered_map<VertexT, VertexT>;
+
+    static DomainT BuildDomain(model::gdd::graph_t const& pattern,
+                               model::gdd::graph_t const& graph);
+
+    static bool LabelsMatch(std::string const& lhs, std::string const& rhs) noexcept {
+        return lhs == rhs;  // TODO: wildcards
+    }
+
     model::gdd::graph_t const& GetGraph() const noexcept {
         return graph_;
     }

--- a/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/gdd_validator.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <span>
 
 #include "core/algorithms/algorithm.h"
 #include "core/algorithms/gdd/gdd.h"
@@ -19,6 +20,7 @@ private:
     std::vector<std::size_t> matches_count_;
     config::ThreadNumType threads_ = 1;
 
+    struct PatternGrouping;
     struct ValidationExecutor;
     struct SequentialValidationExecutor;
     struct ParallelValidationExecutor;
@@ -52,20 +54,15 @@ protected:
         return lhs == rhs;  // TODO: wildcards
     }
 
-    model::gdd::graph_t const& GetGraph() const noexcept {
-        return graph_;
-    }
-
-    std::vector<model::Gdd> const& GetGdds() const noexcept {
-        return gdds_;
-    }
-
     struct GddHoldsResult {
         std::optional<GddCounterexample> ce;
         std::size_t match_count = 0;
     };
 
-    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) = 0;
+    // every GDD in a group shares the same pattern, so we want to match it once if it
+    // is possible
+    virtual void HoldsGroup(std::span<model::Gdd const* const> group,
+                            model::gdd::graph_t const& graph, std::span<GddHoldsResult> output) = 0;
 
     virtual std::unique_ptr<GddValidator> CreateWorker() const = 0;
 

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
@@ -4,6 +4,7 @@ namespace algos {
 
 GddValidator::GddHoldsResult NaiveGddValidator::Holds(model::Gdd const& gdd,
                                                       model::gdd::graph_t const& graph) {
+    match_count_ = 0;
     model::gdd::graph_t const& pattern = gdd.GetPattern();
     if (domain_ = BuildDomain(pattern, graph); domain_.size() == boost::num_vertices(pattern)) {
         MappingT partial_map;
@@ -17,10 +18,13 @@ GddValidator::GddHoldsResult NaiveGddValidator::Holds(model::Gdd const& gdd,
     return {std::nullopt, match_count_};
 }
 
-bool NaiveGddValidator::GraphHasCompatibleEdge(VertexT graph_src, VertexT graph_dst,
-                                               std::string const& pattern_edge_label) const {
-    auto const& graph = GetGraph();
+std::unique_ptr<GddValidator> NaiveGddValidator::CreateWorker() const {
+    return std::make_unique<NaiveGddValidator>();
+}
 
+bool NaiveGddValidator::GraphHasCompatibleEdge(model::gdd::graph_t const& graph, VertexT graph_src,
+                                               VertexT graph_dst,
+                                               std::string const& pattern_edge_label) {
     for (auto const graph_edge : boost::make_iterator_range(boost::out_edges(graph_src, graph))) {
         if (boost::target(graph_edge, graph) != graph_dst) {
             continue;
@@ -34,16 +38,17 @@ bool NaiveGddValidator::GraphHasCompatibleEdge(VertexT graph_src, VertexT graph_
     return false;
 }
 
-bool NaiveGddValidator::AllPatternEdgesArePreserved(model::gdd::graph_t const& pattern,
+bool NaiveGddValidator::AllPatternEdgesArePreserved(model::gdd::graph_t const& graph,
+                                                    model::gdd::graph_t const& pattern,
                                                     VertexT pattern_src, VertexT pattern_dst,
-                                                    VertexT graph_src, VertexT graph_dst) const {
+                                                    VertexT graph_src, VertexT graph_dst) {
     for (auto const pattern_edge :
          boost::make_iterator_range(boost::out_edges(pattern_src, pattern))) {
         if (boost::target(pattern_edge, pattern) != pattern_dst) {
             continue;
         }
 
-        if (!GraphHasCompatibleEdge(graph_src, graph_dst, pattern[pattern_edge].label)) {
+        if (!GraphHasCompatibleEdge(graph, graph_src, graph_dst, pattern[pattern_edge].label)) {
             return false;
         }
     }
@@ -51,16 +56,17 @@ bool NaiveGddValidator::AllPatternEdgesArePreserved(model::gdd::graph_t const& p
     return true;
 }
 
-bool NaiveGddValidator::CanExtendMapping(MappingT const& partial_map,
+bool NaiveGddValidator::CanExtendMapping(model::gdd::graph_t const& graph,
+                                         MappingT const& partial_map,
                                          model::gdd::graph_t const& pattern, VertexT pattern_var,
-                                         VertexT graph_vertex) const {
+                                         VertexT graph_vertex) {
     return std::ranges::all_of(partial_map, [&](auto const& mapped_pair) {
         auto const& [mapped_pattern_var, mapped_graph_vertex] = mapped_pair;
 
-        return AllPatternEdgesArePreserved(pattern, mapped_pattern_var, pattern_var,
+        return AllPatternEdgesArePreserved(graph, pattern, mapped_pattern_var, pattern_var,
                                            mapped_graph_vertex, graph_vertex) &&
-               AllPatternEdgesArePreserved(pattern, pattern_var, mapped_pattern_var, graph_vertex,
-                                           mapped_graph_vertex);
+               AllPatternEdgesArePreserved(graph, pattern, pattern_var, mapped_pattern_var,
+                                           graph_vertex, mapped_graph_vertex);
     });
 }
 
@@ -85,7 +91,7 @@ bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
         }
 
         for (VertexT graph_vertex : graph_vertex_candidates) {
-            if (!CanExtendMapping(partial_map, pattern, pattern_var, graph_vertex)) {
+            if (!CanExtendMapping(graph, partial_map, pattern, pattern_var, graph_vertex)) {
                 continue;
             }
 

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
@@ -2,19 +2,19 @@
 
 namespace algos {
 
-std::optional<model::GddCounterexample> NaiveGddValidator::Holds(model::Gdd const& gdd,
-                                                                 model::gdd::graph_t const& graph) {
+GddValidator::GddHoldsResult NaiveGddValidator::Holds(model::Gdd const& gdd,
+                                                      model::gdd::graph_t const& graph) {
     model::gdd::graph_t const& pattern = gdd.GetPattern();
     if (domain_ = BuildDomain(pattern, graph); domain_.size() == boost::num_vertices(pattern)) {
         MappingT partial_map;
         partial_map.reserve(boost::num_vertices(pattern));
         if (GddCounterexample counterexample{};
             ExistsCounterexample(gdd, graph, partial_map, counterexample)) {
-            return counterexample;
+            return {counterexample, match_count_};
         }
     }
 
-    return std::nullopt;
+    return {std::nullopt, match_count_};
 }
 
 bool NaiveGddValidator::GraphHasCompatibleEdge(VertexT graph_src, VertexT graph_dst,
@@ -69,6 +69,7 @@ bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
                                              MappingT& partial_map,
                                              GddCounterexample& counterexample) {
     if (partial_map.size() == domain_.size()) {
+        ++match_count_;
         bool const sat = gdd.Satisfies(graph, partial_map);
 
         if (!sat) {

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
@@ -7,6 +7,7 @@ std::optional<model::GddCounterexample> NaiveGddValidator::Holds(model::Gdd cons
     model::gdd::graph_t const& pattern = gdd.GetPattern();
     if (domain_ = BuildDomain(pattern, graph); domain_.size() == boost::num_vertices(pattern)) {
         MappingT partial_map;
+        partial_map.reserve(boost::num_vertices(pattern));
         if (GddCounterexample counterexample{};
             ExistsCounterexample(gdd, graph, partial_map, counterexample)) {
             return counterexample;
@@ -14,21 +15,6 @@ std::optional<model::GddCounterexample> NaiveGddValidator::Holds(model::Gdd cons
     }
 
     return std::nullopt;
-}
-
-NaiveGddValidator::DomainT NaiveGddValidator::BuildDomain(model::gdd::graph_t const& pattern,
-                                                          model::gdd::graph_t const& graph) {
-    DomainT dom;
-
-    for (auto [pv, pend] = boost::vertices(pattern); pv != pend; ++pv) {
-        for (auto [gv, gend] = boost::vertices(graph); gv != gend; ++gv) {
-            if (model::Gdd::LabelsMatch(pattern[*pv].label, graph[*gv].label)) {
-                dom[*pv].emplace_back(*gv);
-            }
-        }
-    }
-
-    return dom;
 }
 
 bool NaiveGddValidator::GraphHasCompatibleEdge(VertexT graph_src, VertexT graph_dst,
@@ -102,7 +88,7 @@ bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
                 continue;
             }
 
-            auto const [it, inserted] = partial_map.emplace(pattern_var, graph_vertex);
+            auto const [_, inserted] = partial_map.emplace(pattern_var, graph_vertex);
             if (!inserted) {
                 continue;
             }
@@ -111,7 +97,7 @@ bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
                 return true;
             }
 
-            partial_map.erase(it);
+            partial_map.erase(pattern_var);
         }
         break;  // other pattern variables are assigned on the next recursion levels
     }

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.cpp
@@ -1,21 +1,30 @@
 #include "naive_gdd_validator.h"
 
+#include <algorithm>
+#include <cassert>
+#include <span>
+
 namespace algos {
 
-GddValidator::GddHoldsResult NaiveGddValidator::Holds(model::Gdd const& gdd,
-                                                      model::gdd::graph_t const& graph) {
-    match_count_ = 0;
-    model::gdd::graph_t const& pattern = gdd.GetPattern();
-    if (domain_ = BuildDomain(pattern, graph); domain_.size() == boost::num_vertices(pattern)) {
-        MappingT partial_map;
-        partial_map.reserve(boost::num_vertices(pattern));
-        if (GddCounterexample counterexample{};
-            ExistsCounterexample(gdd, graph, partial_map, counterexample)) {
-            return {counterexample, match_count_};
-        }
+void NaiveGddValidator::HoldsGroup(std::span<model::Gdd const* const> group,
+                                   model::gdd::graph_t const& graph,
+                                   std::span<GddHoldsResult> output) {
+    assert(group.size() == output.size());
+    std::ranges::fill(output, GddHoldsResult{});
+
+    if (group.empty()) {
+        return;
     }
 
-    return {std::nullopt, match_count_};
+    model::gdd::graph_t const& pattern = group.front()->GetPattern();
+    if (domain_ = BuildDomain(pattern, graph); domain_.size() != boost::num_vertices(pattern)) {
+        return;
+    }
+
+    MappingT partial_map;
+    partial_map.reserve(boost::num_vertices(pattern));
+    std::size_t remaining = group.size();
+    FindCounterexamples(group, graph, pattern, partial_map, output, remaining);
 }
 
 std::unique_ptr<GddValidator> NaiveGddValidator::CreateWorker() const {
@@ -70,21 +79,27 @@ bool NaiveGddValidator::CanExtendMapping(model::gdd::graph_t const& graph,
     });
 }
 
-bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
-                                             model::gdd::graph_t const& graph,
-                                             MappingT& partial_map,
-                                             GddCounterexample& counterexample) {
+bool NaiveGddValidator::FindCounterexamples(std::span<model::Gdd const* const> group,
+                                            model::gdd::graph_t const& graph,
+                                            model::gdd::graph_t const& pattern,
+                                            MappingT& partial_map, std::span<GddHoldsResult> output,
+                                            std::size_t& remaining) {
     if (partial_map.size() == domain_.size()) {
-        ++match_count_;
-        bool const sat = gdd.Satisfies(graph, partial_map);
+        for (std::size_t gdd_index = 0; gdd_index < group.size(); ++gdd_index) {
+            if (output[gdd_index].ce.has_value()) {
+                continue;
+            }
 
-        if (!sat) {
-            counterexample = model::BuildCounterexample(gdd.GetPattern(), graph, partial_map);
+            ++output[gdd_index].match_count;
+            if (!group[gdd_index]->Satisfies(graph, partial_map)) {
+                output[gdd_index].ce = model::BuildCounterexample(pattern, graph, partial_map);
+                --remaining;
+            }
         }
-        return !sat;
+
+        return remaining == 0;
     }
 
-    auto const& pattern = gdd.GetPattern();
     for (auto const& [pattern_var, graph_vertex_candidates] : domain_) {
         if (partial_map.contains(pattern_var)) {
             continue;
@@ -100,7 +115,7 @@ bool NaiveGddValidator::ExistsCounterexample(model::Gdd const& gdd,
                 continue;
             }
 
-            if (ExistsCounterexample(gdd, graph, partial_map, counterexample)) {
+            if (FindCounterexamples(group, graph, pattern, partial_map, output, remaining)) {
                 return true;
             }
 

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
@@ -6,16 +6,8 @@ namespace algos {
 
 class NaiveGddValidator : public GddValidator {
 private:
-    using VertexT = model::gdd::vertex_t;
-    using EdgeT = model::gdd::edge_t;
-    using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
-    using MappingT = std::unordered_map<VertexT, VertexT>;
-    using GddCounterexample = model::GddCounterexample;
-
     DomainT domain_;
 
-    static DomainT BuildDomain(model::gdd::graph_t const& pattern,
-                               model::gdd::graph_t const& graph);
     bool ExistsCounterexample(model::Gdd const& gdd, model::gdd::graph_t const& graph,
                               MappingT& partial_map, GddCounterexample& counterexample);
 

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
@@ -11,19 +11,22 @@ private:
     bool ExistsCounterexample(model::Gdd const& gdd, model::gdd::graph_t const& graph,
                               MappingT& partial_map, GddCounterexample& counterexample);
 
-    bool GraphHasCompatibleEdge(VertexT graph_src, VertexT graph_dst,
-                                std::string const& pattern_edge_label) const;
-    bool AllPatternEdgesArePreserved(model::gdd::graph_t const& pattern, VertexT pattern_src,
-                                     VertexT pattern_dst, VertexT graph_src,
-                                     VertexT graph_dst) const;
-    bool CanExtendMapping(MappingT const& partial_map, model::gdd::graph_t const& pattern,
-                          VertexT pattern_var, VertexT graph_vertex) const;
+    static bool GraphHasCompatibleEdge(model::gdd::graph_t const& graph, VertexT graph_src,
+                                       VertexT graph_dst, std::string const& pattern_edge_label);
+    static bool AllPatternEdgesArePreserved(model::gdd::graph_t const& graph,
+                                            model::gdd::graph_t const& pattern, VertexT pattern_src,
+                                            VertexT pattern_dst, VertexT graph_src,
+                                            VertexT graph_dst);
+    static bool CanExtendMapping(model::gdd::graph_t const& graph, MappingT const& partial_map,
+                                 model::gdd::graph_t const& pattern, VertexT pattern_var,
+                                 VertexT graph_vertex);
 
     std::size_t match_count_ = 0;
 
 protected:
-
     virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
+
+    virtual std::unique_ptr<GddValidator> CreateWorker() const final;
 
 public:
     NaiveGddValidator() = default;

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
@@ -19,9 +19,11 @@ private:
     bool CanExtendMapping(MappingT const& partial_map, model::gdd::graph_t const& pattern,
                           VertexT pattern_var, VertexT graph_vertex) const;
 
+    std::size_t match_count_ = 0;
+
 protected:
-    virtual std::optional<GddCounterexample> Holds(model::Gdd const& gdd,
-                                                   model::gdd::graph_t const& graph) final;
+
+    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
 
 public:
     NaiveGddValidator() = default;

--- a/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/naive_gdd_validator.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <span>
+
 #include "gdd_validator.h"
 
 namespace algos {
@@ -8,8 +10,11 @@ class NaiveGddValidator : public GddValidator {
 private:
     DomainT domain_;
 
-    bool ExistsCounterexample(model::Gdd const& gdd, model::gdd::graph_t const& graph,
-                              MappingT& partial_map, GddCounterexample& counterexample);
+    // returns true when a counterexample is found for every GDD of the group
+    bool FindCounterexamples(std::span<model::Gdd const* const> group,
+                             model::gdd::graph_t const& graph, model::gdd::graph_t const& pattern,
+                             MappingT& partial_map, std::span<GddHoldsResult> output,
+                             std::size_t& remaining);
 
     static bool GraphHasCompatibleEdge(model::gdd::graph_t const& graph, VertexT graph_src,
                                        VertexT graph_dst, std::string const& pattern_edge_label);
@@ -21,10 +26,10 @@ private:
                                  model::gdd::graph_t const& pattern, VertexT pattern_var,
                                  VertexT graph_vertex);
 
-    std::size_t match_count_ = 0;
-
 protected:
-    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
+    virtual void HoldsGroup(std::span<model::Gdd const* const> group,
+                            model::gdd::graph_t const& graph,
+                            std::span<GddHoldsResult> output) final;
 
     virtual std::unique_ptr<GddValidator> CreateWorker() const final;
 

--- a/src/core/algorithms/gdd/gdd_validator/qvo_strategies.h
+++ b/src/core/algorithms/gdd/gdd_validator/qvo_strategies.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <deque>
+#include <vector>
+
+#include "core/algorithms/gdd/gdd.h"
+#include "core/algorithms/gdd/gdd_graph_description.h"
+
+namespace algos {
+
+template <typename T>
+concept QvoStrategy = requires(T strategy) {
+    requires std::constructible_from<T, model::gdd::graph_t const & /*graph*/,
+                                     model::gdd::graph_t const & /*pattern*/,
+                                     model::gdd::detail::DomainT const &> /*domain*/;
+
+    { strategy.Order() } -> std::convertible_to<std::vector<model::gdd::vertex_t>>;
+};
+
+class BfsQvoStrategy {
+private:
+    using GraphT = model::gdd::graph_t;
+    using VertexT = model::gdd::vertex_t;
+    using DomainT = model::gdd::detail::DomainT;
+
+    GraphT const &pattern_;
+    DomainT const &domain_;
+
+    std::vector<VertexT> qvo_;
+    std::unordered_set<VertexT> visited_;
+    std::unordered_set<VertexT> queued_;
+    std::deque<VertexT> queue_;
+
+    std::size_t GetDomainSize(VertexT pattern_vertex) const;
+    std::size_t GetPatternDegree(VertexT vertex) const;
+    bool IsBetterRoot(VertexT lhs, VertexT rhs) const;
+    VertexT ChooseNextRoot() const;
+    void EnqueueIfNeeded(VertexT vertex);
+    void EnqueueUndirectedNeighbors(VertexT vertex);
+    void VisitNext();
+
+public:
+    BfsQvoStrategy(GraphT const & /*graph*/, GraphT const &pattern, DomainT const &domain)
+        : pattern_(pattern), domain_(domain) {}
+
+    std::vector<VertexT> Order();
+};
+
+class CostBasedQvoStrategy {
+private:
+    using GraphT = model::gdd::graph_t;
+    using VertexT = model::gdd::vertex_t;
+    using DomainT = model::gdd::detail::DomainT;
+
+    enum class Direction : std::uint8_t { kIn, kOut };
+
+    struct ExtensionListDescriptor {
+        VertexT from;  // placed in order pattern vertex
+        Direction direction;
+        std::string edge_label;
+    };
+
+    static constexpr std::size_t kExhaustiveLimit = 7;
+
+    GraphT const &graph_;
+    GraphT const &pattern_;
+    DomainT const &domain_;
+
+    std::unordered_map<std::string, double> avg_out_size_;
+    std::unordered_map<std::string, double> avg_in_size_;
+    void ComputeAvgListSizes();
+
+    std::size_t VertexDomainSize(VertexT pattern_vertex) const;
+    double AvgListSize(std::string const &edge_label, Direction direction) const;
+
+    bool ConnectsToPlaced(VertexT vertex,
+                          std::unordered_map<VertexT, std::size_t> const &placed) const;
+    std::vector<ExtensionListDescriptor> ExtensionListsFor(
+            VertexT to, std::unordered_map<VertexT, std::size_t> const &placed) const;
+    double StepCost(VertexT next, std::size_t level,
+                    std::unordered_map<VertexT, std::size_t> const &placed,
+                    std::vector<double> const &card_by_level, double &match_estimate) const;
+
+    std::vector<VertexT> OrderExhaustive() const;
+    std::vector<VertexT> OrderGreedy() const;
+
+    struct PatternVerticesIdComparator {
+        GraphT const &pattern;
+
+        bool operator()(VertexT a, VertexT b) const noexcept {
+            return pattern[a].id < pattern[b].id;
+        }
+    } pattern_vertices_comparator_{pattern_};
+
+public:
+    CostBasedQvoStrategy(GraphT const &graph, GraphT const &pattern, DomainT const &domain)
+        : graph_(graph), pattern_(pattern), domain_(domain) {
+        ComputeAvgListSizes();
+    }
+
+    std::vector<VertexT> Order() const {
+        std::size_t const m = boost::num_vertices(pattern_);
+        if (m == 0) {
+            return {};
+        }
+        return m <= kExhaustiveLimit ? OrderExhaustive() : OrderGreedy();
+    }
+};
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/qvo_strategies.h
+++ b/src/core/algorithms/gdd/gdd_validator/qvo_strategies.h
@@ -10,9 +10,9 @@ namespace algos {
 
 template <typename T>
 concept QvoStrategy = requires(T strategy) {
-    requires std::constructible_from<T, model::gdd::graph_t const & /*graph*/,
-                                     model::gdd::graph_t const & /*pattern*/,
-                                     model::gdd::detail::DomainT const &> /*domain*/;
+    requires std::constructible_from<T, model::gdd::graph_t const& /*graph*/,
+                                     model::gdd::graph_t const& /*pattern*/,
+                                     model::gdd::detail::DomainT const&> /*domain*/;
 
     { strategy.Order() } -> std::convertible_to<std::vector<model::gdd::vertex_t>>;
 };
@@ -23,8 +23,8 @@ private:
     using VertexT = model::gdd::vertex_t;
     using DomainT = model::gdd::detail::DomainT;
 
-    GraphT const &pattern_;
-    DomainT const &domain_;
+    GraphT const& pattern_;
+    DomainT const& domain_;
 
     std::vector<VertexT> qvo_;
     std::unordered_set<VertexT> visited_;
@@ -40,7 +40,7 @@ private:
     void VisitNext();
 
 public:
-    BfsQvoStrategy(GraphT const & /*graph*/, GraphT const &pattern, DomainT const &domain)
+    BfsQvoStrategy(GraphT const& /*graph*/, GraphT const& pattern, DomainT const& domain)
         : pattern_(pattern), domain_(domain) {}
 
     std::vector<VertexT> Order();
@@ -62,30 +62,30 @@ private:
 
     static constexpr std::size_t kExhaustiveLimit = 7;
 
-    GraphT const &graph_;
-    GraphT const &pattern_;
-    DomainT const &domain_;
+    GraphT const& graph_;
+    GraphT const& pattern_;
+    DomainT const& domain_;
 
     std::unordered_map<std::string, double> avg_out_size_;
     std::unordered_map<std::string, double> avg_in_size_;
     void ComputeAvgListSizes();
 
     std::size_t VertexDomainSize(VertexT pattern_vertex) const;
-    double AvgListSize(std::string const &edge_label, Direction direction) const;
+    double AvgListSize(std::string const& edge_label, Direction direction) const;
 
     bool ConnectsToPlaced(VertexT vertex,
-                          std::unordered_map<VertexT, std::size_t> const &placed) const;
+                          std::unordered_map<VertexT, std::size_t> const& placed) const;
     std::vector<ExtensionListDescriptor> ExtensionListsFor(
-            VertexT to, std::unordered_map<VertexT, std::size_t> const &placed) const;
+            VertexT to, std::unordered_map<VertexT, std::size_t> const& placed) const;
     double StepCost(VertexT next, std::size_t level,
-                    std::unordered_map<VertexT, std::size_t> const &placed,
-                    std::vector<double> const &card_by_level, double &match_estimate) const;
+                    std::unordered_map<VertexT, std::size_t> const& placed,
+                    std::vector<double> const& card_by_level, double& match_estimate) const;
 
     std::vector<VertexT> OrderExhaustive() const;
     std::vector<VertexT> OrderGreedy() const;
 
     struct PatternVerticesIdComparator {
-        GraphT const &pattern;
+        GraphT const& pattern;
 
         bool operator()(VertexT a, VertexT b) const noexcept {
             return pattern[a].id < pattern[b].id;
@@ -93,7 +93,7 @@ private:
     } pattern_vertices_comparator_{pattern_};
 
 public:
-    CostBasedQvoStrategy(GraphT const &graph, GraphT const &pattern, DomainT const &domain)
+    CostBasedQvoStrategy(GraphT const& graph, GraphT const& pattern, DomainT const& domain)
         : graph_(graph), pattern_(pattern), domain_(domain) {
         ComputeAvgListSizes();
     }

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -57,6 +57,7 @@ bool WcojGddValidator::IsPatternWeaklyConnected() const {
 
 GddValidator::GddHoldsResult WcojGddValidator::Holds(model::Gdd const& gdd,
                                                      model::gdd::graph_t const& graph) {
+    match_count_ = 0;
     Prepare(gdd, graph);
 
     OperationResult result = Scan();
@@ -72,16 +73,17 @@ GddValidator::GddHoldsResult WcojGddValidator::Holds(model::Gdd const& gdd,
         }
     }
 
-    match_count_ = cur_level_.count();
+    std::size_t const matches_size = cur_level_.count();
     std::size_t const width = cur_level_.width;
     MappingT full_match;
-    for (std::size_t i = 0; i < match_count_; ++i) {
+    for (std::size_t i = 0; i < matches_size; ++i) {
         VertexT const* row = cur_level_.row(i);
         full_match.clear();
         for (std::size_t j = 0; j < width; ++j) {
             full_match.emplace(qvo_[j], row[j]);
         }
 
+        ++match_count_;
         if (!gdd_->Satisfies(graph, full_match)) {
             return {model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match),
                     match_count_};
@@ -89,6 +91,10 @@ GddValidator::GddHoldsResult WcojGddValidator::Holds(model::Gdd const& gdd,
     }
 
     return {std::nullopt, match_count_};
+}
+
+std::unique_ptr<GddValidator> WcojGddValidator::CreateWorker() const {
+    return std::make_unique<WcojGddValidator>();
 }
 
 WcojGddValidator::OperationResult WcojGddValidator::Scan() {

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -1,0 +1,376 @@
+#include "wcoj_gdd_validator.h"
+
+#include <algorithm>
+#include <deque>
+#include <ranges>
+#include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/range/iterator_range.hpp>
+
+namespace algos {
+
+namespace {
+
+// boost::breadth_first_search goes through out_edges only, and there is no
+// way to pass directed graph as undirected without making a copy of it (as far as I know)
+class BfsQueryVertexOrder { private:
+    using GraphT = model::gdd::graph_t;
+    using VertexT = model::gdd::vertex_t;
+    using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
+
+    GraphT const& pattern_;
+    DomainT const& domain_;
+
+    std::vector<VertexT> qvo_;
+    std::unordered_set<VertexT> visited_;
+    std::unordered_set<VertexT> queued_;
+    std::deque<VertexT> queue_;
+
+    std::size_t GetDomainSize(VertexT pattern_vertex) const {
+        auto const it = domain_.find(pattern_vertex);
+        if (it == domain_.end()) {
+            return 0;
+        }
+        return it->second.size();
+    }
+
+    std::size_t GetPatternDegree(VertexT vertex) const {
+        return boost::out_degree(vertex, pattern_) + boost::in_degree(vertex, pattern_);
+    }
+
+    bool IsBetterRoot(VertexT lhs, VertexT rhs) const {
+        std::size_t const lhs_domain_size = GetDomainSize(lhs);
+        std::size_t const rhs_domain_size = GetDomainSize(rhs);
+
+        if (lhs_domain_size != rhs_domain_size) {
+            return lhs_domain_size < rhs_domain_size;
+        }
+
+        std::size_t const lhs_degree = GetPatternDegree(lhs);
+        std::size_t const rhs_degree = GetPatternDegree(rhs);
+
+        if (lhs_degree != rhs_degree) {
+            return lhs_degree > rhs_degree;
+        }
+
+        return pattern_[lhs].id < pattern_[rhs].id;
+    }
+
+    VertexT ChooseNextRoot() const {
+        bool found = false;
+        VertexT best{};
+
+        for (auto const vertex : boost::make_iterator_range(boost::vertices(pattern_))) {
+            if (visited_.contains(vertex)) {
+                continue;
+            }
+
+            if (!found || IsBetterRoot(vertex, best)) {
+                best = vertex;
+                found = true;
+            }
+        }
+
+        if (!found) {
+            throw std::logic_error("BuildQueryVertexOrder called with no unvisited vertices left");
+        }
+
+        return best;
+    }
+
+    void EnqueueIfNeeded(VertexT vertex) {
+        if (!visited_.contains(vertex) && queued_.emplace(vertex).second) {
+            queue_.push_back(vertex);
+        }
+    }
+
+    void EnqueueUndirectedNeighbors(VertexT vertex) {
+        for (auto const edge : boost::make_iterator_range(boost::out_edges(vertex, pattern_))) {
+            EnqueueIfNeeded(boost::target(edge, pattern_));
+        }
+
+        for (auto const edge : boost::make_iterator_range(boost::in_edges(vertex, pattern_))) {
+            EnqueueIfNeeded(boost::source(edge, pattern_));
+        }
+    }
+
+    void VisitNext() {
+        VertexT const current = queue_.front();
+        queue_.pop_front();
+        queued_.erase(current);
+
+        if (!visited_.emplace(current).second) {
+            return;
+        }
+
+        qvo_.push_back(current);
+        EnqueueUndirectedNeighbors(current);
+    }
+
+public:
+    BfsQueryVertexOrder(GraphT const& pattern, DomainT const& domain)
+        : pattern_(pattern), domain_(domain) {}
+
+    std::vector<VertexT> Build() {
+        qvo_.clear();
+        visited_.clear();
+        queued_.clear();
+        queue_.clear();
+
+        std::size_t const vertex_count = boost::num_vertices(pattern_);
+        qvo_.reserve(vertex_count);
+
+        while (qvo_.size() != vertex_count) {
+            if (queue_.empty()) {
+                EnqueueIfNeeded(ChooseNextRoot());
+            }
+
+            VisitNext();
+        }
+
+        return qvo_;
+    }
+};
+
+}  // namespace
+
+void WcojGddValidator::Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph) {
+    gdd_ = &gdd;
+    graph_ = &graph;
+    pattern_ = &gdd.GetPattern();
+
+    match_levels_.clear();
+    adjacency_index_.clear();
+
+    match_levels_.reserve(boost::num_vertices(*pattern_));
+
+    // O(Q_V * G_V)
+    domain_ = BuildDomain(*pattern_, *graph_);
+    // O(Q_V + Q_E)
+    qvo_ = BuildQueryVertexOrder();
+}
+
+std::vector<GddValidator::VertexT> WcojGddValidator::BuildQueryVertexOrder() const {
+    // base implementation, does not use graph statistics and does not compute
+    // cost of QVO plan
+    return BfsQueryVertexOrder(*pattern_, domain_).Build();
+}
+
+std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const& gdd,
+                                                                model::gdd::graph_t const& graph) {
+    Prepare(gdd, graph);
+
+    OperationResult result = Scan();
+    if (result == OperationResult::kEmpty) {
+        return std::nullopt;
+    }
+
+    while (result != OperationResult::kFinished) {
+        if (result = ExtendIntersect(); result == OperationResult::kEmpty) {
+            return std::nullopt;
+        }
+    }
+
+    for (MappingT const& full_match : match_levels_.back()) {
+        if (!gdd_->Satisfies(graph, full_match)) {
+            return model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match);
+        }
+    }
+
+    return std::nullopt;
+}
+
+WcojGddValidator::OperationResult WcojGddValidator::Scan() {
+    if (qvo_.empty()) {
+        return OperationResult::kEmpty;
+    }
+
+    auto const first_pv = qvo_.front();
+
+    auto const domain_it = domain_.find(first_pv);
+    if (domain_it == domain_.end() || domain_it->second.empty()) {
+        return OperationResult::kEmpty;
+    }
+
+    auto const& candidates = domain_it->second;
+
+    MatchLevelT level;
+    // O(G_V)
+    for (auto const gv : candidates) {
+        level.emplace_back(MappingT{{first_pv, gv}});
+    }
+
+    match_levels_.emplace_back(std::move(level));
+    if (qvo_.size() == 1) {
+        return OperationResult::kFinished;
+    }
+
+    return OperationResult::kProduced;
+}
+
+WcojGddValidator::OperationResult WcojGddValidator::ExtendIntersect() {
+    std::size_t const match_level = match_levels_.size();
+
+    if (match_level == 0) {
+        throw std::logic_error("Scan call is required before ExtendIntersect call");
+    }
+    if (match_level >= qvo_.size()) {
+        return OperationResult::kFinished;
+    }
+
+    auto const new_pv = qvo_[match_level];
+    MatchLevelT const& prev_level = match_levels_[match_level - 1];
+    MatchLevelT next_level;
+
+    auto const& descriptors = BuildDescriptorsFor(new_pv, match_level);
+    for (MappingT const& partial_match : prev_level) {
+        std::vector<VertexT> const extension_set =
+                ComputeExtensionSet(partial_match, new_pv, descriptors);
+
+        for (VertexT graph_vertex : extension_set) {
+            MappingT extended_match = partial_match;
+
+            if (auto const [_, inserted] = extended_match.emplace(new_pv, graph_vertex);
+                !inserted) {
+                throw std::logic_error("New pattern vertex is already present in partial match");
+            }
+
+            next_level.emplace_back(std::move(extended_match));
+        }
+    }
+
+    if (next_level.empty()) {
+        return OperationResult::kEmpty;
+    }
+
+    match_levels_.emplace_back(std::move(next_level));
+
+    return match_levels_.size() == qvo_.size() ? OperationResult::kFinished
+                                               : OperationResult::kProduced;
+}
+
+std::vector<WcojGddValidator::AdjacencyDescriptor> WcojGddValidator::BuildDescriptorsFor(
+        VertexT new_pv, std::size_t level) const {
+    if (level > qvo_.size()) {
+        throw std::logic_error("BuildDescriptorsFor level is greater than qvo_.size()");
+    }
+
+    std::vector<AdjacencyDescriptor> descriptors;
+    for (std::size_t i = 0; i < level; ++i) {
+        VertexT const old_pv = qvo_[i];
+
+        for (auto const edge : boost::make_iterator_range(boost::out_edges(old_pv, *pattern_))) {
+            if (boost::target(edge, *pattern_) == new_pv) {
+                descriptors.push_back(AdjacencyDescriptor{
+                        .pattern_vertex = old_pv,
+                        .direction = Direction::kOut,
+                        .edge_label = (*pattern_)[edge].label,
+                });
+            }
+        }
+
+        for (auto const edge : boost::make_iterator_range(boost::in_edges(old_pv, *pattern_))) {
+            if (boost::source(edge, *pattern_) == new_pv) {
+                descriptors.push_back(AdjacencyDescriptor{
+                        .pattern_vertex = old_pv,
+                        .direction = Direction::kIn,
+                        .edge_label = (*pattern_)[edge].label,
+                });
+            }
+        }
+    }
+
+    return descriptors;
+}
+
+std::vector<GddValidator::VertexT> const& WcojGddValidator::GetNeighbors(
+        VertexT graph_vertex, Direction direction, std::string const& edge_label) {
+    if (graph_ == nullptr) {
+        throw std::logic_error("GetNeighbors called before Prepare");
+    }
+
+    NeighborKey const key{
+            .graph_vertex = graph_vertex,
+            .direction = direction,
+            .edge_label = edge_label,
+    };
+
+    if (auto const it = adjacency_index_.find(key); it != adjacency_index_.end()) {
+        return it->second;
+    }
+
+    auto [it, inserted] = adjacency_index_.emplace(key, std::vector<VertexT>{});
+    std::vector<VertexT>& neighbors = it->second;
+
+    if (direction == Direction::kOut) {
+        for (auto const edge :
+             boost::make_iterator_range(boost::out_edges(graph_vertex, *graph_))) {
+            if (LabelsMatch(edge_label, (*graph_)[edge].label)) {
+                neighbors.push_back(boost::target(edge, *graph_));
+            }
+        }
+    } else {
+        for (auto const edge : boost::make_iterator_range(boost::in_edges(graph_vertex, *graph_))) {
+            if (LabelsMatch(edge_label, (*graph_)[edge].label)) {
+                neighbors.push_back(boost::source(edge, *graph_));
+            }
+        }
+    }
+
+    return neighbors;
+}
+
+std::vector<GddValidator::VertexT> WcojGddValidator::ComputeExtensionSet(
+        MappingT const& partial_match, VertexT new_pv,
+        std::vector<AdjacencyDescriptor> const& descriptors) {
+    auto const domain_it = domain_.find(new_pv);
+    if (domain_it == domain_.end() || domain_it->second.empty()) {
+        return {};
+    }
+
+    std::vector<VertexT> const& domain = domain_it->second;
+
+    if (descriptors.empty()) {
+        return domain;
+    }
+
+    std::unordered_set candidates(domain.begin(), domain.end());
+
+    for (auto const& [pattern_vertex, direction, edge_label] : descriptors) {
+        auto const mapped_it = partial_match.find(pattern_vertex);
+        if (mapped_it == partial_match.end()) {
+            throw std::logic_error(
+                    "Descriptor references a pattern vertex absent from partial match");
+        }
+
+        VertexT const mapped_graph_vertex = mapped_it->second;
+        std::vector<VertexT> const& neighbors =
+                GetNeighbors(mapped_graph_vertex, direction, edge_label);
+
+        if (neighbors.empty()) {
+            return {};
+        }
+
+        std::unordered_set neighbor_set(neighbors.begin(), neighbors.end());
+
+        for (auto it = candidates.begin(); it != candidates.end();) {
+            if (!neighbor_set.contains(*it)) {
+                it = candidates.erase(it);
+            } else {
+                ++it;
+            }
+        }
+
+        if (candidates.empty()) {
+            return {};
+        }
+    }
+
+    std::vector extension_set(candidates.begin(), candidates.end());
+    return extension_set;
+}
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -16,7 +16,8 @@ namespace {
 
 // boost::breadth_first_search goes through out_edges only, and there is no
 // way to pass directed graph as undirected without making a copy of it (as far as I know)
-class BfsQueryVertexOrder { private:
+class BfsQueryVertexOrder {
+private:
     using GraphT = model::gdd::graph_t;
     using VertexT = model::gdd::vertex_t;
     using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
@@ -147,9 +148,10 @@ void WcojGddValidator::Prepare(model::Gdd const& gdd, model::gdd::graph_t const&
 
     match_levels_.reserve(boost::num_vertices(*pattern_));
 
-    // O(Q_V * G_V)
     domain_ = BuildDomain(*pattern_, *graph_);
-    // O(Q_V + Q_E)
+    for (auto& set : domain_ | std::views::values) {
+        std::ranges::sort(set);
+    }
     qvo_ = BuildQueryVertexOrder();
 }
 
@@ -198,16 +200,11 @@ WcojGddValidator::OperationResult WcojGddValidator::Scan() {
     auto const& candidates = domain_it->second;
 
     MatchLevelT level;
-    // O(G_V)
     for (auto const gv : candidates) {
         level.emplace_back(MappingT{{first_pv, gv}});
     }
 
     match_levels_.emplace_back(std::move(level));
-    if (qvo_.size() == 1) {
-        return OperationResult::kFinished;
-    }
-
     return OperationResult::kProduced;
 }
 
@@ -320,6 +317,9 @@ std::vector<GddValidator::VertexT> const& WcojGddValidator::GetNeighbors(
         }
     }
 
+    std::ranges::sort(neighbors);
+    auto const [first, last] = std::ranges::unique(neighbors.begin(), neighbors.end());
+    neighbors.erase(first, last);
     return neighbors;
 }
 
@@ -337,7 +337,9 @@ std::vector<GddValidator::VertexT> WcojGddValidator::ComputeExtensionSet(
         return domain;
     }
 
-    std::unordered_set candidates(domain.begin(), domain.end());
+    std::vector<std::vector<VertexT> const*> lists;
+    lists.reserve(descriptors.size() + 1);
+    lists.push_back(&domain);
 
     for (auto const& [pattern_vertex, direction, edge_label] : descriptors) {
         auto const mapped_it = partial_match.find(pattern_vertex);
@@ -346,31 +348,33 @@ std::vector<GddValidator::VertexT> WcojGddValidator::ComputeExtensionSet(
                     "Descriptor references a pattern vertex absent from partial match");
         }
 
-        VertexT const mapped_graph_vertex = mapped_it->second;
         std::vector<VertexT> const& neighbors =
-                GetNeighbors(mapped_graph_vertex, direction, edge_label);
+                GetNeighbors(mapped_it->second, direction, edge_label);
 
         if (neighbors.empty()) {
             return {};
         }
 
-        std::unordered_set neighbor_set(neighbors.begin(), neighbors.end());
-
-        for (auto it = candidates.begin(); it != candidates.end();) {
-            if (!neighbor_set.contains(*it)) {
-                it = candidates.erase(it);
-            } else {
-                ++it;
-            }
-        }
-
-        if (candidates.empty()) {
-            return {};
-        }
+        // neighbors are cached in adjacency_index_, so the pointer lives
+        lists.push_back(&neighbors);
     }
 
-    std::vector extension_set(candidates.begin(), candidates.end());
-    return extension_set;
+    // for faster intersections, |A \cap B| <= max(|A|, |B|)
+    std::ranges::sort(lists, [](auto const* a, auto const* b) { return a->size() < b->size(); });
+
+    std::vector<VertexT> acc = IntersectSorted(*lists[0], *lists[1]);
+    for (std::size_t i = 2; i < lists.size() && !acc.empty(); ++i) {
+        acc = IntersectSorted(acc, *lists[i]);
+    }
+    return acc;
+}
+
+std::vector<GddValidator::VertexT> WcojGddValidator::IntersectSorted(
+        std::vector<VertexT> const& lhs, std::vector<VertexT> const& rhs) {
+    std::vector<VertexT> result;
+    result.reserve(std::min(lhs.size(), rhs.size()));
+    std::ranges::set_intersection(lhs, rhs, std::back_inserter(result));
+    return result;
 }
 
 }  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -1,7 +1,6 @@
 #include "wcoj_gdd_validator.h"
 
 #include <algorithm>
-#include <deque>
 #include <ranges>
 #include <stdexcept>
 #include <unordered_map>
@@ -12,153 +11,22 @@
 
 namespace algos {
 
-namespace {
-
-// boost::breadth_first_search goes through out_edges only, and there is no
-// way to pass directed graph as undirected without making a copy of it (as far as I know)
-class BfsQueryVertexOrder {
-private:
-    using GraphT = model::gdd::graph_t;
-    using VertexT = model::gdd::vertex_t;
-    using DomainT = std::unordered_map<VertexT, std::vector<VertexT>>;
-
-    GraphT const& pattern_;
-    DomainT const& domain_;
-
-    std::vector<VertexT> qvo_;
-    std::unordered_set<VertexT> visited_;
-    std::unordered_set<VertexT> queued_;
-    std::deque<VertexT> queue_;
-
-    std::size_t GetDomainSize(VertexT pattern_vertex) const {
-        auto const it = domain_.find(pattern_vertex);
-        if (it == domain_.end()) {
-            return 0;
-        }
-        return it->second.size();
-    }
-
-    std::size_t GetPatternDegree(VertexT vertex) const {
-        return boost::out_degree(vertex, pattern_) + boost::in_degree(vertex, pattern_);
-    }
-
-    bool IsBetterRoot(VertexT lhs, VertexT rhs) const {
-        std::size_t const lhs_domain_size = GetDomainSize(lhs);
-        std::size_t const rhs_domain_size = GetDomainSize(rhs);
-
-        if (lhs_domain_size != rhs_domain_size) {
-            return lhs_domain_size < rhs_domain_size;
-        }
-
-        std::size_t const lhs_degree = GetPatternDegree(lhs);
-        std::size_t const rhs_degree = GetPatternDegree(rhs);
-
-        if (lhs_degree != rhs_degree) {
-            return lhs_degree > rhs_degree;
-        }
-
-        return pattern_[lhs].id < pattern_[rhs].id;
-    }
-
-    VertexT ChooseNextRoot() const {
-        bool found = false;
-        VertexT best{};
-
-        for (auto const vertex : boost::make_iterator_range(boost::vertices(pattern_))) {
-            if (visited_.contains(vertex)) {
-                continue;
-            }
-
-            if (!found || IsBetterRoot(vertex, best)) {
-                best = vertex;
-                found = true;
-            }
-        }
-
-        if (!found) {
-            throw std::logic_error("BuildQueryVertexOrder called with no unvisited vertices left");
-        }
-
-        return best;
-    }
-
-    void EnqueueIfNeeded(VertexT vertex) {
-        if (!visited_.contains(vertex) && queued_.emplace(vertex).second) {
-            queue_.push_back(vertex);
-        }
-    }
-
-    void EnqueueUndirectedNeighbors(VertexT vertex) {
-        for (auto const edge : boost::make_iterator_range(boost::out_edges(vertex, pattern_))) {
-            EnqueueIfNeeded(boost::target(edge, pattern_));
-        }
-
-        for (auto const edge : boost::make_iterator_range(boost::in_edges(vertex, pattern_))) {
-            EnqueueIfNeeded(boost::source(edge, pattern_));
-        }
-    }
-
-    void VisitNext() {
-        VertexT const current = queue_.front();
-        queue_.pop_front();
-        queued_.erase(current);
-
-        if (!visited_.emplace(current).second) {
-            return;
-        }
-
-        qvo_.push_back(current);
-        EnqueueUndirectedNeighbors(current);
-    }
-
-public:
-    BfsQueryVertexOrder(GraphT const& pattern, DomainT const& domain)
-        : pattern_(pattern), domain_(domain) {}
-
-    std::vector<VertexT> Build() {
-        qvo_.clear();
-        visited_.clear();
-        queued_.clear();
-        queue_.clear();
-
-        std::size_t const vertex_count = boost::num_vertices(pattern_);
-        qvo_.reserve(vertex_count);
-
-        while (qvo_.size() != vertex_count) {
-            if (queue_.empty()) {
-                EnqueueIfNeeded(ChooseNextRoot());
-            }
-
-            VisitNext();
-        }
-
-        return qvo_;
-    }
-};
-
-}  // namespace
-
 void WcojGddValidator::Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph) {
     gdd_ = &gdd;
     graph_ = &graph;
     pattern_ = &gdd.GetPattern();
 
-    match_levels_.clear();
+    cur_level_.clear();
+    next_level_.clear();
+    level_count_ = 0;
     adjacency_index_.clear();
-
-    match_levels_.reserve(boost::num_vertices(*pattern_));
 
     domain_ = BuildDomain(*pattern_, *graph_);
     for (auto& set : domain_ | std::views::values) {
         std::ranges::sort(set);
     }
-    qvo_ = BuildQueryVertexOrder();
-}
 
-std::vector<GddValidator::VertexT> WcojGddValidator::BuildQueryVertexOrder() const {
-    // base implementation, does not use graph statistics and does not compute
-    // cost of QVO plan
-    return BfsQueryVertexOrder(*pattern_, domain_).Build();
+    qvo_ = BuildQueryVertexOrder<CostBasedQvoStrategy>();
 }
 
 std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const& gdd,
@@ -176,7 +44,16 @@ std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const
         }
     }
 
-    for (MappingT const& full_match : match_levels_.back()) {
+    std::size_t const count = cur_level_.count();
+    std::size_t const width = cur_level_.width;
+    MappingT full_match;
+    for (std::size_t i = 0; i < count; ++i) {
+        VertexT const* row = cur_level_.row(i);
+        full_match.clear();
+        for (std::size_t j = 0; j < width; ++j) {
+            full_match.emplace(qvo_[j], row[j]);
+        }
+
         if (!gdd_->Satisfies(graph, full_match)) {
             return model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match);
         }
@@ -199,54 +76,50 @@ WcojGddValidator::OperationResult WcojGddValidator::Scan() {
 
     auto const& candidates = domain_it->second;
 
-    MatchLevelT level;
-    for (auto const gv : candidates) {
-        level.emplace_back(MappingT{{first_pv, gv}});
-    }
+    cur_level_.reset(1);
+    cur_level_.data.assign(candidates.begin(), candidates.end());
 
-    match_levels_.emplace_back(std::move(level));
+    level_count_ = 1;
     return OperationResult::kProduced;
 }
 
 WcojGddValidator::OperationResult WcojGddValidator::ExtendIntersect() {
-    std::size_t const match_level = match_levels_.size();
+    intersection_cache_.last_isect_valid = false;
 
-    if (match_level == 0) {
+    if (level_count_ == 0) {
         throw std::logic_error("Scan call is required before ExtendIntersect call");
     }
-    if (match_level >= qvo_.size()) {
+    if (level_count_ >= qvo_.size()) {
         return OperationResult::kFinished;
     }
 
-    auto const new_pv = qvo_[match_level];
-    MatchLevelT const& prev_level = match_levels_[match_level - 1];
-    MatchLevelT next_level;
+    auto const new_pv = qvo_[level_count_];
+    std::size_t const parent_width = cur_level_.width;
+    std::size_t const parent_count = cur_level_.count();
 
-    auto const& descriptors = BuildDescriptorsFor(new_pv, match_level);
-    for (MappingT const& partial_match : prev_level) {
-        std::vector<VertexT> const extension_set =
-                ComputeExtensionSet(partial_match, new_pv, descriptors);
+    next_level_.reset(level_count_ + 1);
+    // at least one child per parent
+    next_level_.data.reserve(cur_level_.data.size() + parent_count);
 
-        for (VertexT graph_vertex : extension_set) {
-            MappingT extended_match = partial_match;
+    auto const& descriptors = BuildDescriptorsFor(new_pv, level_count_);
+    for (std::size_t i = 0; i < parent_count; ++i) {
+        VertexT const* parent = cur_level_.row(i);
+        std::vector<VertexT> const& extension_set =
+                ComputeExtensionSet(parent, new_pv, descriptors);
 
-            if (auto const [_, inserted] = extended_match.emplace(new_pv, graph_vertex);
-                !inserted) {
-                throw std::logic_error("New pattern vertex is already present in partial match");
-            }
-
-            next_level.emplace_back(std::move(extended_match));
+        for (VertexT const graph_vertex : extension_set) {
+            next_level_.push_row(parent, parent_width, graph_vertex);
         }
     }
 
-    if (next_level.empty()) {
+    if (next_level_.count() == 0) {
         return OperationResult::kEmpty;
     }
 
-    match_levels_.emplace_back(std::move(next_level));
+    std::swap(cur_level_, next_level_);
+    ++level_count_;
 
-    return match_levels_.size() == qvo_.size() ? OperationResult::kFinished
-                                               : OperationResult::kProduced;
+    return level_count_ == qvo_.size() ? OperationResult::kFinished : OperationResult::kProduced;
 }
 
 std::vector<WcojGddValidator::AdjacencyDescriptor> WcojGddValidator::BuildDescriptorsFor(
@@ -263,6 +136,7 @@ std::vector<WcojGddValidator::AdjacencyDescriptor> WcojGddValidator::BuildDescri
             if (boost::target(edge, *pattern_) == new_pv) {
                 descriptors.push_back(AdjacencyDescriptor{
                         .pattern_vertex = old_pv,
+                        .qvo_index = i,
                         .direction = Direction::kOut,
                         .edge_label = (*pattern_)[edge].label,
                 });
@@ -273,6 +147,7 @@ std::vector<WcojGddValidator::AdjacencyDescriptor> WcojGddValidator::BuildDescri
             if (boost::source(edge, *pattern_) == new_pv) {
                 descriptors.push_back(AdjacencyDescriptor{
                         .pattern_vertex = old_pv,
+                        .qvo_index = i,
                         .direction = Direction::kIn,
                         .edge_label = (*pattern_)[edge].label,
                 });
@@ -323,58 +198,85 @@ std::vector<GddValidator::VertexT> const& WcojGddValidator::GetNeighbors(
     return neighbors;
 }
 
-std::vector<GddValidator::VertexT> WcojGddValidator::ComputeExtensionSet(
-        MappingT const& partial_match, VertexT new_pv,
+std::vector<GddValidator::VertexT> const& WcojGddValidator::ComputeExtensionSet(
+        VertexT const* partial_match, VertexT new_pv,
         std::vector<AdjacencyDescriptor> const& descriptors) {
     auto const domain_it = domain_.find(new_pv);
     if (domain_it == domain_.end() || domain_it->second.empty()) {
-        return {};
+        intersection_cache_.last_isect_valid = false;
+        intersection_cache_.last_isect_key.clear();
+        intersection_cache_.last_isect_set.clear();
+        return intersection_cache_.last_isect_set;
     }
 
     std::vector<VertexT> const& domain = domain_it->second;
 
     if (descriptors.empty()) {
+        intersection_cache_.last_isect_valid = false;
         return domain;
+    }
+
+    // lookup intersection cache
+    std::vector<VertexT> key;
+    key.reserve(descriptors.size());
+    for (auto const& d : descriptors) {
+        key.push_back(partial_match[d.qvo_index]);
+    }
+
+    if (intersection_cache_.last_isect_valid && intersection_cache_.last_isect_key == key) {
+        return intersection_cache_.last_isect_set;
     }
 
     std::vector<std::vector<VertexT> const*> lists;
     lists.reserve(descriptors.size() + 1);
     lists.push_back(&domain);
 
-    for (auto const& [pattern_vertex, direction, edge_label] : descriptors) {
-        auto const mapped_it = partial_match.find(pattern_vertex);
-        if (mapped_it == partial_match.end()) {
-            throw std::logic_error(
-                    "Descriptor references a pattern vertex absent from partial match");
-        }
-
-        std::vector<VertexT> const& neighbors =
-                GetNeighbors(mapped_it->second, direction, edge_label);
+    for (auto const& d : descriptors) {
+        VertexT const mapped = partial_match[d.qvo_index];
+        std::vector<VertexT> const& neighbors = GetNeighbors(mapped, d.direction, d.edge_label);
 
         if (neighbors.empty()) {
-            return {};
+            intersection_cache_.last_isect_valid = true;
+            intersection_cache_.last_isect_key.assign(key.begin(), key.end());
+            intersection_cache_.last_isect_set.clear();
+            return intersection_cache_.last_isect_set;
         }
 
         // neighbors are cached in adjacency_index_, so the pointer lives
         lists.push_back(&neighbors);
     }
 
+    intersection_cache_.last_isect_key.assign(key.begin(), key.end());
+    IntersectSorted(lists, intersection_cache_.last_isect_set);
+    intersection_cache_.last_isect_valid = true;
+    return intersection_cache_.last_isect_set;
+}
+
+void WcojGddValidator::IntersectSorted(std::vector<std::vector<VertexT> const*>& lists,
+                                       std::vector<VertexT>& out) {
     // for faster intersections, |A \cap B| <= max(|A|, |B|)
     std::ranges::sort(lists, [](auto const* a, auto const* b) { return a->size() < b->size(); });
 
-    std::vector<VertexT> acc = IntersectSorted(*lists[0], *lists[1]);
-    for (std::size_t i = 2; i < lists.size() && !acc.empty(); ++i) {
-        acc = IntersectSorted(acc, *lists[i]);
-    }
-    return acc;
-}
+    out.clear();
+    std::ranges::set_intersection(*lists[0], *lists[1], std::back_inserter(out));
 
-std::vector<GddValidator::VertexT> WcojGddValidator::IntersectSorted(
-        std::vector<VertexT> const& lhs, std::vector<VertexT> const& rhs) {
-    std::vector<VertexT> result;
-    result.reserve(std::min(lhs.size(), rhs.size()));
-    std::ranges::set_intersection(lhs, rhs, std::back_inserter(result));
-    return result;
+    if (lists.size() == 2) {
+        return;
+    }
+
+    scratch_.clear();
+    std::vector<VertexT>* cur = &out;
+    std::vector<VertexT>* tmp = &scratch_;
+
+    for (std::size_t i = 2; i < lists.size() && !cur->empty(); ++i) {
+        tmp->clear();
+        std::ranges::set_intersection(*cur, *lists[i], std::back_inserter(*tmp));
+        std::swap(cur, tmp);
+    }
+
+    if (cur != &out) {
+        std::swap(out, *cur);
+    }
 }
 
 }  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -55,25 +55,27 @@ bool WcojGddValidator::IsPatternWeaklyConnected() const {
     return boost::connected_components(undirected, component.data()) == 1;
 }
 
-std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const& gdd,
-                                                                model::gdd::graph_t const& graph) {
+GddValidator::GddHoldsResult WcojGddValidator::Holds(model::Gdd const& gdd,
+                                                     model::gdd::graph_t const& graph) {
     Prepare(gdd, graph);
 
     OperationResult result = Scan();
     if (result == OperationResult::kEmpty) {
-        return std::nullopt;
+        match_count_ = 0;
+        return {std::nullopt, match_count_};
     }
 
     while (result != OperationResult::kFinished) {
         if (result = ExtendIntersect(); result == OperationResult::kEmpty) {
-            return std::nullopt;
+            match_count_ = 0;
+            return {std::nullopt, match_count_};
         }
     }
 
-    std::size_t const count = cur_level_.count();
+    match_count_ = cur_level_.count();
     std::size_t const width = cur_level_.width;
     MappingT full_match;
-    for (std::size_t i = 0; i < count; ++i) {
+    for (std::size_t i = 0; i < match_count_; ++i) {
         VertexT const* row = cur_level_.row(i);
         full_match.clear();
         for (std::size_t j = 0; j < width; ++j) {
@@ -81,11 +83,12 @@ std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const
         }
 
         if (!gdd_->Satisfies(graph, full_match)) {
-            return model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match);
+            return {model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match),
+                    match_count_};
         }
     }
 
-    return std::nullopt;
+    return {std::nullopt, match_count_};
 }
 
 WcojGddValidator::OperationResult WcojGddValidator::Scan() {

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -7,6 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/connected_components.hpp>
 #include <boost/range/iterator_range.hpp>
 
 namespace algos {
@@ -26,7 +28,31 @@ void WcojGddValidator::Prepare(model::Gdd const& gdd, model::gdd::graph_t const&
         std::ranges::sort(set);
     }
 
-    qvo_ = BuildQueryVertexOrder<CostBasedQvoStrategy>();
+    if (IsPatternWeaklyConnected()) {
+        qvo_ = BuildQueryVertexOrder<CostBasedQvoStrategy>();
+    } else {
+        qvo_ = BuildQueryVertexOrder<BfsQvoStrategy>();
+    }
+}
+
+bool WcojGddValidator::IsPatternWeaklyConnected() const {
+    if (pattern_ == nullptr) {
+        return false;
+    }
+
+    std::size_t const n = boost::num_vertices(*pattern_);
+    if (n == 0) {
+        return true;
+    }
+
+    using UndirectedGraph = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS>;
+    UndirectedGraph undirected(n);
+    for (auto const e : boost::make_iterator_range(boost::edges(*pattern_))) {
+        boost::add_edge(boost::source(e, *pattern_), boost::target(e, *pattern_), undirected);
+    }
+
+    std::vector<int> component(n);
+    return boost::connected_components(undirected, component.data()) == 1;
 }
 
 std::optional<model::GddCounterexample> WcojGddValidator::Holds(model::Gdd const& gdd,

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -1,7 +1,9 @@
 #include "wcoj_gdd_validator.h"
 
 #include <algorithm>
+#include <cassert>
 #include <ranges>
+#include <span>
 #include <stdexcept>
 #include <unordered_map>
 #include <unordered_set>
@@ -13,13 +15,13 @@
 
 namespace algos {
 
-void WcojGddValidator::Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph) {
-    gdd_ = &gdd;
+void WcojGddValidator::Prepare(model::gdd::graph_t const& pattern,
+                               model::gdd::graph_t const& graph) {
     graph_ = &graph;
-    pattern_ = &gdd.GetPattern();
+    pattern_ = &pattern;
 
-    cur_level_.clear();
-    next_level_.clear();
+    cur_level_.Clear();
+    next_level_.Clear();
     level_count_ = 0;
     adjacency_index_.clear();
 
@@ -55,42 +57,57 @@ bool WcojGddValidator::IsPatternWeaklyConnected() const {
     return boost::connected_components(undirected, component.data()) == 1;
 }
 
-GddValidator::GddHoldsResult WcojGddValidator::Holds(model::Gdd const& gdd,
-                                                     model::gdd::graph_t const& graph) {
-    match_count_ = 0;
-    Prepare(gdd, graph);
+void WcojGddValidator::HoldsGroup(std::span<model::Gdd const* const> group,
+                                  model::gdd::graph_t const& graph,
+                                  std::span<GddHoldsResult> output) {
+    assert(group.size() == output.size());
+    std::ranges::fill(output, GddHoldsResult{});
+
+    if (group.empty()) {
+        return;
+    }
+
+    // matching runs once for the pattern shared by the group
+    Prepare(group.front()->GetPattern(), graph);
 
     OperationResult result = Scan();
     if (result == OperationResult::kEmpty) {
-        match_count_ = 0;
-        return {std::nullopt, match_count_};
+        return;
     }
 
     while (result != OperationResult::kFinished) {
         if (result = ExtendIntersect(); result == OperationResult::kEmpty) {
-            match_count_ = 0;
-            return {std::nullopt, match_count_};
+            return;
         }
     }
 
-    std::size_t const matches_size = cur_level_.count();
+    std::size_t const matches_size = cur_level_.Count();
     std::size_t const width = cur_level_.width;
+
+    std::vector<bool> finished(group.size(), false);
+    std::size_t remaining = group.size();
     MappingT full_match;
-    for (std::size_t i = 0; i < matches_size; ++i) {
-        VertexT const* row = cur_level_.row(i);
+
+    for (std::size_t i = 0; i < matches_size && remaining != 0; ++i) {
+        VertexT const* row = cur_level_.Row(i);
         full_match.clear();
         for (std::size_t j = 0; j < width; ++j) {
             full_match.emplace(qvo_[j], row[j]);
         }
 
-        ++match_count_;
-        if (!gdd_->Satisfies(graph, full_match)) {
-            return {model::BuildCounterexample(gdd_->GetPattern(), *graph_, full_match),
-                    match_count_};
+        for (std::size_t gdd_index = 0; gdd_index < group.size(); ++gdd_index) {
+            if (finished[gdd_index]) {
+                continue;
+            }
+
+            ++output[gdd_index].match_count;
+            if (!group[gdd_index]->Satisfies(graph, full_match)) {
+                output[gdd_index].ce = model::BuildCounterexample(*pattern_, *graph_, full_match);
+                finished[gdd_index] = true;
+                --remaining;
+            }
         }
     }
-
-    return {std::nullopt, match_count_};
 }
 
 std::unique_ptr<GddValidator> WcojGddValidator::CreateWorker() const {
@@ -111,7 +128,7 @@ WcojGddValidator::OperationResult WcojGddValidator::Scan() {
 
     auto const& candidates = domain_it->second;
 
-    cur_level_.reset(1);
+    cur_level_.Reset(1);
     cur_level_.data.assign(candidates.begin(), candidates.end());
 
     level_count_ = 1;
@@ -130,24 +147,24 @@ WcojGddValidator::OperationResult WcojGddValidator::ExtendIntersect() {
 
     auto const new_pv = qvo_[level_count_];
     std::size_t const parent_width = cur_level_.width;
-    std::size_t const parent_count = cur_level_.count();
+    std::size_t const parent_count = cur_level_.Count();
 
-    next_level_.reset(level_count_ + 1);
+    next_level_.Reset(level_count_ + 1);
     // at least one child per parent
     next_level_.data.reserve(cur_level_.data.size() + parent_count);
 
     auto const& descriptors = BuildDescriptorsFor(new_pv, level_count_);
     for (std::size_t i = 0; i < parent_count; ++i) {
-        VertexT const* parent = cur_level_.row(i);
+        VertexT const* parent = cur_level_.Row(i);
         std::vector<VertexT> const& extension_set =
                 ComputeExtensionSet(parent, new_pv, descriptors);
 
         for (VertexT const graph_vertex : extension_set) {
-            next_level_.push_row(parent, parent_width, graph_vertex);
+            next_level_.PushRow(parent, parent_width, graph_vertex);
         }
     }
 
-    if (next_level_.count() == 0) {
+    if (next_level_.Count() == 0) {
         return OperationResult::kEmpty;
     }
 

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.cpp
@@ -15,15 +15,44 @@
 
 namespace algos {
 
+namespace {
+
+// first position in [first, last) holding a value >= target
+// complexity is O(log d) where d is the distance to result
+template <typename T>
+T const* LeapFrogSeek(T const* first, T const* last, T target) {
+    if (first == last || !(*first < target)) {
+        return first;
+    }
+
+    // *first < target holds from here on, so `lo` always stays below the answer
+    auto const size = static_cast<std::size_t>(last - first);
+    std::size_t lo = 0;
+    std::size_t hi = 1;
+    while (hi < size && first[hi] < target) {
+        lo = hi;
+        hi <<= 1;
+    }
+
+    return std::lower_bound(first + lo + 1, first + std::min(hi, size), target);
+}
+
+}  // namespace
+
 void WcojGddValidator::Prepare(model::gdd::graph_t const& pattern,
                                model::gdd::graph_t const& graph) {
+    // adjacency_index_ is keyed by (graph vertex, direction, edge label) only, so it
+    // stays valid across every group matched for the same graph
+    if (graph_ != &graph) {
+        adjacency_index_.clear();
+    }
+
     graph_ = &graph;
     pattern_ = &pattern;
 
     cur_level_.Clear();
     next_level_.Clear();
     level_count_ = 0;
-    adjacency_index_.clear();
 
     domain_ = BuildDomain(*pattern_, *graph_);
     for (auto& set : domain_ | std::views::values) {
@@ -299,35 +328,66 @@ std::vector<GddValidator::VertexT> const& WcojGddValidator::ComputeExtensionSet(
     }
 
     intersection_cache_.last_isect_key.assign(key.begin(), key.end());
-    IntersectSorted(lists, intersection_cache_.last_isect_set);
+    LeapFrogJoin(lists, intersection_cache_.last_isect_set);
     intersection_cache_.last_isect_valid = true;
     return intersection_cache_.last_isect_set;
 }
 
-void WcojGddValidator::IntersectSorted(std::vector<std::vector<VertexT> const*>& lists,
-                                       std::vector<VertexT>& out) {
-    // for faster intersections, |A \cap B| <= max(|A|, |B|)
-    std::ranges::sort(lists, [](auto const* a, auto const* b) { return a->size() < b->size(); });
-
+void WcojGddValidator::LeapFrogJoin(std::vector<std::vector<VertexT> const*>& lists,
+                                    std::vector<VertexT>& out) {
     out.clear();
-    std::ranges::set_intersection(*lists[0], *lists[1], std::back_inserter(out));
-
-    if (lists.size() == 2) {
+    if (lists.empty()) {
         return;
     }
 
-    scratch_.clear();
-    std::vector<VertexT>* cur = &out;
-    std::vector<VertexT>* tmp = &scratch_;
-
-    for (std::size_t i = 2; i < lists.size() && !cur->empty(); ++i) {
-        tmp->clear();
-        std::ranges::set_intersection(*cur, *lists[i], std::back_inserter(*tmp));
-        std::swap(cur, tmp);
+    if (lists.size() == 1) {
+        out.assign(lists.front()->begin(), lists.front()->end());
+        return;
     }
 
-    if (cur != &out) {
-        std::swap(out, *cur);
+    std::ranges::sort(lists, [](auto const* a, auto const* b) { return a->size() < b->size(); });
+    if (lists.front()->empty()) {
+        return;
+    }
+
+    std::size_t const list_count = lists.size();
+    cursors_.resize(list_count);
+    for (std::size_t i = 0; i < list_count; ++i) {
+        cursors_[i] = ListCursor{
+                .cursor = lists[i]->data(),
+                .end = lists[i]->data() + lists[i]->size(),
+        };
+    }
+
+    // search for candidate in other lists
+    VertexT candidate = *cursors_[0].cursor;
+    // count of lists where candidate is matched
+    std::size_t matched = 1;
+    // current list index
+    std::size_t index = 1;
+
+    while (true) {
+        ListCursor& list = cursors_[index];
+        list.cursor = LeapFrogSeek(list.cursor, list.end, candidate);
+        if (list.cursor == list.end) {
+            return;
+        }
+
+        if (*list.cursor == candidate) {
+            if (++matched == list_count) {
+                out.push_back(candidate);
+                if (++list.cursor == list.end) {
+                    return;
+                }
+                candidate = *list.cursor;
+                matched = 1;
+            }
+        } else {
+            candidate = *list.cursor;
+            matched = 1;
+        }
+
+        index = index + 1 < list_count ? index + 1 : 0;
     }
 }
 

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -43,11 +43,13 @@ private:
     void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
     std::vector<VertexT> BuildQueryVertexOrder() const;
     std::vector<AdjacencyDescriptor> BuildDescriptorsFor(VertexT new_pv, std::size_t level) const;
-    std::vector<VertexT> ComputeExtensionSet(
-            MappingT const& partial_match, VertexT new_pv,
-            std::vector<AdjacencyDescriptor> const& descriptors);
+    std::vector<VertexT> ComputeExtensionSet(MappingT const& partial_match, VertexT new_pv,
+                                             std::vector<AdjacencyDescriptor> const& descriptors);
     std::vector<VertexT> const& GetNeighbors(VertexT graph_vertex, Direction direction,
                                              std::string const& edge_label);
+
+    static std::vector<VertexT> IntersectSorted(std::vector<VertexT> const& lhs,
+                                                std::vector<VertexT> const& rhs);
 
     struct NeighborKeyHash {
         std::size_t operator()(NeighborKey const& key) const {

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -132,10 +132,12 @@ private:
         bool last_isect_valid = false;
     } intersection_cache_;
 
-    std::size_t match_count_;
+    std::size_t match_count_ = 0;
 
 protected:
     virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
+
+    virtual std::unique_ptr<GddValidator> CreateWorker() const final;
 
 public:
     WcojGddValidator() = default;

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -46,7 +46,7 @@ private:
         }
     };
 
-    // wcoj matching is iterative proccess - match is built vertex-by-vertex.
+    // wcoj matching is iterative process - match is built vertex-by-vertex.
     // level is a partial mapping of first k pattern vertices to graph vertices.
     // keys may be dropped: it is a prefix of QVO array (prefix size is a
     // number of level). hence, we can store all matches as matrix (flat array
@@ -94,6 +94,7 @@ private:
     OperationResult ExtendIntersect();
 
     void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
+    bool IsPatternWeaklyConnected() const;
 
     template <QvoStrategy Strategy>
     std::vector<VertexT> BuildQueryVertexOrder() const {

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <type_traits>
+
+#include <boost/container_hash/hash.hpp>
+
+#include "gdd_validator.h"
+
+namespace algos {
+
+class WcojGddValidator : public GddValidator {
+private:
+    enum class Direction : std::uint8_t { kIn, kOut };
+    enum class OperationResult : std::uint8_t { kEmpty, kProduced, kFinished };
+
+    struct AdjacencyDescriptor {
+        VertexT pattern_vertex;
+        Direction direction;
+        std::string edge_label;
+    };
+
+    struct NeighborKey {
+        VertexT graph_vertex;
+        Direction direction;
+        std::string edge_label;
+
+        bool operator==(NeighborKey const&) const = default;
+    };
+
+    using MatchLevelT = std::vector<MappingT>;
+
+    DomainT domain_;
+    std::vector<MatchLevelT> match_levels_;
+    std::vector<VertexT> qvo_;
+    model::Gdd const* gdd_ = nullptr;
+    model::gdd::graph_t const* pattern_ = nullptr;
+    model::gdd::graph_t const* graph_ = nullptr;
+
+    // differs from paper - builds 1-match, not 2-match.
+    OperationResult Scan();
+    OperationResult ExtendIntersect();
+
+    void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
+    std::vector<VertexT> BuildQueryVertexOrder() const;
+    std::vector<AdjacencyDescriptor> BuildDescriptorsFor(VertexT new_pv, std::size_t level) const;
+    std::vector<VertexT> ComputeExtensionSet(
+            MappingT const& partial_match, VertexT new_pv,
+            std::vector<AdjacencyDescriptor> const& descriptors);
+    std::vector<VertexT> const& GetNeighbors(VertexT graph_vertex, Direction direction,
+                                             std::string const& edge_label);
+
+    struct NeighborKeyHash {
+        std::size_t operator()(NeighborKey const& key) const {
+            using boost::hash_combine;
+            using boost::hash_value;
+
+            std::size_t seed = 0;
+
+            hash_combine(seed, hash_value(key.graph_vertex));
+            hash_combine(seed,
+                         hash_value(static_cast<std::underlying_type_t<Direction>>(key.direction)));
+            hash_combine(seed, hash_value(key.edge_label));
+
+            return seed;
+        }
+    };
+
+    std::unordered_map<NeighborKey, std::vector<VertexT>, NeighborKeyHash> adjacency_index_;
+
+protected:
+    virtual std::optional<GddCounterexample> Holds(model::Gdd const& gdd,
+                                                   model::gdd::graph_t const& graph) final;
+
+public:
+    WcojGddValidator() = default;
+};
+
+}  // namespace algos

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -132,9 +132,10 @@ private:
         bool last_isect_valid = false;
     } intersection_cache_;
 
+    std::size_t match_count_;
+
 protected:
-    virtual std::optional<GddCounterexample> Holds(model::Gdd const& gdd,
-                                                   model::gdd::graph_t const& graph) final;
+    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
 
 public:
     WcojGddValidator() = default;

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -4,7 +4,9 @@
 
 #include <boost/container_hash/hash.hpp>
 
+#include "core/util/logger.h"
 #include "gdd_validator.h"
+#include "qvo_strategies.h"
 
 namespace algos {
 
@@ -15,6 +17,7 @@ private:
 
     struct AdjacencyDescriptor {
         VertexT pattern_vertex;
+        std::size_t qvo_index;  // position of pattern_vertex in qvo_
         Direction direction;
         std::string edge_label;
     };
@@ -26,30 +29,6 @@ private:
 
         bool operator==(NeighborKey const&) const = default;
     };
-
-    using MatchLevelT = std::vector<MappingT>;
-
-    DomainT domain_;
-    std::vector<MatchLevelT> match_levels_;
-    std::vector<VertexT> qvo_;
-    model::Gdd const* gdd_ = nullptr;
-    model::gdd::graph_t const* pattern_ = nullptr;
-    model::gdd::graph_t const* graph_ = nullptr;
-
-    // differs from paper - builds 1-match, not 2-match.
-    OperationResult Scan();
-    OperationResult ExtendIntersect();
-
-    void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
-    std::vector<VertexT> BuildQueryVertexOrder() const;
-    std::vector<AdjacencyDescriptor> BuildDescriptorsFor(VertexT new_pv, std::size_t level) const;
-    std::vector<VertexT> ComputeExtensionSet(MappingT const& partial_match, VertexT new_pv,
-                                             std::vector<AdjacencyDescriptor> const& descriptors);
-    std::vector<VertexT> const& GetNeighbors(VertexT graph_vertex, Direction direction,
-                                             std::string const& edge_label);
-
-    static std::vector<VertexT> IntersectSorted(std::vector<VertexT> const& lhs,
-                                                std::vector<VertexT> const& rhs);
 
     struct NeighborKeyHash {
         std::size_t operator()(NeighborKey const& key) const {
@@ -67,7 +46,90 @@ private:
         }
     };
 
+    // wcoj matching is iterative proccess - match is built vertex-by-vertex.
+    // level is a partial mapping of first k pattern vertices to graph vertices.
+    // keys may be dropped: it is a prefix of QVO array (prefix size is a
+    // number of level). hence, we can store all matches as matrix (flat array
+    // of graph vertices, data, with width - mapping level).
+    // `MappingT match` can be restored as {(qvo[i], row[i]) for i in 0..width}
+    // for each row in level
+    struct MatchLevel {
+        std::vector<VertexT> data;
+        std::size_t width = 0;
+
+        void clear() noexcept {
+            data.clear();
+            width = 0;
+        }
+
+        void reset(std::size_t w) {
+            data.clear();
+            width = w;
+        }
+
+        std::size_t count() const noexcept {
+            return width != 0 ? data.size() / width : 0;
+        }
+
+        VertexT const* row(std::size_t i) const noexcept {
+            return data.data() + i * width;
+        }
+
+        void push_row(VertexT const* parent, std::size_t parent_width, VertexT appended) {
+            data.insert(data.end(), parent, parent + parent_width);
+            data.push_back(appended);
+        }
+    };
+
+    DomainT domain_;
+    MatchLevel cur_level_;
+    MatchLevel next_level_;
+    std::size_t level_count_ = 0;  // == cur_level_.width
+    std::vector<VertexT> qvo_;
+    model::Gdd const* gdd_ = nullptr;
+    model::gdd::graph_t const* pattern_ = nullptr;
+    model::gdd::graph_t const* graph_ = nullptr;
+
+    OperationResult Scan();  // differs from paper - builds 1-match, not 2-match.
+    OperationResult ExtendIntersect();
+
+    void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
+
+    template <QvoStrategy Strategy>
+    std::vector<VertexT> BuildQueryVertexOrder() const {
+        if (pattern_ == nullptr) {
+            LOG_WARN("Calling BuildQueryVertexOrder while pattern_ == nullptr");
+            return {};
+        }
+        if (graph_ == nullptr) {
+            LOG_WARN("Calling BuildQueryVertexOrder while graph_ == nullptr");
+            return {};
+        }
+        return Strategy(*graph_, *pattern_, domain_).Order();
+    }
+
+    std::vector<AdjacencyDescriptor> BuildDescriptorsFor(VertexT new_pv, std::size_t level) const;
+    // partial_match points to a FlatLevel row
+    std::vector<VertexT> const& ComputeExtensionSet(
+            VertexT const* partial_match, VertexT new_pv,
+            std::vector<AdjacencyDescriptor> const& descriptors);
+    std::vector<VertexT> const& GetNeighbors(VertexT graph_vertex, Direction direction,
+                                             std::string const& edge_label);
+
+    // `IntersectSorted` is in hot path, scratch_ is a buffer that supposed not to shrink
+    // its capacity and be used for insertions of `std::set_intersection` result
+    std::vector<VertexT> scratch_;
+    void IntersectSorted(std::vector<std::vector<VertexT> const*>& lists,
+                         std::vector<VertexT>& out);
+
     std::unordered_map<NeighborKey, std::vector<VertexT>, NeighborKeyHash> adjacency_index_;
+
+    struct IntersectionCache {
+        // mapped graph vertices in the same order descriptors are
+        std::vector<VertexT> last_isect_key;
+        std::vector<VertexT> last_isect_set;
+        bool last_isect_valid = false;
+    } intersection_cache_;
 
 protected:
     virtual std::optional<GddCounterexample> Holds(model::Gdd const& gdd,

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -117,11 +117,18 @@ private:
     std::vector<VertexT> const& GetNeighbors(VertexT graph_vertex, Direction direction,
                                              std::string const& edge_label);
 
-    // `IntersectSorted` is in hot path, scratch_ is a buffer that supposed not to shrink
-    // its capacity and be used for insertions of `std::set_intersection` result
-    std::vector<VertexT> scratch_;
-    void IntersectSorted(std::vector<std::vector<VertexT> const*>& lists,
-                         std::vector<VertexT>& out);
+    // set intersections is in hot path, the optimal way to deal with them
+    // is "Leapfrog join for unary predicates"; see https://arxiv.org/pdf/1210.0481
+    // this algo has complexity of O(N_{min} * log(N_{max}/N_{min})) instead of
+    // pairwise intersection which is O(N_{max} * lists.size())
+    struct ListCursor {
+        VertexT const* cursor;
+        VertexT const* end;
+    };
+
+    // reused by LeapFrogJoin, supposed not to shrink
+    std::vector<ListCursor> cursors_;
+    void LeapFrogJoin(std::vector<std::vector<VertexT> const*>& lists, std::vector<VertexT>& out);
 
     std::unordered_map<NeighborKey, std::vector<VertexT>, NeighborKeyHash> adjacency_index_;
 

--- a/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
+++ b/src/core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include <type_traits>
 
 #include <boost/container_hash/hash.hpp>
@@ -57,25 +58,25 @@ private:
         std::vector<VertexT> data;
         std::size_t width = 0;
 
-        void clear() noexcept {
+        void Clear() noexcept {
             data.clear();
             width = 0;
         }
 
-        void reset(std::size_t w) {
+        void Reset(std::size_t w) {
             data.clear();
             width = w;
         }
 
-        std::size_t count() const noexcept {
+        std::size_t Count() const noexcept {
             return width != 0 ? data.size() / width : 0;
         }
 
-        VertexT const* row(std::size_t i) const noexcept {
+        VertexT const* Row(std::size_t i) const noexcept {
             return data.data() + i * width;
         }
 
-        void push_row(VertexT const* parent, std::size_t parent_width, VertexT appended) {
+        void PushRow(VertexT const* parent, std::size_t parent_width, VertexT appended) {
             data.insert(data.end(), parent, parent + parent_width);
             data.push_back(appended);
         }
@@ -86,14 +87,13 @@ private:
     MatchLevel next_level_;
     std::size_t level_count_ = 0;  // == cur_level_.width
     std::vector<VertexT> qvo_;
-    model::Gdd const* gdd_ = nullptr;
     model::gdd::graph_t const* pattern_ = nullptr;
     model::gdd::graph_t const* graph_ = nullptr;
 
     OperationResult Scan();  // differs from paper - builds 1-match, not 2-match.
     OperationResult ExtendIntersect();
 
-    void Prepare(model::Gdd const& gdd, model::gdd::graph_t const& graph);
+    void Prepare(model::gdd::graph_t const& pattern, model::gdd::graph_t const& graph);
     bool IsPatternWeaklyConnected() const;
 
     template <QvoStrategy Strategy>
@@ -132,10 +132,10 @@ private:
         bool last_isect_valid = false;
     } intersection_cache_;
 
-    std::size_t match_count_ = 0;
-
 protected:
-    virtual GddHoldsResult Holds(model::Gdd const& gdd, model::gdd::graph_t const& graph) final;
+    virtual void HoldsGroup(std::span<model::Gdd const* const> group,
+                            model::gdd::graph_t const& graph,
+                            std::span<GddHoldsResult> output) final;
 
     virtual std::unique_ptr<GddValidator> CreateWorker() const final;
 

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -191,6 +191,7 @@ desbordante_add_bind(
     ${DESBORDANTE_PREFIX}::gdd::validator
     magic_enum::magic_enum
     Boost::headers
+    spdlog::spdlog_header_only
 )
 
 desbordante_add_bind(

--- a/src/python_bindings/CMakeLists.txt
+++ b/src/python_bindings/CMakeLists.txt
@@ -193,6 +193,7 @@ desbordante_add_bind(
     ${DESBORDANTE_PREFIX}::gdd
     ${DESBORDANTE_PREFIX}::gdd::validator
     Boost::headers
+    spdlog::spdlog_header_only
 )
 
 desbordante_add_bind(

--- a/src/python_bindings/gdd/bind_gdd_verification.cpp
+++ b/src/python_bindings/gdd/bind_gdd_verification.cpp
@@ -522,6 +522,7 @@ void BindGddVerification(pybind11::module_& main_module) {
 
     py::class_<GddValidator, Algorithm>(gdd_module, "GddValidator")
             .def("get_result", &GddValidator::GetResult)
+            .def("get_matches_count", &GddValidator::GetMatchesCount)
             .def("get_counterexamples", &GddValidator::GetCounterexamples);
 
     auto const gdd_algos_module = gdd_module.def_submodule("algorithms");

--- a/src/python_bindings/gdd/bind_gdd_verification.cpp
+++ b/src/python_bindings/gdd/bind_gdd_verification.cpp
@@ -16,6 +16,7 @@
 #include "core/algorithms/gdd/gdd_graph_description.h"
 #include "core/algorithms/gdd/gdd_validator/gdd_validator.h"
 #include "core/algorithms/gdd/gdd_validator/naive_gdd_validator.h"
+#include "core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h"
 #include "core/parser/graph_parser/graph_parser.h"
 #include "python_bindings/py_util/bind_primitive.h"
 
@@ -147,6 +148,7 @@ void BindGddVerification(pybind11::module_& main_module) {
     using algos::Algorithm;
     using algos::GddValidator;
     using algos::NaiveGddValidator;
+    using algos::WcojGddValidator;
     using model::Gdd;
     using model::GddCounterexample;
     using model::GddCounterexampleVertex;
@@ -524,10 +526,12 @@ void BindGddVerification(pybind11::module_& main_module) {
 
     auto const gdd_algos_module = gdd_module.def_submodule("algorithms");
 
-    auto default_cls = detail::RegisterAlgorithm<NaiveGddValidator, GddValidator>(
-            gdd_algos_module, "NaiveGddValidator");
+    detail::RegisterAlgorithm<NaiveGddValidator, GddValidator>(gdd_algos_module,
+                                                               "NaiveGddValidator");
+    auto wcoj_cls = detail::RegisterAlgorithm<WcojGddValidator, GddValidator>(gdd_algos_module,
+                                                                              "WcojGddValidator");
 
-    gdd_algos_module.attr("Default") = default_cls;
+    gdd_algos_module.attr("Default") = wcoj_cls;
     gdd_module.attr("Default") = gdd_algos_module.attr("Default");
 }
 

--- a/src/python_bindings/gdd/bind_gdd_verification.cpp
+++ b/src/python_bindings/gdd/bind_gdd_verification.cpp
@@ -526,12 +526,11 @@ void BindGddVerification(pybind11::module_& main_module) {
 
     auto const gdd_algos_module = gdd_module.def_submodule("algorithms");
 
-    detail::RegisterAlgorithm<NaiveGddValidator, GddValidator>(gdd_algos_module,
-                                                               "NaiveGddValidator");
-    auto wcoj_cls = detail::RegisterAlgorithm<WcojGddValidator, GddValidator>(gdd_algos_module,
-                                                                              "WcojGddValidator");
+    auto default_cls = detail::RegisterAlgorithm<NaiveGddValidator, GddValidator>(
+            gdd_algos_module, "NaiveGddValidator");
+    detail::RegisterAlgorithm<WcojGddValidator, GddValidator>(gdd_algos_module, "WcojGddValidator");
 
-    gdd_algos_module.attr("Default") = wcoj_cls;
+    gdd_algos_module.attr("Default") = default_cls;
     gdd_module.attr("Default") = gdd_algos_module.attr("Default");
 }
 

--- a/src/tests/unit/test_gdd_constraint_satisfaction.cpp
+++ b/src/tests/unit/test_gdd_constraint_satisfaction.cpp
@@ -62,7 +62,7 @@ TEST_P(GddSatisfiesAttrConstTest, WorksAsExpected) {
     graph_t g;
     auto const gv = AddVertex(g, tc.graph_vertex_id, tc.graph_vertex_label, tc.graph_vertex_attrs);
     auto const pv = FindVertexById(p, 1);
-    std::unordered_map<vertex_t, vertex_t> const map{{pv, gv}};
+    model::gdd::detail::MappingT const map{{pv, gv}};
 
     if (tc.expect_throw) {
         EXPECT_THROW(gdd.Satisfies(g, map), std::logic_error);
@@ -289,7 +289,7 @@ TEST_P(GddSatisfiesAttrAttrTest, WorksAsExpected) {
     auto const p1 = FindVertexById(p, 1);
     auto const p2 = FindVertexById(p, 2);
 
-    std::unordered_map<vertex_t, vertex_t> const map{{p1, g1}, {p2, g2}};
+    model::gdd::detail::MappingT const map{{p1, g1}, {p2, g2}};
     EXPECT_EQ(gdd.Satisfies(g, map), tc.expected);
 }
 
@@ -346,7 +346,7 @@ TEST_P(GddSatisfiesRelConstTest, WorksAsExpected) {
     AddEdge(g, a, b, tc.actual_edge_label);
 
     auto const pv = FindVertexById(p, 1);
-    std::unordered_map<vertex_t, vertex_t> const map{{pv, a}};
+    model::gdd::detail::MappingT const map{{pv, a}};
 
     EXPECT_EQ(gdd.Satisfies(g, map), tc.expected);
 }
@@ -403,7 +403,7 @@ TEST_P(GddSatisfiesRelRelTest, WorksAsExpected) {
 
     auto const p1 = FindVertexById(p, 1);
     auto const p2 = FindVertexById(p, 2);
-    std::unordered_map<vertex_t, vertex_t> const map{{p1, a}, {p2, c_v}};
+    model::gdd::detail::MappingT const map{{p1, a}, {p2, c_v}};
 
     EXPECT_EQ(gdd.Satisfies(g, map), tc.expected);
 }
@@ -449,7 +449,7 @@ TEST(GddSatisfiesConstraint, EmptyLhsRhsSatisfies) {
     auto const gv = AddVertex(g, 10, "X");
     auto const pv = FindVertexById(p, 1);
 
-    std::unordered_map<vertex_t, vertex_t> map;
+    model::gdd::detail::MappingT map;
     map.emplace(pv, gv);
 
     EXPECT_TRUE(gdd.Satisfies(g, map));
@@ -493,7 +493,7 @@ TEST(GddSatisfiesConstraint, RelConstNonInt64ConstValueTypesThrows) {
     AddEdge(g, a, b, "knows");
 
     auto const pv = FindVertexById(p, 1);
-    std::unordered_map<vertex_t, vertex_t> const map{{pv, a}};
+    model::gdd::detail::MappingT const map{{pv, a}};
 
     EXPECT_THROW(gdd.Satisfies(g, map), std::logic_error);
 }

--- a/src/tests/unit/test_gdd_validator.cpp
+++ b/src/tests/unit/test_gdd_validator.cpp
@@ -14,6 +14,7 @@
 #include "core/algorithms/gdd/gdd_validator/naive_gdd_validator.h"
 #include "core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h"
 #include "core/config/names.h"
+#include "core/config/thread_number/type.h"
 #include "tests/unit/test_gdd_utils.h"
 
 using model::Gdd;
@@ -53,6 +54,17 @@ struct ValidatorCase {
 
 std::vector<ValidatorCase> GetValidatorCases() {
     return {[] {
+                return ValidatorCase{
+                        .case_name = "EmptyGddInput",
+                        .temp_file_name = "gdd_empty_input.dot",
+                        .graph_dot = R"(digraph G {
+                            1 [label = "X"];
+                        })",
+                        .input_gdds = {},
+                        .expected_valid_gdds = {},
+                };
+            }(),
+            [] {
                 auto const pattern = tests::gdd::utils::MakeSingleVertexPattern(0, "City");
 
                 Gdd const gdd(pattern, Gdd::Phi{},
@@ -403,6 +415,12 @@ std::vector<ValidatorCase> GetValidatorCases() {
 template <class T>
 class GddValidatorCasesTest : public ::testing::TestWithParam<ValidatorCase> {
 protected:
+    struct ValidatorOutput {
+        std::vector<Gdd> valid_gdds;
+        std::vector<model::GddCounterexample> counterexamples;
+        std::vector<std::size_t> matches_count;
+    };
+
     static std::filesystem::path WriteTempDotFile(std::string const& dot,
                                                   std::string const& file_name) {
         auto const path =
@@ -416,31 +434,79 @@ protected:
     }
 
     static std::unique_ptr<algos::GddValidator> CreateGddValidatorInstance(
-            std::filesystem::path const& graph_path, std::vector<Gdd> const& gdds) {
+            std::filesystem::path const& graph_path, std::vector<Gdd> const& gdds,
+            config::ThreadNumType threads) {
         algos::StdParamsMap const option_map = {
                 {config::names::kGraphData, graph_path},
                 {config::names::kGddData, gdds},
+                {config::names::kThreads, threads},
         };
         return algos::CreateAndLoadAlgorithm<T>(option_map);
     }
 
-    static void CheckCase(ValidatorCase const& tc) {
-        auto const graph_path = WriteTempDotFile(tc.graph_dot, tc.temp_file_name);
-        auto const validator = CreateGddValidatorInstance(graph_path, tc.input_gdds);
+    static ValidatorOutput CaptureOutput(algos::GddValidator const& validator) {
+        return {
+                .valid_gdds = validator.GetResult(),
+                .counterexamples = validator.GetCounterexamples(),
+                .matches_count = validator.GetMatchesCount(),
+        };
+    }
 
-        validator->Execute();
-        auto const out = validator->GetResult();
+    static void ExpectCounterexamplesEqual(std::vector<model::GddCounterexample> const& actual,
+                                           std::vector<model::GddCounterexample> const& expected) {
+        ASSERT_EQ(actual.size(), expected.size());
+        for (std::size_t ce_index = 0; ce_index < actual.size(); ++ce_index) {
+            SCOPED_TRACE(ce_index);
+            EXPECT_EQ(actual[ce_index].gdd_index, expected[ce_index].gdd_index);
+            ASSERT_EQ(actual[ce_index].match.size(), expected[ce_index].match.size());
+            for (std::size_t match_index = 0; match_index < actual[ce_index].match.size();
+                 ++match_index) {
+                auto const& actual_vertex = actual[ce_index].match[match_index];
+                auto const& expected_vertex = expected[ce_index].match[match_index];
+                EXPECT_EQ(actual_vertex.pattern_vertex_id, expected_vertex.pattern_vertex_id);
+                EXPECT_EQ(actual_vertex.pattern_vertex_label, expected_vertex.pattern_vertex_label);
+                EXPECT_EQ(actual_vertex.graph_vertex_id, expected_vertex.graph_vertex_id);
+                EXPECT_EQ(actual_vertex.graph_vertex_label, expected_vertex.graph_vertex_label);
+                EXPECT_EQ(actual_vertex.graph_vertex_attributes,
+                          expected_vertex.graph_vertex_attributes);
+            }
+        }
+    }
 
-        EXPECT_THAT(out, testing::UnorderedElementsAreArray(tc.expected_valid_gdds));
+    static void ExpectCaseResult(ValidatorOutput const& output, ValidatorCase const& tc) {
+        EXPECT_EQ(output.valid_gdds, tc.expected_valid_gdds);
 
         std::vector<std::size_t> actual_counterexample_indices;
-        actual_counterexample_indices.reserve(validator->GetCounterexamples().size());
-        for (auto const& [gdd_index, match] : validator->GetCounterexamples()) {
+        actual_counterexample_indices.reserve(output.counterexamples.size());
+        for (auto const& [gdd_index, match] : output.counterexamples) {
             actual_counterexample_indices.push_back(gdd_index);
         }
+        EXPECT_EQ(actual_counterexample_indices, tc.expected_counterexample_gdd_indices);
+        EXPECT_EQ(output.matches_count.size(), tc.input_gdds.size());
+    }
 
-        EXPECT_THAT(actual_counterexample_indices,
-                    testing::UnorderedElementsAreArray(tc.expected_counterexample_gdd_indices));
+    static void CheckCase(ValidatorCase const& tc) {
+        auto const graph_path = WriteTempDotFile(tc.graph_dot, tc.temp_file_name);
+        auto const validator =
+                CreateGddValidatorInstance(graph_path, tc.input_gdds, config::ThreadNumType{1});
+        validator->Execute();
+        ValidatorOutput const sequential = CaptureOutput(*validator);
+        ExpectCaseResult(sequential, tc);
+
+        validator->SetOption(config::names::kThreads, config::ThreadNumType{4});
+        validator->Execute();
+        ValidatorOutput const parallel = CaptureOutput(*validator);
+        ExpectCaseResult(parallel, tc);
+        EXPECT_EQ(parallel.valid_gdds, sequential.valid_gdds);
+        ExpectCounterexamplesEqual(parallel.counterexamples, sequential.counterexamples);
+        EXPECT_EQ(parallel.matches_count, sequential.matches_count);
+
+        validator->SetOption(config::names::kThreads, config::ThreadNumType{1});
+        validator->Execute();
+        ValidatorOutput const sequential_again = CaptureOutput(*validator);
+        EXPECT_EQ(sequential_again.valid_gdds, sequential.valid_gdds);
+        ExpectCounterexamplesEqual(sequential_again.counterexamples, sequential.counterexamples);
+        EXPECT_EQ(sequential_again.matches_count, sequential.matches_count);
 
         if (std::filesystem::exists(graph_path)) {
             std::filesystem::remove(graph_path);
@@ -457,7 +523,61 @@ TYPED_TEST_P(GddValidatorCasesTest, ReturnsExpectedValidGdds) {
     }
 }
 
-REGISTER_TYPED_TEST_SUITE_P(GddValidatorCasesTest, ReturnsExpectedValidGdds);
+TYPED_TEST_P(GddValidatorCasesTest, MatchCountIsPerGddAndStopsAtFirstCounterexample) {
+    auto const pattern = tests::gdd::utils::MakeSingleVertexPattern(0, "X");
+    Gdd const invalid_gdd(pattern, Gdd::Phi{}, Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
+    std::vector const gdds{invalid_gdd, invalid_gdd};
+    auto const graph_path = TestFixture::WriteTempDotFile(
+            R"(digraph G {
+                1 [label = "X", name = "First"];
+                2 [label = "X", name = "Second"];
+            })",
+            "gdd_match_count_stops_at_ce.dot");
+
+    auto const validator =
+            TestFixture::CreateGddValidatorInstance(graph_path, gdds, config::ThreadNumType{1});
+    validator->Execute();
+    EXPECT_EQ(validator->GetMatchesCount(), (std::vector<std::size_t>{1, 1}));
+
+    validator->SetOption(config::names::kThreads, config::ThreadNumType{2});
+    validator->Execute();
+    EXPECT_EQ(validator->GetMatchesCount(), (std::vector<std::size_t>{1, 1}));
+
+    if (std::filesystem::exists(graph_path)) {
+        std::filesystem::remove(graph_path);
+    }
+}
+
+TYPED_TEST_P(GddValidatorCasesTest, ParallelWorkerExceptionLeavesResultsEmpty) {
+    auto const pattern = tests::gdd::utils::MakeSingleVertexPattern(0, "A");
+    Gdd const valid_gdd(pattern, Gdd::Phi{}, Gdd::Phi{});
+    auto const invalid_constraint = tests::gdd::utils::RelConst(
+            0, "knows", model::gdd::detail::ConstValue{std::string{"not-an-id"}});
+    Gdd const throwing_gdd(pattern, Gdd::Phi{invalid_constraint}, Gdd::Phi{});
+    std::vector const gdds{valid_gdd, throwing_gdd};
+    auto const graph_path = TestFixture::WriteTempDotFile(
+            R"(digraph G {
+                1 [label = "A"];
+                2 [label = "B"];
+                1 -> 2 [label = "knows"];
+            })",
+            "gdd_parallel_worker_exception.dot");
+
+    auto const validator =
+            TestFixture::CreateGddValidatorInstance(graph_path, gdds, config::ThreadNumType{2});
+    EXPECT_THROW(validator->Execute(), std::logic_error);
+    EXPECT_TRUE(validator->GetResult().empty());
+    EXPECT_TRUE(validator->GetCounterexamples().empty());
+    EXPECT_TRUE(validator->GetMatchesCount().empty());
+
+    if (std::filesystem::exists(graph_path)) {
+        std::filesystem::remove(graph_path);
+    }
+}
+
+REGISTER_TYPED_TEST_SUITE_P(GddValidatorCasesTest, ReturnsExpectedValidGdds,
+                            MatchCountIsPerGddAndStopsAtFirstCounterexample,
+                            ParallelWorkerExceptionLeavesResultsEmpty);
 
 using GddValidatorAlgorithms = ::testing::Types<algos::NaiveGddValidator, algos::WcojGddValidator>;
 

--- a/src/tests/unit/test_gdd_validator.cpp
+++ b/src/tests/unit/test_gdd_validator.cpp
@@ -12,6 +12,7 @@
 #include "core/algorithms/algo_factory.h"
 #include "core/algorithms/gdd/gdd.h"
 #include "core/algorithms/gdd/gdd_validator/naive_gdd_validator.h"
+#include "core/algorithms/gdd/gdd_validator/wcoj_gdd_validator.h"
 #include "core/config/names.h"
 #include "tests/unit/test_gdd_utils.h"
 
@@ -50,6 +51,356 @@ struct ValidatorCase {
     std::vector<std::size_t> expected_counterexample_gdd_indices{};
 };
 
+std::vector<ValidatorCase> GetValidatorCases() {
+    return {[] {
+                auto const pattern = tests::gdd::utils::MakeSingleVertexPattern(0, "City");
+
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "VertexLabelMatters",
+                        .temp_file_name = "gdd_vertex_label_matters.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Country", name = "France"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+            [] {
+                auto const pattern = MakePatternPersonCity("lives_in");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "EdgeLabelMatters",
+                        .temp_file_name = "gdd_edge_label_matters.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Person", name = "Misha"];
+                                2 [label = "City", name = "Amsterdam"];
+                                1 -> 2 [label = "works_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+            [] {
+                auto const pattern = MakePatternPersonCity();
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(1, "label", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "DirectedEdgeOrientationMatters",
+                        .temp_file_name = "gdd_directed_edge_orientation_matters.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Person"];
+                                2 [label = "City"];
+                                2 -> 1 [label = "lives_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+            [] {
+                auto const pattern = MakeArrowPattern(0, "X", 1, "X", "L");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{AttrAttr(0, "id", 1, "id",
+                                                model::gdd::detail::DistanceMetric::kAbsDiff,
+                                                model::gdd::detail::CmpOp::kGt, 0.0)});
+
+                return ValidatorCase{
+                        .case_name = "HomomorphicMatchAllowsVertexMerging",
+                        .temp_file_name = "gdd_homomorphic_vertex_merging.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "X"];
+                                1 -> 1 [label = "L"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "City"];
+                        1 [label = "Country"];
+                        2 [label = "Country"];
+                        0 -> 1 [label = "capital_of"];
+                        0 -> 2 [label = "located_in"];
+                    })");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name =
+                                "HomomorphicMatchSameTargetForDifferentPatternVertices"
+                                "MatchExists",
+                        .temp_file_name = "gdd_homomorphic_same_target_match_exists.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "City", name = "Paris"];
+                                101 [label = "Country", name = "France"];
+                                1 -> 101 [label = "capital_of"];
+                                1 -> 101 [label = "located_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "City"];
+                        1 [label = "Country"];
+                        2 [label = "Country"];
+                        0 -> 1 [label = "capital_of"];
+                        0 -> 2 [label = "located_in"];
+                    })");
+
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{AttrAttr(1, "name", 2, "name",
+                                                model::gdd::detail::DistanceMetric::kEditDistance,
+                                                model::gdd::detail::CmpOp::kEq, 0.0)});
+
+                return ValidatorCase{
+                        .case_name = "HomomorphicMatchSameTargetForDifferentPatternVertices",
+                        .temp_file_name = "gdd_homomorphic_same_target_valid.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "City", name = "Paris"];
+                                101 [label = "Country", name = "France"];
+                                1 -> 101 [label = "capital_of"];
+                                1 -> 101 [label = "located_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "A"];
+                        1 [label = "B"];
+                        2 [label = "C"];
+                    })");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "DisconnectedPatternIsolatedVerticesCanBeMatched",
+                        .temp_file_name = "gdd_disconnected_isolated_vertices.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                10 [label = "A", name = "a"];
+                                11 [label = "B", name = "b"];
+                                12 [label = "C", name = "c"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "A"];
+                        1 [label = "B"];
+                        0 -> 1 [label = "l"];
+                    })");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "ConnectedPatternCannotJumpAcrossGraphComponents",
+                        .temp_file_name = "gdd_connected_cannot_jump_components.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "A", name = "left"];
+                                2 [label = "B", name = "right"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                        .expected_counterexample_gdd_indices = {},
+                };
+            }(),
+            [] {
+                auto const pattern = MakePatternPersonCity("lives_in");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "ParallelEdgesDifferentLabelsPatternNeedsOne",
+                        .temp_file_name = "gdd_parallel_edges_one_needed_label.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Person", name = "Misha"];
+                                2 [label = "City", name = "Amsterdam"];
+                                1 -> 2 [label = "works_in"];
+                                1 -> 2 [label = "lives_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "Person"];
+                        1 [label = "City"];
+                        0 -> 1 [label = "works_in"];
+                        0 -> 1 [label = "lives_in"];
+                    })");
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
+                return ValidatorCase{
+                        .case_name = "ParallelEdgesDifferentLabelsPatternNeedsBoth",
+                        .temp_file_name = "gdd_parallel_edges_both_needed_label.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Person", name = "Misha"];
+                                2 [label = "City", name = "Amsterdam"];
+                                1 -> 2 [label = "works_in"];
+                                1 -> 2 [label = "lives_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        0 [label = "Person"];
+                        1 [label = "City"];
+                        0 -> 1 [label = "lives_in"];
+                        0 -> 1 [label = "works_in"];
+                    })");
+
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{tests::gdd::utils::AttrConst(
+                                      1, "name", std::string("Impossible"),
+                                      model::gdd::detail::DistanceMetric::kEditDistance,
+                                      model::gdd::detail::CmpOp::kEq, 0.0)});
+
+                return ValidatorCase{
+                        .case_name = "PatternHasTwoParallelEdgesDifferentLabelsGraphHasOne",
+                        .temp_file_name = "gdd_pattern_parallel_edges_graph_has_one.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "Person", name = "Misha"];
+                                2 [label = "City", name = "Amsterdam"];
+                                1 -> 2 [label = "lives_in"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                        .expected_counterexample_gdd_indices = {},
+                };
+            }(),
+            [] {
+                auto const pattern = ReadGraphFromDot(R"(digraph P {
+                        1 [label = "root"];
+                        2 [label = "succ"];
+                        3 [label = "succ"];
+
+                        1 -> 2 [label = "edge"];
+                        1 -> 3 [label = "edge"];
+                    })");
+
+                Gdd const gdd(pattern, Gdd::Phi{},
+                              Gdd::Phi{AttrAttr(2, "name", 3, "name",
+                                                model::gdd::detail::DistanceMetric::kEditDistance,
+                                                model::gdd::detail::CmpOp::kGt, 0.0)});
+
+                return ValidatorCase{
+                        .case_name = "RootWithTwoSuccChildrenOneComponentSatisfiesAnotherViolates",
+                        .temp_file_name = "gdd_root_two_succ_children_one_component_violates.dot",
+                        .graph_dot = R"(
+                            digraph G {
+                                1 [label = "root", name = "v"];
+                                2 [label = "succ", name = "l"];
+                                3 [label = "succ", name = "r"];
+                                1 -> 2 [label = "edge"];
+                                1 -> 3 [label = "edge"];
+
+                                4 [label = "root", name = "u"];
+                                5 [label = "succ", name = "w"];
+                                4 -> 5 [label = "edge"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const g1 = MakeGddMishaLivesInAmsterdam();
+                auto const g2 = MakeGddRigaInLatvia();
+                auto const g3 = MakeGddVacuousImplicationNonexistentPerson();
+                auto const g4 = MakeGddPersonAge25ImpliesLivesInAmsterdamAsRelationConstraint();
+                auto const g5 = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
+
+                return ValidatorCase{
+                        .case_name = "LargeGraphAllSatisfied",
+                        .temp_file_name = "gdd_large_graph_all_good.dot",
+                        .graph_dot = LargeGraphAllGoodDot(),
+                        .input_gdds = {g1, g2, g3, g4, g5},
+                        .expected_valid_gdds = {g1, g2, g3, g4, g5},
+                };
+            }(),
+            [] {
+                auto const gdd_bad = MakeGddMishaLivesInAmsterdam();
+                auto const gdd_ok1 = MakeGddRigaInLatvia();
+                auto const gdd_ok2 = MakeGddVacuousImplicationNonexistentPerson();
+                auto const gdd_ok3 =
+                        MakeGddPersonAge25ImpliesLivesInAmsterdamAsRelationConstraint();
+                auto const gdd_ok4 = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
+
+                return ValidatorCase{
+                        .case_name = "LargeGraphDetectsViolation",
+                        .temp_file_name = "gdd_large_graph_with_violation.dot",
+                        .graph_dot = LargeGraphWithViolationMishaAlsoLivesInRigaDot(),
+                        .input_gdds = {gdd_bad, gdd_ok1, gdd_ok2, gdd_ok3, gdd_ok4},
+                        .expected_valid_gdds = {gdd_ok1, gdd_ok2, gdd_ok3, gdd_ok4},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }(),
+            [] {
+                auto const gdd = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
+
+                return ValidatorCase{
+                        .case_name = "UsesCustomAttributesAndLabel",
+                        .temp_file_name = "gdd_custom_attrs_graph.dot",
+                        .graph_dot = LargeGraphAllGoodDot(),
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+            [] {
+                auto const gdd = MakeGddCompanyHqInAmsterdamNoCompanyInGraph();
+
+                return ValidatorCase{
+                        .case_name = "EmptyMatchSetIsSatisfied",
+                        .temp_file_name = "gdd_no_matches_company_city.dot",
+                        .graph_dot = R"(digraph G {
+                                1 [label="Person", name="Misha"];
+                                2 [label="Person", name="Bob"];
+                                1 -> 2 [label="friend"];
+                            })",
+                        .input_gdds = {gdd},
+                        .expected_valid_gdds = {gdd},
+                };
+            }(),
+            [] {
+                auto const weak_gdd = MakeGddDblpWeakAuthorResolution();
+                auto const strong_gdd = MakeGddDblpStrongAuthorResolution();
+
+                return ValidatorCase{
+                        .case_name = "DblpStrongHoldsWeakFails",
+                        .temp_file_name = "gdd_dblp_like_graph.dot",
+                        .graph_dot = DblpLikeGraphDot(),
+                        .input_gdds = {weak_gdd, strong_gdd},
+                        .expected_valid_gdds = {strong_gdd},
+                        .expected_counterexample_gdd_indices = {0},
+                };
+            }()};
+}
+
+template <class T>
 class GddValidatorCasesTest : public ::testing::TestWithParam<ValidatorCase> {
 protected:
     static std::filesystem::path WriteTempDotFile(std::string const& dot,
@@ -67,386 +418,43 @@ protected:
                 {config::names::kGraphData, graph_path},
                 {config::names::kGddData, gdds},
         };
-        return algos::CreateAndLoadAlgorithm<algos::NaiveGddValidator>(option_map);
+        return algos::CreateAndLoadAlgorithm<T>(option_map);
+    }
+
+    static void CheckCase(ValidatorCase const& tc) {
+        auto const graph_path = WriteTempDotFile(tc.graph_dot, tc.temp_file_name);
+        auto const validator = CreateGddValidatorInstance(graph_path, tc.input_gdds);
+
+        validator->Execute();
+        auto const out = validator->GetResult();
+
+        EXPECT_THAT(out, testing::UnorderedElementsAreArray(tc.expected_valid_gdds));
+
+        std::vector<std::size_t> actual_counterexample_indices;
+        actual_counterexample_indices.reserve(validator->GetCounterexamples().size());
+        for (auto const& [gdd_index, match] : validator->GetCounterexamples()) {
+            actual_counterexample_indices.push_back(gdd_index);
+        }
+
+        EXPECT_THAT(actual_counterexample_indices,
+                    testing::UnorderedElementsAreArray(tc.expected_counterexample_gdd_indices));
     }
 };
 
-TEST_P(GddValidatorCasesTest, ReturnsExpectedValidGdds) {
-    ValidatorCase const& tc = GetParam();
+TYPED_TEST_SUITE_P(GddValidatorCasesTest);
 
-    auto const graph_path = WriteTempDotFile(tc.graph_dot, tc.temp_file_name);
-    auto const validator = CreateGddValidatorInstance(graph_path, tc.input_gdds);
-
-    validator->Execute();
-    auto const out = validator->GetResult();
-
-    EXPECT_THAT(out, testing::UnorderedElementsAreArray(tc.expected_valid_gdds));
-
-    std::vector<std::size_t> actual_counterexample_indices;
-    actual_counterexample_indices.reserve(validator->GetCounterexamples().size());
-    for (auto const& [gdd_index, match] : validator->GetCounterexamples()) {
-        actual_counterexample_indices.push_back(gdd_index);
+TYPED_TEST_P(GddValidatorCasesTest, ReturnsExpectedValidGdds) {
+    for (ValidatorCase const& tc : GetValidatorCases()) {
+        SCOPED_TRACE(tc.case_name);
+        TestFixture::CheckCase(tc);
     }
-
-    EXPECT_THAT(actual_counterexample_indices,
-                testing::UnorderedElementsAreArray(tc.expected_counterexample_gdd_indices));
 }
 
-INSTANTIATE_TEST_SUITE_P(
-        ValidatorCases, GddValidatorCasesTest,
-        ::testing::Values(
-                [] {
-                    auto const pattern = tests::gdd::utils::MakeSingleVertexPattern(0, "City");
+REGISTER_TYPED_TEST_SUITE_P(GddValidatorCasesTest, ReturnsExpectedValidGdds);
 
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "VertexLabelMatters",
-                            .temp_file_name = "gdd_vertex_label_matters.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Country", name = "France"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-                [] {
-                    auto const pattern = MakePatternPersonCity("lives_in");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "EdgeLabelMatters",
-                            .temp_file_name = "gdd_edge_label_matters.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Person", name = "Misha"];
-                                2 [label = "City", name = "Amsterdam"];
-                                1 -> 2 [label = "works_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-                [] {
-                    auto const pattern = MakePatternPersonCity();
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(1, "label", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "DirectedEdgeOrientationMatters",
-                            .temp_file_name = "gdd_directed_edge_orientation_matters.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Person"];
-                                2 [label = "City"];
-                                2 -> 1 [label = "lives_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-                [] {
-                    auto const pattern = MakeArrowPattern(0, "X", 1, "X", "L");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{AttrAttr(0, "id", 1, "id",
-                                                    model::gdd::detail::DistanceMetric::kAbsDiff,
-                                                    model::gdd::detail::CmpOp::kGt, 0.0)});
+using GddValidatorAlgorithms = ::testing::Types<algos::NaiveGddValidator, algos::WcojGddValidator>;
 
-                    return ValidatorCase{
-                            .case_name = "HomomorphicMatchAllowsVertexMerging",
-                            .temp_file_name = "gdd_homomorphic_vertex_merging.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "X"];
-                                1 -> 1 [label = "L"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "City"];
-                        1 [label = "Country"];
-                        2 [label = "Country"];
-                        0 -> 1 [label = "capital_of"];
-                        0 -> 2 [label = "located_in"];
-                    })");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name =
-                                    "HomomorphicMatchSameTargetForDifferentPatternVertices"
-                                    "MatchExists",
-                            .temp_file_name = "gdd_homomorphic_same_target_match_exists.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "City", name = "Paris"];
-                                101 [label = "Country", name = "France"];
-                                1 -> 101 [label = "capital_of"];
-                                1 -> 101 [label = "located_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "City"];
-                        1 [label = "Country"];
-                        2 [label = "Country"];
-                        0 -> 1 [label = "capital_of"];
-                        0 -> 2 [label = "located_in"];
-                    })");
-
-                    Gdd const gdd(
-                            pattern, Gdd::Phi{},
-                            Gdd::Phi{AttrAttr(1, "name", 2, "name",
-                                              model::gdd::detail::DistanceMetric::kEditDistance,
-                                              model::gdd::detail::CmpOp::kEq, 0.0)});
-
-                    return ValidatorCase{
-                            .case_name = "HomomorphicMatchSameTargetForDifferentPatternVertices",
-                            .temp_file_name = "gdd_homomorphic_same_target_valid.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "City", name = "Paris"];
-                                101 [label = "Country", name = "France"];
-                                1 -> 101 [label = "capital_of"];
-                                1 -> 101 [label = "located_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "A"];
-                        1 [label = "B"];
-                        2 [label = "C"];
-                    })");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(0, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "DisconnectedPatternIsolatedVerticesCanBeMatched",
-                            .temp_file_name = "gdd_disconnected_isolated_vertices.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                10 [label = "A", name = "a"];
-                                11 [label = "B", name = "b"];
-                                12 [label = "C", name = "c"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "A"];
-                        1 [label = "B"];
-                        0 -> 1 [label = "l"];
-                    })");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "ConnectedPatternCannotJumpAcrossGraphComponents",
-                            .temp_file_name = "gdd_connected_cannot_jump_components.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "A", name = "left"];
-                                2 [label = "B", name = "right"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                            .expected_counterexample_gdd_indices = {},
-                    };
-                }(),
-                [] {
-                    auto const pattern = MakePatternPersonCity("lives_in");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "ParallelEdgesDifferentLabelsPatternNeedsOne",
-                            .temp_file_name = "gdd_parallel_edges_one_needed_label.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Person", name = "Misha"];
-                                2 [label = "City", name = "Amsterdam"];
-                                1 -> 2 [label = "works_in"];
-                                1 -> 2 [label = "lives_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "Person"];
-                        1 [label = "City"];
-                        0 -> 1 [label = "works_in"];
-                        0 -> 1 [label = "lives_in"];
-                    })");
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{EqStrAttrToConst(1, "name", "Impossible")});
-                    return ValidatorCase{
-                            .case_name = "ParallelEdgesDifferentLabelsPatternNeedsBoth",
-                            .temp_file_name = "gdd_parallel_edges_both_needed_label.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Person", name = "Misha"];
-                                2 [label = "City", name = "Amsterdam"];
-                                1 -> 2 [label = "works_in"];
-                                1 -> 2 [label = "lives_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        0 [label = "Person"];
-                        1 [label = "City"];
-                        0 -> 1 [label = "lives_in"];
-                        0 -> 1 [label = "works_in"];
-                    })");
-
-                    Gdd const gdd(pattern, Gdd::Phi{},
-                                  Gdd::Phi{tests::gdd::utils::AttrConst(
-                                          1, "name", std::string("Impossible"),
-                                          model::gdd::detail::DistanceMetric::kEditDistance,
-                                          model::gdd::detail::CmpOp::kEq, 0.0)});
-
-                    return ValidatorCase{
-                            .case_name = "PatternHasTwoParallelEdgesDifferentLabelsGraphHasOne",
-                            .temp_file_name = "gdd_pattern_parallel_edges_graph_has_one.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "Person", name = "Misha"];
-                                2 [label = "City", name = "Amsterdam"];
-                                1 -> 2 [label = "lives_in"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                            .expected_counterexample_gdd_indices = {},
-                    };
-                }(),
-                [] {
-                    auto const pattern = ReadGraphFromDot(R"(digraph P {
-                        1 [label = "root"];
-                        2 [label = "succ"];
-                        3 [label = "succ"];
-
-                        1 -> 2 [label = "edge"];
-                        1 -> 3 [label = "edge"];
-                    })");
-
-                    Gdd const gdd(
-                            pattern, Gdd::Phi{},
-                            Gdd::Phi{AttrAttr(2, "name", 3, "name",
-                                              model::gdd::detail::DistanceMetric::kEditDistance,
-                                              model::gdd::detail::CmpOp::kGt, 0.0)});
-
-                    return ValidatorCase{
-                            .case_name =
-                                    "RootWithTwoSuccChildrenOneComponentSatisfiesAnotherViolates",
-                            .temp_file_name =
-                                    "gdd_root_two_succ_children_one_component_violates.dot",
-                            .graph_dot = R"(
-                            digraph G {
-                                1 [label = "root", name = "v"];
-                                2 [label = "succ", name = "l"];
-                                3 [label = "succ", name = "r"];
-                                1 -> 2 [label = "edge"];
-                                1 -> 3 [label = "edge"];
-
-                                4 [label = "root", name = "u"];
-                                5 [label = "succ", name = "w"];
-                                4 -> 5 [label = "edge"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const g1 = MakeGddMishaLivesInAmsterdam();
-                    auto const g2 = MakeGddRigaInLatvia();
-                    auto const g3 = MakeGddVacuousImplicationNonexistentPerson();
-                    auto const g4 = MakeGddPersonAge25ImpliesLivesInAmsterdamAsRelationConstraint();
-                    auto const g5 = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
-
-                    return ValidatorCase{
-                            .case_name = "LargeGraphAllSatisfied",
-                            .temp_file_name = "gdd_large_graph_all_good.dot",
-                            .graph_dot = LargeGraphAllGoodDot(),
-                            .input_gdds = {g1, g2, g3, g4, g5},
-                            .expected_valid_gdds = {g1, g2, g3, g4, g5},
-                    };
-                }(),
-                [] {
-                    auto const gdd_bad = MakeGddMishaLivesInAmsterdam();
-                    auto const gdd_ok1 = MakeGddRigaInLatvia();
-                    auto const gdd_ok2 = MakeGddVacuousImplicationNonexistentPerson();
-                    auto const gdd_ok3 =
-                            MakeGddPersonAge25ImpliesLivesInAmsterdamAsRelationConstraint();
-                    auto const gdd_ok4 = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
-
-                    return ValidatorCase{
-                            .case_name = "LargeGraphDetectsViolation",
-                            .temp_file_name = "gdd_large_graph_with_violation.dot",
-                            .graph_dot = LargeGraphWithViolationMishaAlsoLivesInRigaDot(),
-                            .input_gdds = {gdd_bad, gdd_ok1, gdd_ok2, gdd_ok3, gdd_ok4},
-                            .expected_valid_gdds = {gdd_ok1, gdd_ok2, gdd_ok3, gdd_ok4},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }(),
-                [] {
-                    auto const gdd = MakeGddLabelConstraintPersonImpliesCityLabelCloseToCity();
-
-                    return ValidatorCase{
-                            .case_name = "UsesCustomAttributesAndLabel",
-                            .temp_file_name = "gdd_custom_attrs_graph.dot",
-                            .graph_dot = LargeGraphAllGoodDot(),
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-                [] {
-                    auto const gdd = MakeGddCompanyHqInAmsterdamNoCompanyInGraph();
-
-                    return ValidatorCase{
-                            .case_name = "EmptyMatchSetIsSatisfied",
-                            .temp_file_name = "gdd_no_matches_company_city.dot",
-                            .graph_dot = R"(digraph G {
-                                1 [label="Person", name="Misha"];
-                                2 [label="Person", name="Bob"];
-                                1 -> 2 [label="friend"];
-                            })",
-                            .input_gdds = {gdd},
-                            .expected_valid_gdds = {gdd},
-                    };
-                }(),
-                [] {
-                    auto const weak_gdd = MakeGddDblpWeakAuthorResolution();
-                    auto const strong_gdd = MakeGddDblpStrongAuthorResolution();
-
-                    return ValidatorCase{
-                            .case_name = "DblpStrongHoldsWeakFails",
-                            .temp_file_name = "gdd_dblp_like_graph.dot",
-                            .graph_dot = DblpLikeGraphDot(),
-                            .input_gdds = {weak_gdd, strong_gdd},
-                            .expected_valid_gdds = {strong_gdd},
-                            .expected_counterexample_gdd_indices = {0},
-                    };
-                }()),
-        [](testing::TestParamInfo<ValidatorCase> const& info) {
-            return SanitizeParamName(info.param.case_name);
-        });
+INSTANTIATE_TYPED_TEST_SUITE_P(GddValidatorCasesTest, GddValidatorCasesTest,
+                               GddValidatorAlgorithms);
 
 }  // namespace tests

--- a/src/tests/unit/test_gdd_validator.cpp
+++ b/src/tests/unit/test_gdd_validator.cpp
@@ -405,7 +405,10 @@ class GddValidatorCasesTest : public ::testing::TestWithParam<ValidatorCase> {
 protected:
     static std::filesystem::path WriteTempDotFile(std::string const& dot,
                                                   std::string const& file_name) {
-        auto const path = std::filesystem::temp_directory_path() / file_name;
+        auto const path =
+                std::filesystem::temp_directory_path() /
+                (std::to_string(std::chrono::system_clock::now().time_since_epoch().count()) +
+                 file_name);
         std::ofstream out(path);
         out << dot;
         out.close();
@@ -438,6 +441,10 @@ protected:
 
         EXPECT_THAT(actual_counterexample_indices,
                     testing::UnorderedElementsAreArray(tc.expected_counterexample_gdd_indices));
+
+        if (std::filesystem::exists(graph_path)) {
+            std::filesystem::remove(graph_path);
+        }
     }
 };
 


### PR DESCRIPTION
Extends GDD verification with a second matching backend, shared-pattern grouping, multi-threaded
execution and per-GDD match counts.

**`WcojGddValidator`** — a second validation backend alongside `NaiveGddValidator`. The naive
validator uses backtracking DFS and visits the match space recursively, which gives low memory usage
but exponential worst-case time. The new validator uses a Worst-Case Optimal Join: matches are built
one query vertex at a time in a flat level buffer, and each extension is a multiway intersection of
sorted adjacency lists with the candidate domain. This gives more optimal time complexity at the cost
of memory proportional to the size of the largest intermediate match set. Adjacency lists are
materialized lazily and cached per (vertex, direction, edge label), and the last computed
intersection is reused when consecutive partial matches share the same extension key.

**Query vertex ordering strategies** control the join order and directly affect both peak memory and
runtime. Two are added behind the `QvoStrategy` concept: `BfsQvoStrategy` (BFS from the vertex with
the smallest domain, tie-broken by pattern degree) and `CostBasedQvoStrategy`, which estimates
intersection cost from average adjacency list sizes per edge label and searches all orderings for
patterns up to 7 vertices, falling back to greedy selection for larger ones. Weakly connected
patterns use the cost-based strategy, disconnected ones fall back to BFS.

**Pattern grouping.** GDDs that share the same pattern are grouped, so subgraph matching runs once
per group instead of once per GDD; every GDD in the group is checked against each produced match, and
a GDD is dropped from the scan as soon as its counterexample is found. The validator interface changes
from `Holds` (one GDD) to `HoldsGroup` (one pattern, several GDDs). Results are permuted back into the
original input order.

**Parallel execution.** `GddValidator` now accepts the standard `threads` option. Group validation
goes through a `ValidationExecutor` strategy: `SequentialValidationExecutor` walks the groups in order,
`ParallelValidationExecutor` distributes groups across a `WorkerThreadPool`, each thread using its own
validator instance created by `CreateWorker`. Thread count is capped by the number of groups, so a
single-pattern workload stays sequential.

**Match counts.** `GddValidator::GetMatchesCount` (exposed to Python as `get_matches_count`) reports,
per input GDD, how many matches were checked — the total number of matches for a GDD that holds, or the
number examined up to its first counterexample.

Also in this PR: `WcojGddValidator` is registered in the Python bindings; the pattern-to-graph mapping
type is now `model::gdd::detail::MappingT` (a `boost::container::flat_map`) instead of
`std::unordered_map`, which is cheaper to build and iterate on the hot path; `BuildDomain` and
`LabelsMatch` moved into the shared base class. Validator tests are converted into a typed test suite
that runs every case against both backends and additionally checks that sequential and parallel runs
produce identical results, counterexamples and match counts.
