### PR TITLE
Simplify RelationalSchema creation

### DIFF
--- a/src/core/algorithms/cfd/model/cfd_relation_data.cpp
+++ b/src/core/algorithms/cfd/model/cfd_relation_data.cpp
@@ -17,7 +17,6 @@ size_t CFDRelationData::GetNumRows() const {
 }
 
 std::unique_ptr<CFDRelationData> CFDRelationData::CreateFrom(model::IDatasetStream& data_stream) {
-    auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName());
     size_t num_columns = data_stream.GetNumberOfColumns();
     std::vector<CFDColumnData::ItemDictionary> item_dictionaries(num_columns);
     std::vector<std::vector<int>> columns_values(num_columns);
@@ -55,10 +54,9 @@ std::unique_ptr<CFDRelationData> CFDRelationData::CreateFrom(model::IDatasetStre
         data_rows.push_back(std::move(row_data));
     }
 
+    auto schema = RelationalSchema::CreateFrom(data_stream);
     std::vector<CFDColumnData> column_data;
     for (size_t i = 0; i < num_columns; ++i) {
-        auto column = Column(schema.get(), data_stream.GetColumnName(i), i);
-        schema->AppendColumn(std::move(column));
         column_data.emplace_back(schema->GetColumn(i), std::move(columns_values[i]),
                                  std::move(item_dictionaries[i]));
     }

--- a/src/core/algorithms/fd/aidfd/aid.cpp
+++ b/src/core/algorithms/fd/aidfd/aid.cpp
@@ -19,12 +19,7 @@ void Aid::LoadDataInternal() {
         throw std::runtime_error("Unable to work on an empty dataset.");
     }
 
-    schema_ = std::make_shared<RelationalSchema>(input_table_->GetRelationName());
-
-    for (size_t i = 0; i < number_of_attributes_; ++i) {
-        std::string const& column_name = input_table_->GetColumnName(static_cast<int>(i));
-        schema_->AppendColumn(column_name);
-    }
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
 
     while (input_table_->HasNextRow()) {
         std::vector<std::string> const& next_line = input_table_->GetNextRow();

--- a/src/core/algorithms/fd/eulerfd/eulerfd.cpp
+++ b/src/core/algorithms/fd/eulerfd/eulerfd.cpp
@@ -25,12 +25,7 @@ void EulerFD::LoadDataInternal() {
         throw std::runtime_error("Unable to work on an empty dataset.");
     }
 
-    schema_ = std::make_shared<RelationalSchema>(input_table_->GetRelationName());
-
-    for (size_t i = 0; i < number_of_attributes_; ++i) {
-        std::string const& column_name = input_table_->GetColumnName(static_cast<int>(i));
-        schema_->AppendColumn(column_name);
-    }
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
 
     // In each column mapping string values into integer values.
     // Using only hash isn't good idea because collisions don't processing.

--- a/src/core/algorithms/fd/fdep/fdep.cpp
+++ b/src/core/algorithms/fd/fdep/fdep.cpp
@@ -22,10 +22,7 @@ void FDep::LoadDataInternal() {
         throw std::runtime_error("Unable to work on an empty dataset.");
     }
 
-    schema_ = std::make_shared<RelationalSchema>(input_table_->GetRelationName());
-    for (size_t i = 0; i < number_attributes_; ++i) {
-        schema_->AppendColumn(input_table_->GetColumnName(static_cast<int>(i)));
-    }
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
 
     std::vector<std::string> next_line;
     while (input_table_->HasNextRow()) {

--- a/src/core/algorithms/ind/faida/preprocessing/abstract_column_store.cpp
+++ b/src/core/algorithms/ind/faida/preprocessing/abstract_column_store.cpp
@@ -14,11 +14,8 @@ void AbstractColumnStore::LoadData(std::string const& dataset_name, TableIndex t
         throw std::runtime_error("Got an empty file: IND mining is meaningless.");
     }
 
-    schema_ = std::make_unique<RelationalSchema>(input_data.GetRelationName());
-    for (ColumnIndex col_idx = 0; col_idx < num_columns; ++col_idx) {
-        auto column = Column(schema_.get(), input_data.GetColumnName(col_idx), col_idx);
-        schema_->AppendColumn(std::move(column));
-    }
+    schema_ = RelationalSchema::CreateFrom(input_data);
+
     column_properties_ =
             std::vector<ColumnProperty>(input_data.GetNumberOfColumns(), ColumnProperty::kOrdinary);
 

--- a/src/core/algorithms/ind/ind_algorithm.cpp
+++ b/src/core/algorithms/ind/ind_algorithm.cpp
@@ -13,11 +13,7 @@ INDAlgorithm::INDAlgorithm() : Algorithm() {
 void INDAlgorithm::LoadDataInternal() {
     schemas_ = std::make_shared<std::vector<std::unique_ptr<RelationalSchema>>>();
     for (auto const& input_table : input_tables_) {
-        auto schema = std::make_unique<RelationalSchema>(input_table->GetRelationName());
-        for (size_t i{0}; i < input_table->GetNumberOfColumns(); ++i) {
-            schema->AppendColumn(input_table->GetColumnName(i));
-        }
-        schemas_->push_back(std::move(schema));
+        schemas_->push_back(RelationalSchema::CreateFrom(*input_table));
     }
 
     LoadINDAlgorithmDataInternal();

--- a/src/core/algorithms/md/hymd/hymd.cpp
+++ b/src/core/algorithms/md/hymd/hymd.cpp
@@ -154,23 +154,13 @@ void HyMD::RegisterOptions() {
 void HyMD::ResetStateMd() {}
 
 void HyMD::LoadDataInternal() {
-    left_schema_ = std::make_shared<RelationalSchema>(left_table_->GetRelationName());
-    std::size_t const left_table_cols = left_table_->GetNumberOfColumns();
-    for (Index i : utility::IndexRange(left_table_cols)) {
-        left_schema_->AppendColumn(left_table_->GetColumnName(i));
-    }
+    left_schema_ = RelationalSchema::CreateFrom(*left_table_);
 
     if (right_table_ == nullptr) {
         right_schema_ = left_schema_;
-
         records_info_ = indexes::RecordsInfo::CreateFrom(*left_table_);
     } else {
-        right_schema_ = std::make_unique<RelationalSchema>(right_table_->GetRelationName());
-        std::size_t const right_table_cols = right_table_->GetNumberOfColumns();
-        for (Index i : utility::IndexRange(right_table_cols)) {
-            right_schema_->AppendColumn(right_table_->GetColumnName(i));
-        }
-
+        right_schema_ = RelationalSchema::CreateFrom(*right_table_);
         records_info_ = indexes::RecordsInfo::CreateFrom(*left_table_, *right_table_);
     }
 

--- a/src/core/algorithms/md/md_verifier/md_verifier.cpp
+++ b/src/core/algorithms/md/md_verifier/md_verifier.cpp
@@ -32,15 +32,6 @@ public:
         return pool_ptr_;
     }
 };
-
-auto CreateSchema(config::InputTable const& table) {
-    auto schema = std::make_shared<RelationalSchema>(table->GetRelationName());
-    std::size_t const cols = table->GetNumberOfColumns();
-    for (model::Index i : algos::hymd::utility::IndexRange(cols)) {
-        schema->AppendColumn(table->GetColumnName(i));
-    }
-    return schema;
-}
 }  // namespace
 
 namespace algos::md {
@@ -55,8 +46,8 @@ void MDVerifier::ResetState() {
 }
 
 void MDVerifier::LoadDataInternal() {
-    left_schema_ = CreateSchema(left_table_);
-    right_schema_ = right_table_ ? CreateSchema(right_table_) : left_schema_;
+    left_schema_ = RelationalSchema::CreateFrom(*left_table_);
+    right_schema_ = right_table_ ? RelationalSchema::CreateFrom(*right_table_) : left_schema_;
 }
 
 void MDVerifier::RegisterOptions() {

--- a/src/core/model/table/column_encoded_relation_data.cpp
+++ b/src/core/model/table/column_encoded_relation_data.cpp
@@ -10,7 +10,6 @@ namespace model {
 std::unique_ptr<ColumnEncodedRelationData> ColumnEncodedRelationData::CreateFrom(
         config::InputTable& data_stream, TableIndex table_id,
         ValueDictionaryType value_dictionary) {
-    auto schema = std::make_unique<RelationalSchema>(data_stream->GetRelationName());
     size_t const num_columns = data_stream->GetNumberOfColumns();
     std::vector<std::vector<int>> column_vectors = std::vector<std::vector<int>>(num_columns);
     std::vector<std::string> row;
@@ -35,10 +34,9 @@ std::unique_ptr<ColumnEncodedRelationData> ColumnEncodedRelationData::CreateFrom
         }
     }
 
+    std::unique_ptr<RelationalSchema> schema = RelationalSchema::CreateFrom(*data_stream);
     std::vector<EncodedColumnData> column_data;
     for (size_t i = 0; i < num_columns; ++i) {
-        auto column = Column(schema.get(), data_stream->GetColumnName(i), i);
-        schema->AppendColumn(std::move(column));
         column_data.emplace_back(table_id, schema->GetColumn(i), std::move(column_vectors[i]),
                                  std::move(unique_values[i]), value_dictionary);
     }

--- a/src/core/model/table/column_layout_relation_data.cpp
+++ b/src/core/model/table/column_layout_relation_data.cpp
@@ -45,7 +45,6 @@ std::shared_ptr<model::PLIWS const> ColumnLayoutRelationData::CalculatePLIWS(
 
 std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
         model::IDatasetStream& data_stream) {
-    auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName());
     std::unordered_map<std::string, int> value_dictionary;
     int next_value_id = 0;
     size_t const num_columns = data_stream.GetNumberOfColumns();
@@ -78,10 +77,9 @@ std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
         }
     }
 
+    auto schema = RelationalSchema::CreateFrom(data_stream);
     std::vector<ColumnData> column_data;
     for (size_t i = 0; i < num_columns; ++i) {
-        auto column = Column(schema.get(), data_stream.GetColumnName(i), i);
-        schema->AppendColumn(std::move(column));
         auto pli = model::PLIWithSingletons::CreateFor(column_vectors[i]);
         column_data.emplace_back(schema->GetColumn(i), std::move(pli));
     }

--- a/src/core/model/table/column_layout_typed_relation_data.cpp
+++ b/src/core/model/table/column_layout_typed_relation_data.cpp
@@ -6,7 +6,6 @@ namespace model {
 
 std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::CreateFrom(
         IDatasetStream& data_stream, bool is_null_eq_null, bool treat_mixed_as_string) {
-    auto schema = std::make_unique<RelationalSchema>(data_stream.GetRelationName());
     size_t const num_columns = data_stream.GetNumberOfColumns();
 
     std::vector<std::vector<std::string>> columns(num_columns);
@@ -32,10 +31,9 @@ std::unique_ptr<ColumnLayoutTypedRelationData> ColumnLayoutTypedRelationData::Cr
         }
     }
 
+    auto schema = RelationalSchema::CreateFrom(data_stream);
     std::vector<TypedColumnData> column_data;
     for (size_t i = 0; i < num_columns; ++i) {
-        Column column(schema.get(), data_stream.GetColumnName(i), i);
-        schema->AppendColumn(std::move(column));
         TypedColumnData typed_column_data = model::TypedColumnDataFactory::CreateFrom(
                 schema->GetColumn(i), std::move(columns[i]), is_null_eq_null,
                 treat_mixed_as_string);

--- a/src/core/model/table/relational_schema.cpp
+++ b/src/core/model/table/relational_schema.cpp
@@ -6,7 +6,31 @@
 #include "core/model/table/vertical.h"
 #include "core/model/table/vertical_map.h"
 
-RelationalSchema::RelationalSchema(std::string name) : columns_(), name_(std::move(name)) {}
+namespace {
+std::vector<std::unique_ptr<Column>> MakeColumns(RelationalSchema const* schema,
+                                                 std::vector<std::string> column_names) {
+    std::vector<std::unique_ptr<Column>> columns;
+    std::size_t const number_of_columns = column_names.size();
+    columns.reserve(number_of_columns);
+    for (model::ColumnIndex i = 0; i != number_of_columns; ++i) {
+        columns.push_back(std::make_unique<Column>(schema, std::move(column_names[i]), i));
+    }
+    return columns;
+}
+}  // namespace
+
+RelationalSchema::RelationalSchema(std::string name, std::vector<std::string> column_names)
+    : columns_(MakeColumns(this, std::move(column_names))), name_(std::move(name)) {}
+
+std::unique_ptr<RelationalSchema> RelationalSchema::CreateFrom(model::IDatasetStream& table) {
+    std::size_t const number_of_columns = table.GetNumberOfColumns();
+    std::vector<std::string> column_names;
+    column_names.reserve(number_of_columns);
+    for (model::ColumnIndex i = 0; i != number_of_columns; ++i) {
+        column_names.push_back(table.GetColumnName(i));
+    }
+    return std::make_unique<RelationalSchema>(table.GetRelationName(), std::move(column_names));
+}
 
 Vertical RelationalSchema::GetVertical(boost::dynamic_bitset<> indices) const {
     return {this, std::move(indices)};
@@ -34,14 +58,6 @@ Column const* RelationalSchema::GetColumn(std::string const& col_name) const {
 
 Column const* RelationalSchema::GetColumn(size_t index) const {
     return columns_.at(index).get();
-}
-
-void RelationalSchema::AppendColumn(std::string const& col_name) {
-    columns_.push_back(std::make_unique<Column>(this, col_name, columns_.size()));
-}
-
-void RelationalSchema::AppendColumn(Column column) {
-    columns_.push_back(std::make_unique<Column>(std::move(column)));
 }
 
 size_t RelationalSchema::GetNumColumns() const {

--- a/src/core/model/table/relational_schema.h
+++ b/src/core/model/table/relational_schema.h
@@ -14,6 +14,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 
+#include "core/model/table/idataset_stream.h"
 #include "core/util/bitset_utils.h"
 
 class Column;
@@ -26,7 +27,9 @@ private:
     std::string name_;
 
 public:
-    RelationalSchema(std::string name);
+    RelationalSchema(std::string name, std::vector<std::string> column_names);
+
+    static std::unique_ptr<RelationalSchema> CreateFrom(model::IDatasetStream& table);
 
     RelationalSchema(RelationalSchema const& other) = delete;
     RelationalSchema& operator=(RelationalSchema const& rhs) = delete;
@@ -49,9 +52,6 @@ public:
     Vertical GetVertical(boost::dynamic_bitset<> indices) const;
 
     Vertical CreateEmptyVertical() const;
-
-    void AppendColumn(std::string const& col_name);
-    void AppendColumn(Column column);
 
     ~RelationalSchema();
 

--- a/src/python_bindings/ind/bind_ind.cpp
+++ b/src/python_bindings/ind/bind_ind.cpp
@@ -89,10 +89,7 @@ IND DeserializeInd(py::tuple t) {
     for (py::tuple const& s_state : schemas_state) {
         std::string s_name = s_state[0].cast<std::string>();
         std::vector<std::string> s_col_names = s_state[1].cast<std::vector<std::string>>();
-        auto schema = std::make_unique<RelationalSchema>(std::move(s_name));
-        for (std::string const& col_name : s_col_names) {
-            schema->AppendColumn(col_name);
-        }
+        auto schema = std::make_unique<RelationalSchema>(std::move(s_name), std::move(s_col_names));
         schemas.push_back(std::move(schema));
     }
     auto schemas_ptr =

--- a/src/python_bindings/py_util/table_serialization.cpp
+++ b/src/python_bindings/py_util/table_serialization.cpp
@@ -25,12 +25,8 @@ std::shared_ptr<RelationalSchema const> DeserializeRelationalSchema(py::tuple t)
         throw std::runtime_error("Invalid state for RelationalSchema pickle!");
     }
     auto schema_name = t[0].cast<std::string>();
-    auto col_data = t[1].cast<std::vector<std::string>>();
-    auto schema = std::make_shared<RelationalSchema>(std::move(schema_name));
-    for (std::string& col_name : col_data) {
-        schema->AppendColumn(std::move(col_name));
-    }
-    return schema;
+    auto column_names = t[1].cast<std::vector<std::string>>();
+    return std::make_shared<RelationalSchema>(std::move(schema_name), std::move(column_names));
 }
 
 // relational schema conversion suitable for py::hash

--- a/src/python_bindings/py_util/table_serialization.cpp
+++ b/src/python_bindings/py_util/table_serialization.cpp
@@ -12,12 +12,12 @@ namespace table_serialization {
 
 py::tuple SerializeRelationalSchema(RelationalSchema const* schema) {
     std::vector<std::unique_ptr<Column>> const& columns = schema->GetColumns();
-    std::vector<std::pair<std::string, unsigned int>> col_data;
-    col_data.reserve(columns.size());
+    std::vector<std::string> column_names;
+    column_names.reserve(columns.size());
     for (auto const& col_ptr : columns) {
-        col_data.emplace_back(col_ptr->GetName(), col_ptr->GetIndex());
+        column_names.emplace_back(col_ptr->GetName());
     }
-    return py::make_tuple(schema->GetName(), std::move(col_data));
+    return py::make_tuple(schema->GetName(), std::move(column_names));
 }
 
 std::shared_ptr<RelationalSchema const> DeserializeRelationalSchema(py::tuple t) {
@@ -25,11 +25,10 @@ std::shared_ptr<RelationalSchema const> DeserializeRelationalSchema(py::tuple t)
         throw std::runtime_error("Invalid state for RelationalSchema pickle!");
     }
     auto schema_name = t[0].cast<std::string>();
-    auto col_data = t[1].cast<std::vector<std::pair<std::string, unsigned int>>>();
+    auto col_data = t[1].cast<std::vector<std::string>>();
     auto schema = std::make_shared<RelationalSchema>(std::move(schema_name));
-    for (auto& [col_name, col_index] : col_data) {
-        Column c(schema.get(), std::move(col_name), col_index);
-        schema->AppendColumn(std::move(c));
+    for (std::string& col_name : col_data) {
+        schema->AppendColumn(std::move(col_name));
     }
     return schema;
 }

--- a/src/python_bindings/sfd/bind_sfd.cpp
+++ b/src/python_bindings/sfd/bind_sfd.cpp
@@ -27,7 +27,7 @@ algos::Correlation DeserializeCorrelation(py::tuple t) {
         throw std::runtime_error("Invalid state for Correlation pickle!");
     }
     std::shared_ptr<RelationalSchema> dummy_schema =
-            std::make_shared<RelationalSchema>("__dummy__");
+            std::make_shared<RelationalSchema>("__dummy__", std::vector<std::string>{});
     Column lhs_col =
             table_serialization::DeserializeColumn(t[0].cast<py::tuple>(), dummy_schema.get());
     Column rhs_col =


### PR DESCRIPTION
Depends on #795

Creating RelationalSchema involves the same loop every time, this puts it into the class itself.