### PR TITLE
Reduce debug info in sanitizer CI builds

### DIFF
--- a/.github/workflows/core-tests.yml
+++ b/.github/workflows/core-tests.yml
@@ -71,9 +71,9 @@ jobs:
 
         cfg:
           - { BUILD_TYPE: Release }
-          - { BUILD_TYPE: Debug }
-          - { BUILD_TYPE: Debug, SANITIZER : ADDRESS, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1"' }
-          - { BUILD_TYPE: Debug, SANITIZER : UB, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1"' }
+          - { BUILD_TYPE: Debug, CMAKE_OPTS : '-DDESBORDANTE_CI_REDUCED_DEBUG_INFO=ON' }
+          - { BUILD_TYPE: Debug, SANITIZER : ADDRESS, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1" -DDESBORDANTE_CI_REDUCED_DEBUG_INFO=ON' }
+          - { BUILD_TYPE: Debug, SANITIZER : UB, CMAKE_OPTS : '-DCMAKE_CXX_FLAGS_DEBUG="-O1" -DDESBORDANTE_CI_REDUCED_DEBUG_INFO=ON' }
 
     runs-on: ${{ matrix.system.os }}
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ option(DESBORDANTE_BUILD_TESTS "Build tests" ON)
 # This option only takes effect if DESBORDANTE_BUILD_TESTS or DESBORDANTE_BUILD_BENCHMARKS is ON
 option(DESBORDANTE_FETCH_DATASETS "Fetch datasets for tests or benchmarks" ON)
 option(DESBORDANTE_GDB_SYMBOLS "Include debug information for use by GDB" OFF)
+option(DESBORDANTE_CI_REDUCED_DEBUG_INFO "Use reduced debug info intended for CI builds" OFF)
 # ---- Vertical Hashing Optimization ----
 # Performance/functionality trade-off:
 # - Disabled by default for maximum performance
@@ -125,13 +126,19 @@ endif()
 set(RELEASE_BUILD_OPTS ${BUILD_OPTS})
 set(DEBUG_BUILD_OPTS "${BUILD_OPTS}")
 
+if(DESBORDANTE_CI_REDUCED_DEBUG_INFO)
+    set(DESBORDANTE_DEBUG_INFO_FLAG "-g1")
+else()
+    set(DESBORDANTE_DEBUG_INFO_FLAG "-g")
+endif()
+
 # Set common DEBUG build options
 string(
     JOIN
     ";"
     DEBUG_BUILD_OPTS
     "${DEBUG_BUILD_OPTS}"
-    "-g"
+    "${DESBORDANTE_DEBUG_INFO_FLAG}"
     "-Wall"
     "-Wextra"
     "-Werror"


### PR DESCRIPTION
Add a dedicated CMake option for reduced CI debug info and enable it for ASan and UBSan core test jobs.

This switches sanitizer builds from full -g debug info to -g1 while leaving local and non-sanitized builds unchanged.