### PR TITLE
Drop Python 3.8 and 3.9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Here is a list of papers about patterns, organized in the recommended reading or
 ## Installation (this is what you probably want if you are not a project maintainer)
 Desbordante is [available](https://pypi.org/project/desbordante/) at the Python Package Index (PyPI). Dependencies:
 
-* Python >=3.8
+* Python >=3.10
 
 To install Desbordante type:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "scikit_build_core.build"
 name = "desbordante"
 version = "2.4.1"
 description = "Science-intensive high-performance data profiler"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 readme = "README_PYPI.md"
 license = { text = "AGPL-3.0-only" }
 
@@ -14,8 +14,6 @@ classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS :: MacOS X",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
End-of-life Python versions are unsupported by other software, so can cause unexpected problems during CI wheel builds. Also makes the builds faster since we have to build fewer versions.