### PR TITLE
Remove extra references to nulls

### DIFF
--- a/src/core/algorithms/fd/fd_verifier/dynamic_fd_verifier.cpp
+++ b/src/core/algorithms/fd/fd_verifier/dynamic_fd_verifier.cpp
@@ -186,15 +186,11 @@ std::vector<int> DynamicFDVerifier::ParseRowForPLI(
     std::vector<int> result{};
     for (size_t index : indices) {
         std::string const& field = *(row_begin + index);
-        if (field.empty()) {
-            result.emplace_back(kNullValueId);
-        } else {
-            auto [iter, is_value_new] = value_dictionary_.try_emplace(field, next_value_id_);
-            if (is_value_new) {
-                next_value_id_++;
-            }
-            result.emplace_back(iter->second);
+        auto [iter, is_value_new] = value_dictionary_.try_emplace(field, next_value_id_);
+        if (is_value_new) {
+            next_value_id_++;
         }
+        result.emplace_back(iter->second);
     }
     return result;
 }

--- a/src/core/algorithms/fd/fd_verifier/dynamic_fd_verifier.h
+++ b/src/core/algorithms/fd/fd_verifier/dynamic_fd_verifier.h
@@ -35,7 +35,6 @@ private:
 
     std::unordered_map<std::string, int> value_dictionary_{};
     int next_value_id_ = 1;
-    static constexpr int kNullValueId = -1;
 
     void VerifyFD() const;
     void CreateFD();

--- a/src/core/model/table/column_encoded_relation_data.cpp
+++ b/src/core/model/table/column_encoded_relation_data.cpp
@@ -25,11 +25,7 @@ std::unique_ptr<ColumnEncodedRelationData> ColumnEncodedRelationData::CreateFrom
         }
         size_t index = 0;
         for (auto&& field : row) {
-            if (field.empty()) {
-                column_vectors[index].push_back(kNullValueId);
-            } else {
-                column_vectors[index].push_back(value_dictionary->ToInt(field));
-            }
+            column_vectors[index].push_back(value_dictionary->ToInt(field));
             unique_values[index].insert(std::move(field));
             ++index;
         }

--- a/src/core/model/table/column_encoded_relation_data.h
+++ b/src/core/model/table/column_encoded_relation_data.h
@@ -18,8 +18,6 @@ public:
                                        std::vector<ColumnType> column_data) noexcept
         : AbstractRelationData(std::move(schema), std::move(column_data)) {}
 
-    static constexpr int kNullValueId = 0;
-
     [[nodiscard]] size_t GetNumRows() const final {
         if (column_data_.empty()) {
             return 0;


### PR DESCRIPTION
kNullValueId was not referenced anywhere else, looks like leftovers from 8978da057d0184e803be5df77cce0d455ad2867b.