### PR TITLE
Disambigulate DataFrames if no name is given

### DIFF
--- a/src/python_bindings/py_util/create_dataframe_reader.cpp
+++ b/src/python_bindings/py_util/create_dataframe_reader.cpp
@@ -1,6 +1,7 @@
 #include "python_bindings/py_util/create_dataframe_reader.h"
 
 #include "core/config/exceptions.h"
+#include "core/model/index.h"
 #include "python_bindings/py_util/dataframe_reader.h"
 
 namespace python_bindings {
@@ -24,7 +25,7 @@ static bool AllColumnsAreStrings(py::handle dataframe) {
     return dtypes[dtypes.attr("__ne__")(py::str{"string"})].attr("empty").cast<bool>();
 }
 
-config::InputTable CreateDataFrameReader(py::handle dataframe) {
+config::InputTable CreateDataFrameReader(py::handle dataframe, model::Index object_index) {
     if (!IsDataFrame(dataframe))
         throw config::ConfigurationError("Passed object is not a dataframe");
     std::string name = [&]() -> std::string {
@@ -32,7 +33,9 @@ config::InputTable CreateDataFrameReader(py::handle dataframe) {
             return py::str(dataframe.attr("attrs")["name"]);
         } catch (py::error_already_set& e) {
             if (!(e.matches(PyExc_KeyError) || e.matches(PyExc_AttributeError))) throw;
-            return "Pandas dataframe";
+            return object_index == kSingleDataFrame
+                           ? "Pandas dataframe"
+                           : "Pandas dataframe (" + std::to_string(object_index) + ")";
         };
     }();
     if (AllColumnsAreStrings(dataframe)) {

--- a/src/python_bindings/py_util/create_dataframe_reader.h
+++ b/src/python_bindings/py_util/create_dataframe_reader.h
@@ -3,7 +3,11 @@
 #include <pybind11/pybind11.h>
 
 #include "core/config/tabular_data/input_table_type.h"
+#include "core/model/index.h"
 
 namespace python_bindings {
-config::InputTable CreateDataFrameReader(pybind11::handle dataframe);
+static constexpr model::Index kSingleDataFrame = -1;
+
+config::InputTable CreateDataFrameReader(pybind11::handle dataframe,
+                                         model::Index object_index = kSingleDataFrame);
 }  // namespace python_bindings

--- a/src/python_bindings/py_util/py_to_any.cpp
+++ b/src/python_bindings/py_util/py_to_any.cpp
@@ -27,6 +27,7 @@
 #include "core/config/exceptions.h"
 #include "core/config/tabular_data/input_table_type.h"
 #include "core/config/tabular_data/input_tables_type.h"
+#include "core/model/index.h"
 #include "core/model/transaction/input_format_type.h"
 #include "core/parser/csv_parser/csv_parser.h"
 #include "core/parser/sequence_parser/file_sequence_parser.h"
@@ -62,11 +63,13 @@ config::InputTable CreateCsvParser(std::string_view option_name, py::tuple const
             CastAndReplaceCastError<bool>(option_name, arguments[2]));
 }
 
-config::InputTable PythonObjToInputTable(std::string_view option_name, py::handle obj) {
+config::InputTable PythonObjToInputTable(
+        std::string_view option_name, py::handle obj,
+        model::Index object_index = python_bindings::kSingleDataFrame) {
     if (py::isinstance<py::tuple>(obj)) {
         return CreateCsvParser(option_name, py::cast<py::tuple>(obj));
     }
-    return python_bindings::CreateDataFrameReader(obj);
+    return python_bindings::CreateDataFrameReader(obj, object_index);
 }
 
 template <typename Type>
@@ -169,7 +172,10 @@ boost::any SequenceStreamToAny(std::string_view option_name, py::handle obj) {
 boost::any InputTablesToAny(std::string_view option_name, py::handle obj) {
     auto tables = CastAndReplaceCastError<std::vector<py::handle>>(option_name, obj);
     std::vector<config::InputTable> parsers;
-    for (auto const& table : tables) parsers.push_back(PythonObjToInputTable(option_name, table));
+    parsers.reserve(tables.size());
+    for (std::size_t i = 0; i != tables.size(); ++i) {
+        parsers.push_back(PythonObjToInputTable(option_name, tables[i], i));
+    }
     return parsers;
 }
 


### PR DESCRIPTION
This is a continuation of 7a4108d92803557442e49f1106a889d6874e49cd. I figured it would also be useful to disambigulate DataFrames when no name is given. I considered using the id() function for this, but I couldn't find a standard C API for calling it and an index would be easier to deal with anyway.