### PR TITLE
Remove most of non-const non-automatic variable usage

### DIFF
--- a/src/core/algorithms/cfd/model/partition_tidlist.cpp
+++ b/src/core/algorithms/cfd/model/partition_tidlist.cpp
@@ -2,8 +2,6 @@
 
 namespace algos::cfd {
 
-int const PartitionTIdList::kSep = -1;
-
 bool PartitionTIdList::operator==(PartitionTIdList const& b) const {
     return sets_number == b.sets_number && tids == b.tids;
 }

--- a/src/core/algorithms/cfd/model/partition_tidlist.h
+++ b/src/core/algorithms/cfd/model/partition_tidlist.h
@@ -18,7 +18,7 @@ struct PartitionTIdList {
 
     SimpleTIdList tids;
     unsigned sets_number;
-    static int const kSep;  // = -1;
+    static constexpr int kSep = -1;
     bool operator==(PartitionTIdList const&) const;
     bool operator!=(PartitionTIdList const&) const;
     bool operator<(PartitionTIdList const&) const;

--- a/src/core/algorithms/cfd/util/prefix_tree.h
+++ b/src/core/algorithms/cfd/util/prefix_tree.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <queue>
+#include <unordered_map>
 #include <unordered_set>
 
 #include <boost/functional/hash.hpp>

--- a/src/core/algorithms/fd/pyro/pyro.cpp
+++ b/src/core/algorithms/fd/pyro/pyro.cpp
@@ -13,8 +13,6 @@
 
 namespace algos {
 
-std::mutex search_spaces_mutex;
-
 Pyro::Pyro() : PliBasedFDAlgorithm() {
     RegisterOptions();
     fd_consumer_ = [this](auto const& fd) {
@@ -72,13 +70,13 @@ void Pyro::ExecuteInternal() {
 
     unsigned int total_error_calc_count = 0;
 
-    auto const work_on_search_space = [](std::list<std::unique_ptr<SearchSpace>>& search_spaces,
-                                         ProfilingContext* profiling_context,
-                                         [[maybe_unused]] int id) {
+    auto const work_on_search_space = [this](std::list<std::unique_ptr<SearchSpace>>& search_spaces,
+                                             ProfilingContext* profiling_context,
+                                             [[maybe_unused]] int id) {
         while (true) {
             std::unique_ptr<SearchSpace> polled_space;
             {
-                std::scoped_lock<std::mutex> lock(search_spaces_mutex);
+                std::scoped_lock<std::mutex> lock(search_spaces_mutex_);
                 if (search_spaces.empty()) {
                     break;
                 }

--- a/src/core/algorithms/fd/pyro/pyro.h
+++ b/src/core/algorithms/fd/pyro/pyro.h
@@ -13,6 +13,7 @@ namespace algos {
 class Pyro : public DependencyConsumer, public PliBasedFDAlgorithm {
 private:
     std::list<std::unique_ptr<SearchSpace>> search_spaces_;
+    std::mutex search_spaces_mutex_;
 
     CachingMethod caching_method_ = CachingMethod::kCoin;
     CacheEvictionMethod eviction_method_ = CacheEvictionMethod::kDefault;

--- a/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.h
+++ b/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.h
@@ -53,7 +53,7 @@ protected:
                                                unsigned int sample_size, CustomRandom& random);
 
 private:
-    static double std_dev_smoothing_;
+    static constexpr double kStdDevSmoothing = 1;
 
     double RatioToRelationRatio(double ratio) const {
         return ratio * population_size_ / relation_data_->GetNumTuplePairs();

--- a/src/core/algorithms/ind/faida/inclusion_testing/hyperloglog.h
+++ b/src/core/algorithms/ind/faida/inclusion_testing/hyperloglog.h
@@ -33,6 +33,7 @@
 #include <bit>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <vector>

--- a/src/core/algorithms/md/hymd/lattice/node_base.h
+++ b/src/core/algorithms/md/hymd/lattice/node_base.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <map>

--- a/src/core/model/table/position_list_index.cpp
+++ b/src/core/model/table/position_list_index.cpp
@@ -20,8 +20,6 @@
 
 namespace model {
 
-int const PositionListIndex::kSingletonValueId = 0;
-
 PositionListIndex::PositionListIndex(std::deque<std::vector<int>> index, unsigned int size,
                                      double entropy, unsigned long long nep,
                                      unsigned int relation_size, double inverted_entropy,

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -42,7 +42,7 @@ private:
     unsigned int freq_ = 0;
 
 public:
-    static int const kSingletonValueId;
+    static constexpr int kSingletonValueId = 0;
 
     PositionListIndex(std::deque<Cluster> index, unsigned int size, double entropy,
                       unsigned long long nep, unsigned int relation_size,

--- a/src/core/model/types/bitset.h
+++ b/src/core/model/types/bitset.h
@@ -1102,9 +1102,8 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
     typename IStreamType::sentry sentry(is);
     if (sentry) {
         try {
+            typename Traits::int_type const eof = Traits::eof();
             for (size_t i{NumBits}; i > 0; --i) {
-                static typename Traits::int_type eof = Traits::eof();
-
                 typename Traits::int_type c1 = is.rdbuf()->sbumpc();
                 if (Traits::eq_int_type(c1, eof)) {
                     state |= IOSBase::eofbit;

--- a/src/core/model/types/double_type.h
+++ b/src/core/model/types/double_type.h
@@ -13,7 +13,7 @@ class DoubleType final : public NumericType<Double> {
 public:
     DoubleType() noexcept : NumericType<Double>(TypeId::kDouble) {}
 
-    static unsigned int const kDefaultEpsCount = 5;
+    static constexpr unsigned int kDefaultEpsCount = 5;
 
     CompareResult Compare(std::byte const* l, std::byte const* r) const final {
         return CompareEPS(l, r, kDefaultEpsCount);

--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -32,14 +32,15 @@ namespace py = pybind11;
 
 namespace {
 
-constexpr PyTypeObject* const kPyInt = &PyLong_Type;
-constexpr PyTypeObject* const kPyBool = &PyBool_Type;
-constexpr PyTypeObject* const kPyFloat = &PyFloat_Type;
-constexpr PyTypeObject* const kPyStr = &PyUnicode_Type;
-constexpr PyTypeObject* const kPyList = &PyList_Type;
-constexpr PyTypeObject* const kPyTuple = &PyTuple_Type;
-constexpr PyTypeObject* const kPySet = &PySet_Type;
-constexpr PyTypeObject* const kPyDict = &PyDict_Type;
+// Python types and their C names:
+// int -> PyLong_Type
+// bool -> PyBool_Type
+// float -> PyFloat_Type
+// str -> PyUnicode_Type
+// list -> PyList_Type
+// tuple -> PyTuple_Type
+// set -> PySet_Type
+// dict -> PyDict_Type
 
 py::handle MakeType(py::type type) {
     return type;
@@ -63,7 +64,7 @@ py::tuple MakeTypeTuple(TypePtrs... type_ptrs) {
 }
 
 template <typename CppType, PyTypeObject*... PyTypes>
-std::pair<std::type_index, std::function<py::tuple()>> const PyTypePair{
+std::pair<std::type_index, std::function<py::tuple()>> const kPyTypePair{
         std::type_index{typeid(CppType)}, []() { return MakeTypeTuple(PyTypes...); }};
 
 }  // namespace
@@ -80,58 +81,59 @@ py::tuple GetPyType(std::type_index type_index) {
     // possible) as storing pybind11's objects themselves statically is
     // unpredictable and can lead to errors related to garbage collection.
     static std::unordered_map<std::type_index, std::function<py::tuple()>> const type_map{
-            PyTypePair<bool, kPyBool>,
-            PyTypePair<unsigned short, kPyInt>,
-            PyTypePair<int, kPyInt>,
-            PyTypePair<unsigned int, kPyInt>,
-            PyTypePair<double, kPyFloat>,
-            PyTypePair<size_t, kPyInt>,
-            PyTypePair<long double, kPyFloat>,
-            PyTypePair<std::size_t, kPyInt>,
-            PyTypePair<std::vector<std::string>, kPyList, kPyStr>,
-            PyTypePair<config::CustomRandomSeedType, kPyInt>,
-            PyTypePair<algos::metric::Metric, kPyStr>,
-            PyTypePair<algos::metric::MetricAlgo, kPyStr>,
-            PyTypePair<config::PfdErrorMeasureType, kPyStr>,
-            PyTypePair<config::AfdErrorMeasureType, kPyStr>,
-            PyTypePair<model::InputFormatType, kPyStr>,
-            PyTypePair<algos::cfd::Substrategy, kPyStr>,
-            PyTypePair<algos::hymd::LevelDefinition, kPyStr>,
-            PyTypePair<algos::od::Ordering, kPyStr>,
-            PyTypePair<algos::des::DifferentialStrategy, kPyStr>,
-            PyTypePair<std::vector<unsigned int>, kPyList, kPyInt>,
+            kPyTypePair<bool, &PyBool_Type>,
+            kPyTypePair<unsigned short, &PyLong_Type>,
+            kPyTypePair<int, &PyLong_Type>,
+            kPyTypePair<unsigned int, &PyLong_Type>,
+            kPyTypePair<double, &PyFloat_Type>,
+            kPyTypePair<size_t, &PyLong_Type>,
+            kPyTypePair<long double, &PyFloat_Type>,
+            kPyTypePair<std::size_t, &PyLong_Type>,
+            kPyTypePair<std::vector<std::string>, &PyList_Type, &PyUnicode_Type>,
+            kPyTypePair<config::CustomRandomSeedType, &PyLong_Type>,
+            kPyTypePair<algos::metric::Metric, &PyUnicode_Type>,
+            kPyTypePair<algos::metric::MetricAlgo, &PyUnicode_Type>,
+            kPyTypePair<config::PfdErrorMeasureType, &PyUnicode_Type>,
+            kPyTypePair<config::AfdErrorMeasureType, &PyUnicode_Type>,
+            kPyTypePair<model::InputFormatType, &PyUnicode_Type>,
+            kPyTypePair<algos::cfd::Substrategy, &PyUnicode_Type>,
+            kPyTypePair<algos::hymd::LevelDefinition, &PyUnicode_Type>,
+            kPyTypePair<algos::od::Ordering, &PyUnicode_Type>,
+            kPyTypePair<algos::des::DifferentialStrategy, &PyUnicode_Type>,
+            kPyTypePair<std::vector<unsigned int>, &PyList_Type, &PyLong_Type>,
             {typeid(algos::hymd::HyMD::ColumnMatches),
              []() {
                  return MakeTypeTuple(
-                         kPyList,
+                         &PyList_Type,
                          py::type::of<algos::hymd::preprocessing::column_matches::ColumnMatch>());
              }},
             {typeid(model::DDString),
              []() {
-                 return MakeTypeTuple(kPyTuple, kPyList, py::type::of<model::DFStringConstraint>());
+                 return MakeTypeTuple(&PyTuple_Type, &PyList_Type,
+                                      py::type::of<model::DFStringConstraint>());
              }},
             {typeid(config::InputTable),
              []() { return MakeTypeTuple(py::type::of<config::InputTable>()); }},
             {typeid(config::InputTables),
-             []() { return MakeTypeTuple(kPyList, py::type::of<config::InputTable>()); }},
+             []() { return MakeTypeTuple(&PyList_Type, py::type::of<config::InputTable>()); }},
             {typeid(algos::md::ColumnSimilarityClassifier),
              []() { return MakeTypeTuple(py::type::of<algos::md::ColumnSimilarityClassifier>()); }},
             {typeid(std::vector<algos::md::ColumnSimilarityClassifier>),
              []() {
-                 return MakeTypeTuple(kPyList,
+                 return MakeTypeTuple(&PyList_Type,
                                       py::type::of<algos::md::ColumnSimilarityClassifier>());
              }},
             {typeid(std::vector<model::Gdd>),
-             [] { return MakeTypeTuple(kPyList, py::type::of<model::Gdd>()); }},
+             [] { return MakeTypeTuple(&PyList_Type, py::type::of<model::Gdd>()); }},
             {typeid(std::vector<model::GddCounterexample>),
-             [] { return MakeTypeTuple(kPyList, py::type::of<model::GddCounterexample>()); }},
-            PyTypePair<std::filesystem::path, kPyStr>,
-            PyTypePair<std::vector<std::filesystem::path>, kPyList, kPyStr>,
-            PyTypePair<std::unordered_set<size_t>, kPySet, kPyInt>,
-            PyTypePair<std::string, kPyStr>,
-            PyTypePair<std::vector<std::string>, kPyList, kPyStr>,
-            PyTypePair<std::unordered_map<std::string, std::vector<unsigned int>>, kPyDict, kPyStr,
-                       kPyList, kPyInt>,
+             [] { return MakeTypeTuple(&PyList_Type, py::type::of<model::GddCounterexample>()); }},
+            kPyTypePair<std::filesystem::path, &PyUnicode_Type>,
+            kPyTypePair<std::vector<std::filesystem::path>, &PyList_Type, &PyUnicode_Type>,
+            kPyTypePair<std::unordered_set<size_t>, &PySet_Type, &PyLong_Type>,
+            kPyTypePair<std::string, &PyUnicode_Type>,
+            kPyTypePair<std::vector<std::string>, &PyList_Type, &PyUnicode_Type>,
+            kPyTypePair<std::unordered_map<std::string, std::vector<unsigned int>>, &PyDict_Type,
+                        &PyUnicode_Type, &PyList_Type, &PyLong_Type>,
     };
 
     auto const it = type_map.find(type_index);

--- a/src/python_bindings/py_util/opt_to_py.cpp
+++ b/src/python_bindings/py_util/opt_to_py.cpp
@@ -29,34 +29,35 @@ namespace py = pybind11;
 using ConvFunction = std::function<py::object(boost::any)>;
 
 template <typename T>
-std::pair<std::type_index, ConvFunction> normal_conv_pair{
+std::pair<std::type_index, ConvFunction> const kNormalConvPair{
         std::type_index(typeid(T)),
         [](boost::any value) { return py::cast(boost::any_cast<T>(value)); }};
 
 template <typename T>
-std::pair<std::type_index, ConvFunction> enum_conv_pair{
+std::pair<std::type_index, ConvFunction> const kEnumConvPair{
         std::type_index(typeid(T)),
         [](boost::any value) { return py::cast(util::EnumToStr(boost::any_cast<T>(value))); }};
+
 std::unordered_map<std::type_index, ConvFunction> const kConverters{
-        normal_conv_pair<int>,
-        normal_conv_pair<double>,
-        normal_conv_pair<long double>,
-        normal_conv_pair<unsigned int>,
-        normal_conv_pair<bool>,
-        normal_conv_pair<std::vector<std::string>>,
-        normal_conv_pair<config::ThreadNumType>,
-        normal_conv_pair<config::CustomRandomSeedType>,
-        normal_conv_pair<config::MaxLhsType>,
-        normal_conv_pair<config::ErrorType>,
-        normal_conv_pair<config::IndicesType>,
-        normal_conv_pair<model::DDString>,
-        normal_conv_pair<model::Gdd>,
-        enum_conv_pair<algos::metric::MetricAlgo>,
-        enum_conv_pair<algos::metric::Metric>,
-        enum_conv_pair<model::InputFormatType>,
-        enum_conv_pair<algos::hymd::LevelDefinition>,
-        enum_conv_pair<algos::des::DifferentialStrategy>,
-        enum_conv_pair<algos::od::Ordering>};
+        kNormalConvPair<int>,
+        kNormalConvPair<double>,
+        kNormalConvPair<long double>,
+        kNormalConvPair<unsigned int>,
+        kNormalConvPair<bool>,
+        kNormalConvPair<std::vector<std::string>>,
+        kNormalConvPair<config::ThreadNumType>,
+        kNormalConvPair<config::CustomRandomSeedType>,
+        kNormalConvPair<config::MaxLhsType>,
+        kNormalConvPair<config::ErrorType>,
+        kNormalConvPair<config::IndicesType>,
+        kNormalConvPair<model::DDString>,
+        kNormalConvPair<model::Gdd>,
+        kEnumConvPair<algos::metric::MetricAlgo>,
+        kEnumConvPair<algos::metric::Metric>,
+        kEnumConvPair<model::InputFormatType>,
+        kEnumConvPair<algos::hymd::LevelDefinition>,
+        kEnumConvPair<algos::des::DifferentialStrategy>,
+        kEnumConvPair<algos::od::Ordering>};
 }  // namespace
 
 namespace python_bindings {

--- a/src/tests/unit/test_dc_structures.cpp
+++ b/src/tests/unit/test_dc_structures.cpp
@@ -326,16 +326,16 @@ TEST_F(FastADC, DifferentColumnPredicateSpace) {
         }
     };
 
-    check_preds(predicate_builder_->GetPredicates(), different_column_predicates_expected,
+    check_preds(predicate_builder_->GetPredicates(), kDifferentColumnPredicatesExpected,
                 "all predicates");
     check_preds(predicate_builder_->GetNumSingleColumnPredicates(),
-                num_single_column_predicate_group_expected, "numeric single column predicates");
+                kNumSingleColumnPredicateGroupExpected, "numeric single column predicates");
     check_preds(predicate_builder_->GetNumCrossColumnPredicates(),
-                num_cross_column_predicate_group_expected, "numeric cross column predicates");
+                kNumCrossColumnPredicateGroupExpected, "numeric cross column predicates");
     check_preds(predicate_builder_->GetStrSingleColumnPredicates(),
-                str_single_column_predicate_group_expected, "string single column predicates");
+                kStrSingleColumnPredicateGroupExpected, "string single column predicates");
     check_preds(predicate_builder_->GetStrCrossColumnPredicates(),
-                str_cross_column_predicate_group_expected, "string cross column predicates");
+                kStrCrossColumnPredicateGroupExpected, "string cross column predicates");
 }
 
 TEST_F(FastADC, InverseAndMutexMaps) {
@@ -426,18 +426,18 @@ TEST_F(FastADC, ClueSetPredicatePacksAndCorrectionMap) {
     auto correction_map = evidence_aux_structures_builder_->GetCorrectionMap();
 
     for (size_t i = 0; i < packs.size(); ++i) {
-        EXPECT_EQ(packs[i].left_idx, expected_column_indices[i].first);
-        EXPECT_EQ(packs[i].right_idx, expected_column_indices[i].second);
-        ASSERT_EQ(expected_eq_masks[i].size(), 1);
-        EXPECT_EQ(packs[i].eq_pos, expected_eq_masks[i][0]);
-        if (!expected_gt_masks[i].empty()) {
-            ASSERT_EQ(expected_gt_masks[i].size(), 1);
-            EXPECT_EQ(packs[i].gt_pos, expected_gt_masks[i][0]);
+        EXPECT_EQ(packs[i].left_idx, kExpectedColumnIndices[i].first);
+        EXPECT_EQ(packs[i].right_idx, kExpectedColumnIndices[i].second);
+        ASSERT_EQ(kExpectedEqMasks[i].size(), 1);
+        EXPECT_EQ(packs[i].eq_pos, kExpectedEqMasks[i][0]);
+        if (!kExpectedGtMasks[i].empty()) {
+            ASSERT_EQ(kExpectedGtMasks[i].size(), 1);
+            EXPECT_EQ(packs[i].gt_pos, kExpectedGtMasks[i][0]);
         }
     }
 
     for (size_t i = 0; i < correction_map.size(); ++i) {
-        EXPECT_EQ(correction_map[i], VectorToBitset(expected_correction_map[i]));
+        EXPECT_EQ(correction_map[i], VectorToBitset(kExpectedCorrectionMap[i]));
     }
 }
 
@@ -452,7 +452,7 @@ TEST_F(FastADC, ClueSet) {
     ClueSet clue_set = BuildClueSet(pli_shard_builder_->pli_shards,
                                     evidence_aux_structures_builder_->GetPredicatePacks());
 
-    for (auto const& [expected_clue, expected_count] : expected_clue_set) {
+    for (auto const& [expected_clue, expected_count] : kExpectedClueSet) {
         auto found = clue_set.find(PredicateBitset(expected_clue));
         ASSERT_NE(found, clue_set.end()) << "Expected clue " << expected_clue << " not found!";
         ASSERT_EQ(found->second, expected_count) << "Count mismatch for clue " << expected_clue;
@@ -461,7 +461,7 @@ TEST_F(FastADC, ClueSet) {
     // Check that no additional clues are present
     for (auto const& [generated_clue, count] : clue_set) {
         uint64_t clue_value = generated_clue.to_ullong();
-        ASSERT_NE(expected_clue_set.find(clue_value), expected_clue_set.end())
+        ASSERT_NE(kExpectedClueSet.find(clue_value), kExpectedClueSet.end())
                 << "Unexpected clue " << clue_value << " found!";
     }
 }
@@ -475,7 +475,7 @@ TEST_F(FastADC, CardinalityMask) {
     evidence_aux_structures_builder_->BuildAll();
 
     EXPECT_EQ(evidence_aux_structures_builder_->GetCardinalityMask(),
-              VectorToBitset(expected_cardinality_mask));
+              VectorToBitset(kExpectedCardinalityMask));
 }
 
 TEST_F(FastADC, EvidenceSet) {
@@ -492,7 +492,7 @@ TEST_F(FastADC, EvidenceSet) {
     auto evidence_set = std::move(evidence_set_builder_->evidence_set);
 
     std::unordered_set<PredicateBitset> expected_set;
-    for (auto const& expected_vec : expected_evidence_set) {
+    for (auto const& expected_vec : kExpectedEvidenceSet) {
         expected_set.insert(VectorToBitset(expected_vec));
     }
 
@@ -525,7 +525,7 @@ TEST_F(FastADC, TransformedEvidenceSetAndMutexMap) {
     std::vector<Evidence> transformed_evidence_set = organizer.TransformEvidenceSet();
 
     std::unordered_set<PredicateBitset> expected;
-    for (auto const& expected_vec : expected_transformed_evidence_set) {
+    for (auto const& expected_vec : kExpectedTransformedEvidenceSet) {
         expected.insert(VectorToBitset(expected_vec));
     }
 
@@ -537,7 +537,7 @@ TEST_F(FastADC, TransformedEvidenceSetAndMutexMap) {
 
     std::vector<PredicateBitset> transformed_mutex_map = organizer.TransformMutexMap();
     for (size_t i = 0; i < transformed_mutex_map.size(); i++) {
-        EXPECT_EQ(transformed_mutex_map[i], VectorToBitset(expected_mutex_map[i]));
+        EXPECT_EQ(transformed_mutex_map[i], VectorToBitset(kExpectedMutexMap[i]));
     }
 }
 
@@ -568,9 +568,9 @@ TEST_F(FastADC, DenialConstraints) {
     std::set<DenialConstraint, ToStringComparator> ordered_result(
             std::make_move_iterator(result.begin()), std::make_move_iterator(result.end()));
 
-    for (size_t i = 0; i < expected_denial_constraints.size(); i++) {
+    for (size_t i = 0; i < kExpectedDenialConstraints.size(); i++) {
         std::string dc = std::next(ordered_result.begin(), i)->ToString();
-        EXPECT_EQ(dc, expected_denial_constraints[i]) << "Unexpected denial constraint: " << dc;
+        EXPECT_EQ(dc, kExpectedDenialConstraints[i]) << "Unexpected denial constraint: " << dc;
     }
 }
 

--- a/src/tests/unit/test_dc_structures_correct_results.h
+++ b/src/tests/unit/test_dc_structures_correct_results.h
@@ -9,7 +9,7 @@
 #include "core/algorithms/dc/FastADC/model/predicate.h"
 #include "core/model/types/bitset.h"
 
-std::vector<std::string> different_column_predicates_expected = {
+std::vector<std::string> const kDifferentColumnPredicatesExpected = {
         "t.A == s.A", "t.A != s.A", "t.A > s.A",  "t.A < s.A",  "t.A >= s.A", "t.A <= s.A",
         "t.A == s.C", "t.A != s.C", "t.A > s.C",  "t.A < s.C",  "t.A >= s.C", "t.A <= s.C",
         "t.A == s.D", "t.A != s.D", "t.A > s.D",  "t.A < s.D",  "t.A >= s.D", "t.A <= s.D",
@@ -21,33 +21,33 @@ std::vector<std::string> different_column_predicates_expected = {
         "t.F == s.F", "t.F != s.F", "t.G == s.G", "t.G != s.G",
 };
 
-std::vector<std::string> num_single_column_predicate_group_expected = {
+std::vector<std::string> const kNumSingleColumnPredicateGroupExpected = {
         "t.A == s.A", "t.A != s.A", "t.A > s.A", "t.A < s.A", "t.A >= s.A", "t.A <= s.A",
         "t.B == s.B", "t.B != s.B", "t.B > s.B", "t.B < s.B", "t.B >= s.B", "t.B <= s.B",
         "t.C == s.C", "t.C != s.C", "t.C > s.C", "t.C < s.C", "t.C >= s.C", "t.C <= s.C",
         "t.D == s.D", "t.D != s.D", "t.D > s.D", "t.D < s.D", "t.D >= s.D", "t.D <= s.D",
         "t.E == s.E", "t.E != s.E", "t.E > s.E", "t.E < s.E", "t.E >= s.E", "t.E <= s.E"};
 
-std::vector<std::string> num_cross_column_predicate_group_expected = {
+std::vector<std::string> const kNumCrossColumnPredicateGroupExpected = {
         "t.A == s.C", "t.A != s.C", "t.A > s.C", "t.A < s.C", "t.A >= s.C", "t.A <= s.C",
         "t.A == s.D", "t.A != s.D", "t.A > s.D", "t.A < s.D", "t.A >= s.D", "t.A <= s.D",
         "t.C == s.D", "t.C != s.D", "t.C > s.D", "t.C < s.D", "t.C >= s.D", "t.C <= s.D"};
 
-std::vector<std::string> str_single_column_predicate_group_expected = {"t.F == s.F", "t.F != s.F",
-                                                                       "t.G == s.G", "t.G != s.G"};
+std::vector<std::string> const kStrSingleColumnPredicateGroupExpected = {
+        "t.F == s.F", "t.F != s.F", "t.G == s.G", "t.G != s.G"};
 
-std::vector<std::string> str_cross_column_predicate_group_expected = {};
+std::vector<std::string> const kStrCrossColumnPredicateGroupExpected = {};
 
-std::vector<std::pair<size_t, size_t>> expected_column_indices = {
+std::vector<std::pair<size_t, size_t>> const kExpectedColumnIndices = {
         {5, 5}, {6, 6}, {0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {0, 2}, {0, 3}, {2, 3}};
 
-std::vector<std::vector<size_t>> expected_eq_masks = {{0}, {1},  {2},  {4},  {6},
-                                                      {8}, {10}, {12}, {14}, {16}};
+std::vector<std::vector<size_t>> const kExpectedEqMasks = {{0}, {1},  {2},  {4},  {6},
+                                                           {8}, {10}, {12}, {14}, {16}};
 
-std::vector<std::vector<size_t>> expected_gt_masks = {{},  {},   {3},  {5},  {7},
-                                                      {9}, {11}, {13}, {15}, {17}};
+std::vector<std::vector<size_t>> const kExpectedGtMasks = {{},  {},   {3},  {5},  {7},
+                                                           {9}, {11}, {13}, {15}, {17}};
 
-std::vector<std::vector<size_t>> expected_correction_map = {
+std::vector<std::vector<size_t>> const kExpectedCorrectionMap = {
         {48, 49},         {50, 51},         {0, 1, 3, 4},     {2, 3, 4, 5},     {18, 19, 21, 22},
         {20, 21, 22, 23}, {24, 25, 27, 28}, {26, 27, 28, 29}, {36, 37, 39, 40}, {38, 39, 40, 41},
         {42, 43, 45, 46}, {44, 45, 46, 47}, {6, 7, 9, 10},    {8, 9, 10, 11},   {12, 13, 15, 16},
@@ -62,16 +62,16 @@ model::Bitset<algos::fastadc::kMaxPredicateBits> VectorToBitset(
     return bset;
 }
 
-std::unordered_map<uint64_t, size_t> expected_clue_set = {
+std::unordered_map<uint64_t, size_t> const kExpectedClueSet = {
         {2082, 1},   {65570, 1},  {67584, 1},  {67616, 1},  {131104, 1}, {133122, 1}, {133157, 1},
         {148101, 1}, {166152, 1}, {166408, 1}, {168096, 1}, {172448, 1}, {172680, 1}, {172682, 1},
         {172711, 1}, {172712, 1}, {172714, 1}, {174087, 1}, {174728, 1}, {174730, 1}};
 
-std::vector<size_t> expected_cardinality_mask = {1,  3,  5,  7,  9,  11, 13, 15, 17,
-                                                 19, 21, 23, 25, 27, 29, 31, 33, 35,
-                                                 37, 39, 41, 43, 45, 47, 49, 51};
+std::vector<size_t> const kExpectedCardinalityMask = {1,  3,  5,  7,  9,  11, 13, 15, 17,
+                                                      19, 21, 23, 25, 27, 29, 31, 33, 35,
+                                                      37, 39, 41, 43, 45, 47, 49, 51};
 
-std::vector<std::vector<size_t>> expected_evidence_set = {
+std::vector<std::vector<size_t>> const kExpectedEvidenceSet = {
         {1,  3,  5,  7,  9,  11, 13, 15, 17, 19, 20, 22, 25,
          27, 29, 31, 32, 34, 37, 39, 41, 43, 45, 47, 49, 51},
         {0,  4,  5,  7,  8,  10, 13, 14, 16, 19, 20, 22, 25,
@@ -113,7 +113,7 @@ std::vector<std::vector<size_t>> expected_evidence_set = {
         {1,  2,  4,  7,  8,  10, 13, 14, 16, 19, 21, 23, 25,
          26, 28, 31, 32, 34, 37, 38, 40, 43, 45, 47, 49, 50}};
 
-std::vector<std::vector<size_t>> expected_transformed_evidence_set = {
+std::vector<std::vector<size_t>> const kExpectedTransformedEvidenceSet = {
         {11, 13, 14, 15, 18, 19, 22, 24, 26, 28, 29, 31, 33,
          35, 37, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51},
         {7,  9,  11, 13, 14, 18, 19, 22, 24, 26, 28, 29, 31,
@@ -156,60 +156,60 @@ std::vector<std::vector<size_t>> expected_transformed_evidence_set = {
          39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51},
 };
 
-std::vector<std::vector<size_t>> expected_mutex_map = {{0, 21, 22, 23, 24, 49},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {2, 29, 30, 31, 32, 51},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {10, 43},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {15, 39},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {0, 21, 22, 23, 24, 49},
-                                                       {0, 21, 22, 23, 24, 49},
-                                                       {0, 21, 22, 23, 24, 49},
-                                                       {0, 21, 22, 23, 24, 49},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {2, 29, 30, 31, 32, 51},
-                                                       {2, 29, 30, 31, 32, 51},
-                                                       {2, 29, 30, 31, 32, 51},
-                                                       {2, 29, 30, 31, 32, 51},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {15, 39},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {8, 12, 13, 36, 37, 41},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {10, 43},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {6, 17, 18, 34, 35, 45},
-                                                       {3, 16, 19, 20, 33, 46},
-                                                       {4, 11, 14, 38, 40, 47},
-                                                       {5, 7, 9, 42, 44, 48},
-                                                       {0, 21, 22, 23, 24, 49},
-                                                       {1, 25, 26, 27, 28, 50},
-                                                       {2, 29, 30, 31, 32, 51}};
+std::vector<std::vector<size_t>> const kExpectedMutexMap = {{0, 21, 22, 23, 24, 49},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {2, 29, 30, 31, 32, 51},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {10, 43},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {15, 39},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {0, 21, 22, 23, 24, 49},
+                                                            {0, 21, 22, 23, 24, 49},
+                                                            {0, 21, 22, 23, 24, 49},
+                                                            {0, 21, 22, 23, 24, 49},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {2, 29, 30, 31, 32, 51},
+                                                            {2, 29, 30, 31, 32, 51},
+                                                            {2, 29, 30, 31, 32, 51},
+                                                            {2, 29, 30, 31, 32, 51},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {15, 39},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {8, 12, 13, 36, 37, 41},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {10, 43},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {6, 17, 18, 34, 35, 45},
+                                                            {3, 16, 19, 20, 33, 46},
+                                                            {4, 11, 14, 38, 40, 47},
+                                                            {5, 7, 9, 42, 44, 48},
+                                                            {0, 21, 22, 23, 24, 49},
+                                                            {1, 25, 26, 27, 28, 50},
+                                                            {2, 29, 30, 31, 32, 51}};
 
-std::vector<std::string> expected_denial_constraints = {
+std::vector<std::string> const kExpectedDenialConstraints = {
         "¬{ t.A != s.A ∧ t.A != s.C ∧ t.A >= s.D ∧ t.D < s.D }",
         "¬{ t.A != s.A ∧ t.A < s.C ∧ t.A >= s.D ∧ t.E <= s.E }",
         "¬{ t.A != s.A ∧ t.A < s.C ∧ t.C >= s.C }",

--- a/src/tests/unit/test_faida.cpp
+++ b/src/tests/unit/test_faida.cpp
@@ -36,7 +36,7 @@ protected:
 
 using FaidaTestConfig = FaidaINDAlgorithmTest::Config;
 
-static FaidaTestConfig parallel_test_config{
+static constexpr FaidaTestConfig kParallelTestConfig{
         .sample_size = 500,
         .hll_accuracy = 0.001,
         .num_threads = 4,
@@ -45,7 +45,7 @@ static FaidaTestConfig parallel_test_config{
 
 TEST_F(FaidaINDAlgorithmTest, EqualityTest) {
     for (auto& [csv_configs, expected_inds] : kINDEqualityTestConfigs) {
-        CheckINDsListsEqualityTest(CreateFaidaInstance(csv_configs, parallel_test_config),
+        CheckINDsListsEqualityTest(CreateFaidaInstance(csv_configs, kParallelTestConfig),
                                    expected_inds);
     }
 }
@@ -54,7 +54,7 @@ TEST_F(FaidaINDAlgorithmTest, TestTwoTables) {
     INDTestSet expected_inds_subset{{{0, {0, 1, 2, 3}}, {1, {0, 1, 3, 4}}},
                                     {{1, {0, 1, 3, 4}}, {0, {0, 1, 2, 3}}}};
     CheckINDsResultContainsINDsTest(
-            CreateFaidaInstance({kIndTestTableFirst, kIndTestTableSecond}, parallel_test_config),
+            CreateFaidaInstance({kIndTestTableFirst, kIndTestTableSecond}, kParallelTestConfig),
             expected_inds_subset, 47);
 }
 

--- a/src/tests/unit/test_ucc_algorithms.cpp
+++ b/src/tests/unit/test_ucc_algorithms.cpp
@@ -33,10 +33,10 @@ namespace {
 // ARAlgorithmTest for example).
 template <typename AlgorithmUnderTest>
 class UCCAlgorithmTest : public ::testing::Test {
-    static config::ThreadNumType threads_;
+    config::ThreadNumType threads_;
 
 protected:
-    static void SetThreadsParam(config::ThreadNumType threads) noexcept {
+    void SetThreadsParam(config::ThreadNumType threads) noexcept {
         assert(threads > 0);
         threads_ = threads;
     }
@@ -64,7 +64,7 @@ protected:
     }
 
 public:
-    static algos::StdParamsMap GetParamMap(CSVConfig const& csv_config) {
+    algos::StdParamsMap GetParamMap(CSVConfig const& csv_config) const {
         using namespace config::names;
         // Here we return StdParamsMap with option kThreads but some algorithms does not need this
         // option (PyroUCC for example). This does not generate errors, because when creating the
@@ -73,7 +73,7 @@ public:
         return {{kCsvConfig, csv_config}, {kThreads, threads_}};
     }
 
-    static std::unique_ptr<algos::UCCAlgorithm> CreateAlgorithmInstance(
+    std::unique_ptr<algos::UCCAlgorithm> const CreateAlgorithmInstance(
             CSVConfig const& csv_config) {
         return algos::CreateAndLoadAlgorithm<AlgorithmUnderTest>(GetParamMap(csv_config));
     }
@@ -118,31 +118,28 @@ public:
     };
 };
 
-template <typename AlgorithmUnderTest>
-config::ThreadNumType UCCAlgorithmTest<AlgorithmUnderTest>::threads_ = 1;
-
 }  // namespace
 
 TYPED_TEST_SUITE_P(UCCAlgorithmTest);
 
 TYPED_TEST_P(UCCAlgorithmTest, ConsistentHashOnLightDatasets) {
-    TestFixture::SetThreadsParam(1);
-    TestFixture::PerformConsistentHashTestOn(TestFixture::kLightDatasets);
+    this->SetThreadsParam(1);
+    this->PerformConsistentHashTestOn(TestFixture::kLightDatasets);
 }
 
 TYPED_TEST_P(UCCAlgorithmTest, ConsistentHashOnHeavyDatasets) {
-    TestFixture::SetThreadsParam(1);
-    TestFixture::PerformConsistentHashTestOn(TestFixture::kHeavyDatasets);
+    this->SetThreadsParam(1);
+    this->PerformConsistentHashTestOn(TestFixture::kHeavyDatasets);
 }
 
 TYPED_TEST_P(UCCAlgorithmTest, ConsistentHashOnLightDatasetsParallel) {
-    TestFixture::SetThreadsParam(4);
-    TestFixture::PerformConsistentHashTestOn(TestFixture::kLightDatasets);
+    this->SetThreadsParam(4);
+    this->PerformConsistentHashTestOn(TestFixture::kLightDatasets);
 }
 
 TYPED_TEST_P(UCCAlgorithmTest, ConsistentHashOnHeavyDatasetsParallel) {
-    TestFixture::SetThreadsParam(4);
-    TestFixture::PerformConsistentHashTestOn(TestFixture::kHeavyDatasets);
+    this->SetThreadsParam(4);
+    this->PerformConsistentHashTestOn(TestFixture::kHeavyDatasets);
 }
 
 REGISTER_TYPED_TEST_SUITE_P(UCCAlgorithmTest, ConsistentHashOnLightDatasets,


### PR DESCRIPTION
Split off from #637, depends on #791

Removed most non-const non-automatic variable usage. These are generally dangerous to use when we're dealing with sub-interpreters and multiple threads. The three cases that remain are the logging variables in core and Python bindings and the hash counter for the Null type variant the values of which do not compare equal. All are safe.

The core library shouldn't account for Python in particular, so it makes sense to forbid usage of variables like that entirely except in special cases. This can be done using clang-tidy. The check cppcoreguidelines-avoid-non-const-global-variables covers the global variable case. The custom matcher below should catch most of the bad stuff.
```
match varDecl(
    hasGlobalStorage()
    isExpansionInMainFile(),
    unless(isConstexpr()),
    unless(hasType(isConstQualified())),
    unless(
        anyOf(
            isExpandedFromMacro("TEST_P"),
            isExpandedFromMacro("INSTANTIATE_TEST_SUITE_P"),
            isExpandedFromMacro("TYPED_TEST_SUITE_P"),
            isExpandedFromMacro("TYPED_TEST_P"),
            isExpandedFromMacro("INSTANTIATE_TYPED_TEST_SUITE_P"),
            isExpandedFromMacro("TYPED_TEST"),
            isExpandedFromMacro("PYBIND11_MODULE")
        )
    )
)
```