### PR TITLE
Remove custom bitset hashing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,14 +59,6 @@ option(DESBORDANTE_BUILD_TESTS "Build tests" ON)
 option(DESBORDANTE_FETCH_DATASETS "Fetch datasets for tests or benchmarks" ON)
 option(DESBORDANTE_GDB_SYMBOLS "Include debug information for use by GDB" OFF)
 option(DESBORDANTE_CI_REDUCED_DEBUG_INFO "Use reduced debug info intended for CI builds" OFF)
-# ---- Vertical Hashing Optimization ----
-# Performance/functionality trade-off:
-# - Disabled by default for maximum performance
-# - Enabled for wide datasets (>32 columns) with potential performance penalty
-option(DESBORDANTE_SAFE_VERTICAL_HASHING
-       "Enable safe vertical hashing mode. Allows processing wide datasets (>32 columns) \
-       at the cost of reduced performance. Recommended for exploratory data analysis." ON
-)
 option(DESBORDANTE_UNPACK_DATASETS "Unpack datasets" ON)
 option(DESBORDANTE_USE_LTO "Build using interprocedural optimization" OFF)
 

--- a/cmake/desbordante_helpers.cmake
+++ b/cmake/desbordante_helpers.cmake
@@ -8,10 +8,6 @@ set(DESBORDANTE_PREFIX
 set(NAME "${DESBORDANTE_PREFIX}.compile_feats")
 add_library(${NAME} INTERFACE)
 target_compile_features(${NAME} INTERFACE cxx_std_20)
-target_compile_definitions(
-    ${NAME}
-    INTERFACE $<$<BOOL:${DESBORDANTE_SAFE_VERTICAL_HASHING}>:DESBORDANTE_SAFE_VERTICAL_HASHING>
-)
 
 #[=[
     Brief

--- a/src/core/util/custom_hashes.h
+++ b/src/core/util/custom_hashes.h
@@ -1,45 +1,12 @@
 #pragma once
 
-#include "core/model/table/relational_schema.h"
 #include "core/model/table/vertical.h"
-
-class CustomHashing {
-private:
-    enum class BitsetHashingMethod { kTryConvertToUlong, kTrimAndConvertToUlong };
-
-    static constexpr BitsetHashingMethod kDefaultHashingMethod =
-#ifdef DESBORDANTE_SAFE_VERTICAL_HASHING
-            BitsetHashingMethod::kTrimAndConvertToUlong;
-#else
-            BitsetHashingMethod::kTryConvertToUlong;
-#endif
-
-    template <auto BitsetHashingMethod = kDefaultHashingMethod>
-    static size_t BitsetHash(boost::dynamic_bitset<> const& bitset);
-
-    friend std::hash<Vertical>;
-    friend std::hash<Column>;
-};
-
-template <>
-inline size_t CustomHashing::BitsetHash<CustomHashing::BitsetHashingMethod::kTryConvertToUlong>(
-        boost::dynamic_bitset<> const& bitset) {
-    return bitset.to_ulong();
-}
-
-template <>
-inline size_t CustomHashing::BitsetHash<CustomHashing::BitsetHashingMethod::kTrimAndConvertToUlong>(
-        boost::dynamic_bitset<> const& bitset) {
-    boost::dynamic_bitset<> copy_bitset = bitset;
-    copy_bitset.resize(std::numeric_limits<unsigned long>::digits);
-    return copy_bitset.to_ulong();
-}
 
 namespace std {
 template <>
 struct hash<Vertical> {
     size_t operator()(Vertical const& k) const {
-        return CustomHashing::BitsetHash(k.GetColumnIndicesRef());
+        return hash_value(k.GetColumnIndicesRef());
     }
 };
 


### PR DESCRIPTION
Tested Pyro on iowa1kk, everything hashing related took less than 0.01% of time, and the custom hashing is a point of confusion, given that there is a standard way.

docs/papers/Pyro - Maxim Strutovsky - 2020 spring.pdf does not refer to the hashing in any way. The custom hashing was added with Pyro in 7571906f1e5d366915a75ff3477fc5a7. I doubt it is going to affect performance negatively because, first off, it doesn't make any sense to have the algorithm error out when the dataset is too wide in a public library, so we should have SAFE_VERTICAL_HASHING set, and second, the safe method allocates memory for a new bitset and cuts off the last bits, which decreases randomness.