### PR TITLE
Remove ColumnLayoutRelationData use in HPIValid, HyUCC, HyFD

### DIFF
--- a/src/core/algorithms/fd/hycommon/preprocessor.cpp
+++ b/src/core/algorithms/fd/hycommon/preprocessor.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "core/algorithms/fd/hycommon/util/pli_util.h"
+#include "core/model/table/create_stripped_partitions.h"
 
 namespace algos::hy::util {
 
@@ -14,7 +15,7 @@ std::vector<ClusterId> SortAndGetMapping(PLIs& plis) {
                    [&id](auto& pli) { return std::make_pair(std::move(pli), id++); });
 
     auto const cluster_quantity_descending = [](auto const& pli1, auto const& pli2) {
-        return pli1.first->GetNumCluster() > pli2.first->GetNumCluster();
+        return pli1.first.GetNumCluster() > pli2.first.GetNumCluster();
     };
     std::sort(plis_sort_ids.begin(), plis_sort_ids.end(), cluster_quantity_descending);
 
@@ -32,8 +33,8 @@ Columns BuildInvertedPlis(PLIs const& plis) {
 
     for (auto const& pli : plis) {
         ClusterId cluster_id = 0;
-        std::vector<ClusterId> current(pli->GetRelationSize(), PLIUtil::kSingletonClusterId);
-        for (auto const& cluster : pli->GetIndex()) {
+        std::vector<ClusterId> current(pli.GetRelationSize(), PLIUtil::kSingletonClusterId);
+        for (auto const& cluster : pli.GetIndex()) {
             for (int value : cluster) {
                 current[value] = cluster_id;
             }
@@ -59,21 +60,14 @@ Rows BuildRecordRepresentation(algos::hy::Columns const& inverted_plis) {
     return pli_records;
 }
 
-PLIs BuildPLIs(ColumnLayoutRelationData* relation) {
-    PLIs plis;
-    std::transform(relation->GetColumnData().begin(), relation->GetColumnData().end(),
-                   std::back_inserter(plis),
-                   [](auto& column_data) { return column_data.GetPositionListIndex(); });
-    return plis;
-}
-
 }  // namespace algos::hy::util
 
 namespace algos::hy {
 using namespace util;
 
-std::tuple<PLIs, Rows, std::vector<ClusterId>> Preprocess(ColumnLayoutRelationData* relation) {
-    PLIs plis = BuildPLIs(relation);
+std::tuple<PLIsPtr, RowsPtr, std::vector<ClusterId>> Preprocess(
+        model::IDatasetStream& data_stream) {
+    PLIs plis = model::CreateStrippedPartitions(data_stream);
 
     auto og_mapping = SortAndGetMapping(plis);
 
@@ -81,7 +75,8 @@ std::tuple<PLIs, Rows, std::vector<ClusterId>> Preprocess(ColumnLayoutRelationDa
 
     auto pli_records = BuildRecordRepresentation(inverted_plis);
 
-    return std::make_tuple(std::move(plis), std::move(pli_records), std::move(og_mapping));
+    return std::make_tuple(std::make_shared<PLIs>(std::move(plis)),
+                           std::make_shared<Rows>(std::move(pli_records)), std::move(og_mapping));
 }
 
 boost::dynamic_bitset<> RestoreAgreeSet(boost::dynamic_bitset<> const& as,

--- a/src/core/algorithms/fd/hycommon/preprocessor.h
+++ b/src/core/algorithms/fd/hycommon/preprocessor.h
@@ -5,20 +5,19 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "core/algorithms/fd/hycommon/types.h"
-#include "core/model/table/column_layout_relation_data.h"
+#include "core/model/table/idataset_stream.h"
 
 namespace algos::hy::util {
 
 std::vector<ClusterId> SortAndGetMapping(PLIs& plis);
 Columns BuildInvertedPlis(PLIs const& plis);
 Rows BuildRecordRepresentation(Columns const& inverted_plis);
-PLIs BuildPLIs(ColumnLayoutRelationData* relation);
 
 }  // namespace algos::hy::util
 
 namespace algos::hy {
 
-std::tuple<PLIs, Rows, std::vector<ClusterId>> Preprocess(ColumnLayoutRelationData* relation);
+std::tuple<PLIsPtr, RowsPtr, std::vector<ClusterId>> Preprocess(model::IDatasetStream& data_stream);
 boost::dynamic_bitset<> RestoreAgreeSet(boost::dynamic_bitset<> const& as,
                                         std::vector<ClusterId> const& og_mapping, size_t num_cols);
 

--- a/src/core/algorithms/fd/hycommon/sampler.cpp
+++ b/src/core/algorithms/fd/hycommon/sampler.cpp
@@ -136,12 +136,12 @@ void Sampler::ProcessComparisonSuggestions(IdPairs const& comparison_suggestions
 void Sampler::SortClustersParallel() {
     ColumnSlider column_slider(plis_->size());
     std::vector<boost::unique_future<void>> sort_futures;
-    for (model::PLI* pli : *plis_) {
+    for (model::PLI& pli : *plis_) {
         ClusterComparator cluster_comparator(compressed_records_.get(),
                                              column_slider.GetLeftNeighbor(),
                                              column_slider.GetRightNeighbor());
-        auto sort = [pli, cluster_comparator]() {
-            for (model::PLI::Cluster& cluster : pli->GetIndex()) {
+        auto sort = [&pli, cluster_comparator]() {
+            for (model::PLI::Cluster& cluster : pli.GetIndex()) {
                 std::sort(cluster.begin(), cluster.end(), cluster_comparator);
             }
         };
@@ -155,11 +155,11 @@ void Sampler::SortClustersParallel() {
 
 void Sampler::SortClustersSeq() {
     ColumnSlider column_slider(plis_->size());
-    for (model::PLI* pli : *plis_) {
+    for (model::PLI& pli : *plis_) {
         ClusterComparator cluster_comparator(compressed_records_.get(),
                                              column_slider.GetLeftNeighbor(),
                                              column_slider.GetRightNeighbor());
-        for (model::PLI::Cluster& cluster : pli->GetIndex()) {
+        for (model::PLI::Cluster& cluster : pli.GetIndex()) {
             std::sort(cluster.begin(), cluster.end(), cluster_comparator);
         }
         column_slider.ToNextColumn();
@@ -181,7 +181,7 @@ void Sampler::InitializeEfficiencyQueueParallel() {
     for (size_t attr = 0; attr < plis_->size(); ++attr) {
         auto run_window = [attr, this]() {
             Efficiency efficiency(attr);
-            return std::make_pair(efficiency, RunWindowRet(efficiency, *(*plis_)[attr]));
+            return std::make_pair(efficiency, RunWindowRet(efficiency, (*plis_)[attr]));
         };
         boost::packaged_task<EfficiencyAndMatches> task(std::move(run_window));
         futures.push_back(task.get_future());
@@ -212,7 +212,7 @@ void Sampler::InitializeEfficiencyQueueParallel() {
 void Sampler::InitializeEfficiencyQueueSeq() {
     for (size_t attr = 0; attr < plis_->size(); ++attr) {
         Efficiency efficiency(attr);
-        RunWindow(efficiency, *(*plis_)[attr]);
+        RunWindow(efficiency, (*plis_)[attr]);
 
         if (efficiency.CalcEfficiency() > 0) {
             efficiency_queue_.push(efficiency);
@@ -265,7 +265,7 @@ ColumnCombinationList Sampler::GetAgreeSets(IdPairs const& comparison_suggestion
         Efficiency best_efficiency = efficiency_queue_.top();
         efficiency_queue_.pop();
 
-        RunWindow(best_efficiency, *(*plis_)[best_efficiency.GetAttr()]);
+        RunWindow(best_efficiency, (*plis_)[best_efficiency.GetAttr()]);
 
         if (best_efficiency.CalcEfficiency() > 0) {
             efficiency_queue_.push(best_efficiency);

--- a/src/core/algorithms/fd/hycommon/types.h
+++ b/src/core/algorithms/fd/hycommon/types.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/core/algorithms/fd/hycommon/types.h
+++ b/src/core/algorithms/fd/hycommon/types.h
@@ -5,12 +5,7 @@
 #include <vector>
 
 #include "core/model/table/column_index.h"
-
-namespace model {
-
-class PositionListIndex;
-
-}
+#include "core/model/table/position_list_index.h"
 
 namespace algos::hy {
 
@@ -20,7 +15,7 @@ using ClusterId = unsigned int;
 
 // Represents a relation as a list of position list indexes. i-th PLI is a PLI built on i-th column
 // of the relation
-using PLIs = std::vector<model::PositionListIndex*>;
+using PLIs = std::vector<model::PositionListIndex>;
 using PLIsPtr = std::shared_ptr<PLIs>;
 using Row = std::vector<TablePos>;
 // Represents a relation as a list of rows where each row is a list of row values

--- a/src/core/algorithms/fd/hyfd/hyfd.cpp
+++ b/src/core/algorithms/fd/hyfd/hyfd.cpp
@@ -14,33 +14,41 @@
 #include "core/algorithms/fd/hyfd/sampler.h"
 #include "core/algorithms/fd/hyfd/validator.h"
 #include "core/config/names.h"
+#include "core/config/tabular_data/input_table/option.h"
 #include "core/config/thread_number/option.h"
 #include "core/util/logger.h"
 
 namespace algos::hyfd {
 
-HyFD::HyFD() : PliBasedFDAlgorithm() {
+HyFD::HyFD() : FDAlgorithm() {
+    RegisterOption(config::kTableOpt(&input_table_));
     RegisterOption(config::kThreadNumberOpt(&threads_num_));
+
+    MakeOptionsAvailable({config::names::kTable});
 }
 
 void HyFD::MakeExecuteOptsAvailableFDInternal() {
     MakeOptionsAvailable({config::names::kThreads});
 }
 
+void HyFD::LoadDataInternal() {
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
+
+    std::tie(plis_, pli_records_, og_mapping_) = hy::Preprocess(*input_table_);
+    if (plis_->empty()) {
+        throw std::runtime_error("Got an empty dataset: FD mining is meaningless.");
+    }
+}
+
 void HyFD::ExecuteInternal() {
     using namespace hy;
     LOG_TRACE("Executing");
 
-    auto [plis, pli_records, og_mapping] = Preprocess(relation_.get());
-    auto const plis_shared = std::make_shared<PLIs>(std::move(plis));
-    auto const pli_records_shared = std::make_shared<Rows>(std::move(pli_records));
+    Sampler sampler(plis_, pli_records_, threads_num_);
 
-    Sampler sampler(plis_shared, pli_records_shared, threads_num_);
-
-    auto const positive_cover_tree =
-            std::make_shared<fd_tree::FDTree>(GetRelation().GetNumColumns());
+    auto const positive_cover_tree = std::make_shared<fd_tree::FDTree>(schema_->GetNumColumns());
     Inductor inductor(positive_cover_tree);
-    Validator validator(positive_cover_tree, plis_shared, pli_records_shared, threads_num_);
+    Validator validator(positive_cover_tree, plis_, pli_records_, threads_num_);
 
     IdPairs comparison_suggestions;
 
@@ -59,20 +67,19 @@ void HyFD::ExecuteInternal() {
     }
 
     auto fds = positive_cover_tree->FillFDs();
-    RegisterFDs(std::move(fds), og_mapping);
+    RegisterFDs(std::move(fds), og_mapping_);
 }
 
 void HyFD::RegisterFDs(std::vector<RawFD>&& fds, std::vector<hy::ClusterId> const& og_mapping) {
-    auto const* const schema = GetRelation().GetSchema();
     for (auto&& [lhs, rhs] : fds) {
         boost::dynamic_bitset<> mapped_lhs =
-                hy::RestoreAgreeSet(lhs, og_mapping, schema->GetNumColumns());
-        Vertical lhs_v(schema, std::move(mapped_lhs));
+                hy::RestoreAgreeSet(lhs, og_mapping, schema_->GetNumColumns());
+        Vertical lhs_v(schema_.get(), std::move(mapped_lhs));
 
         auto const mapped_rhs = og_mapping[rhs];
-        Column rhs_c(schema, schema->GetColumn(mapped_rhs)->GetName(), mapped_rhs);
+        Column rhs_c(schema_.get(), schema_->GetColumn(mapped_rhs)->GetName(), mapped_rhs);
 
-        RegisterFd(std::move(lhs_v), std::move(rhs_c), relation_->GetSharedPtrSchema());
+        RegisterFd(std::move(lhs_v), std::move(rhs_c), schema_);
     }
 }
 

--- a/src/core/algorithms/fd/hyfd/hyfd.h
+++ b/src/core/algorithms/fd/hyfd/hyfd.h
@@ -5,9 +5,10 @@
 #include <utility>
 #include <vector>
 
+#include "core/algorithms/fd/fd_algorithm.h"
 #include "core/algorithms/fd/hycommon/types.h"
-#include "core/algorithms/fd/pli_based_fd_algorithm.h"
 #include "core/algorithms/fd/raw_fd.h"
+#include "core/config/tabular_data/input_table_type.h"
 #include "core/config/thread_number/type.h"
 #include "core/model/table/position_list_index.h"
 
@@ -36,15 +37,22 @@ namespace algos::hyfd {
  * '16). Association for Computing Machinery, New York, NY, USA, 821–833.
  * https://doi.org/10.1145/2882903.2915203
  */
-class HyFD : public PliBasedFDAlgorithm {
+class HyFD : public FDAlgorithm {
 private:
     void ResetStateFd() final {}
 
+    void LoadDataInternal() final;
     void ExecuteInternal() override;
 
     void RegisterFDs(std::vector<RawFD>&& fds, std::vector<algos::hy::ClusterId> const& og_mapping);
 
     void MakeExecuteOptsAvailableFDInternal() override;
+
+    config::InputTable input_table_;
+    std::shared_ptr<RelationalSchema const> schema_;
+    hy::PLIsPtr plis_;
+    hy::RowsPtr pli_records_;
+    std::vector<hy::ClusterId> og_mapping_;
 
     config::ThreadNumType threads_num_ = 1;
 

--- a/src/core/algorithms/fd/hyfd/validator.cpp
+++ b/src/core/algorithms/fd/hyfd/validator.cpp
@@ -82,7 +82,7 @@ boost::dynamic_bitset<> Refine(algos::hy::IdPairs& comparison_suggestions,
     auto const lhs_column_ids = util::BitsetToIndices<algos::hy::ClusterId>(lhs);
     auto const [rhs_column_ids, rhs_ranks] = BuildRhsMappings(rhs, compressed_records);
 
-    for (auto const& cluster : plis[firstAttr]->GetIndex()) {
+    for (auto const& cluster : plis[firstAttr].GetIndex()) {
         auto lhs_rhs_map = algos::hy::MakeClusterIdentifierToTMap<RhsRowId>(cluster.size());
 
         for (size_t row : cluster) {
@@ -155,7 +155,7 @@ Validator::FDValidations Validator::ProcessZeroLevel(LhsPair const& lhsPair) {
 
     for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
          attr = rhs.find_next(attr)) {
-        if (!(*plis_)[attr]->IsConstant()) {
+        if (!(*plis_)[attr].IsConstant()) {
             vertex->RemoveFd(attr);
             result.InvalidInstances().emplace_back(lhs, attr);
         }
@@ -181,7 +181,7 @@ Validator::FDValidations Validator::ProcessFirstLevel(LhsPair const& lhs_pair) {
 
     for (size_t attr = rhs.find_first(); attr != boost::dynamic_bitset<>::npos;
          attr = rhs.find_next(attr)) {
-        for (auto const& cluster : (*plis_)[lhs_attr]->GetIndex()) {
+        for (auto const& cluster : (*plis_)[lhs_attr].GetIndex()) {
             size_t const cluster_id = (*compressed_records_)[cluster[0]][attr];
             if (algos::hy::PLIUtil::IsSingletonCluster(cluster_id) ||
                 std::any_of(cluster.cbegin(), cluster.cend(), [this, attr, cluster_id](int id) {

--- a/src/core/algorithms/ucc/hpivalid/hpivalid.cpp
+++ b/src/core/algorithms/ucc/hpivalid/hpivalid.cpp
@@ -9,6 +9,8 @@
 #include "core/algorithms/ucc/hpivalid/config.h"
 #include "core/algorithms/ucc/hpivalid/result_collector.h"
 #include "core/algorithms/ucc/hpivalid/tree_search.h"
+#include "core/model/table/create_stripped_partitions.h"
+#include "core/model/table/to_value_id_columns.h"
 #include "core/util/logger.h"
 
 // see algorithms/ucc/hpivalid/LICENSE
@@ -16,28 +18,21 @@
 namespace algos {
 
 void HPIValid::LoadDataInternal() {
-    relation_ = ColumnLayoutRelationData::CreateFrom(*input_table_);
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
 
-    if (relation_->GetColumnData().empty()) {
+    std::vector<model::ValueIdColumn> value_id_columns = model::ToValueIdColumns(*input_table_);
+    if (value_id_columns.empty() || value_id_columns.front().empty()) {
         throw std::runtime_error("Got an empty dataset: UCC mining is meaningless.");
     }
-}
+    tab_.nr_cols = value_id_columns.size();
+    tab_.nr_rows = value_id_columns.front().size();
 
-hpiv::PLITable HPIValid::Preprocess() {
-    hpiv::PLITable tab;
-
-    tab.nr_rows = relation_->GetNumRows();
-    tab.nr_cols = relation_->GetNumColumns();
-
-    model::ColumnIndex const num_columns = relation_->GetNumColumns();
-    auto plis = hy::util::BuildPLIs(relation_.get());
-    for (model::ColumnIndex column_index = 0; column_index < num_columns; column_index++) {
-        std::deque<model::PLI::Cluster> const& index = plis[column_index]->GetIndex();
-        tab.plis.push_back(index);
+    auto plis = model::CreateStrippedPartitions(value_id_columns);
+    for (model::PositionListIndex const& pli : plis) {
+        std::deque<model::PLI::Cluster> const& index = pli.GetIndex();
+        tab_.plis.push_back(index);
     }
-    tab.inverse_mapping = hy::util::BuildInvertedPlis(plis);
-
-    return tab;
+    tab_.inverse_mapping = hy::util::BuildInvertedPlis(plis);
 }
 
 void HPIValid::ExecuteInternal() {
@@ -45,9 +40,8 @@ void HPIValid::ExecuteInternal() {
     hpiv::ResultCollector rc(3600);
 
     rc.SetStartTime();
-    hpiv::PLITable tab = Preprocess();
 
-    hpiv::TreeSearch tree_search(tab, cfg, rc);
+    hpiv::TreeSearch tree_search(tab_, cfg, rc);
     tree_search.Run();
 
     RegisterUCCs(rc);
@@ -57,9 +51,8 @@ void HPIValid::ExecuteInternal() {
 
 void HPIValid::RegisterUCCs(hpiv::ResultCollector const& rc) {
     std::vector<model::RawUCC> ucc_vector = rc.GetUCCs();
-    std::shared_ptr<RelationalSchema const> const& schema = relation_->GetSharedPtrSchema();
     for (auto&& ucc : ucc_vector) {
-        ucc_collection_.Register(schema, std::move(ucc));
+        ucc_collection_.Register(schema_, std::move(ucc));
     }
 }
 

--- a/src/core/algorithms/ucc/hpivalid/hpivalid.h
+++ b/src/core/algorithms/ucc/hpivalid/hpivalid.h
@@ -6,7 +6,7 @@
 #include "core/algorithms/ucc/hpivalid/pli_table.h"
 #include "core/algorithms/ucc/hpivalid/result_collector.h"
 #include "core/algorithms/ucc/ucc_algorithm.h"
-#include "core/model/table/column_layout_relation_data.h"
+#include "core/model/table/relational_schema.h"
 
 // see algorithms/ucc/hpivalid/LICENSE
 
@@ -14,11 +14,11 @@ namespace algos {
 
 class HPIValid : public UCCAlgorithm {
 private:
-    std::shared_ptr<ColumnLayoutRelationData> relation_;
+    std::shared_ptr<RelationalSchema const> schema_;
+    hpiv::PLITable tab_;
 
     void LoadDataInternal() override;
     void ExecuteInternal() override;
-    hpiv::PLITable Preprocess();
     void RegisterUCCs(hpiv::ResultCollector const& rc);
     void PrintInfo(hpiv::ResultCollector const& rc) const;
 

--- a/src/core/algorithms/ucc/hpivalid/result_collector.h
+++ b/src/core/algorithms/ucc/hpivalid/result_collector.h
@@ -7,7 +7,6 @@
 #include "core/algorithms/ucc/hpivalid/hypergraph.h"
 #include "core/algorithms/ucc/raw_ucc.h"
 #include "core/algorithms/ucc/ucc_algorithm.h"
-#include "core/model/table/column_layout_relation_data.h"
 
 // see algorithms/ucc/hpivalid/LICENSE
 

--- a/src/core/algorithms/ucc/hyucc/hyucc.cpp
+++ b/src/core/algorithms/ucc/hyucc/hyucc.cpp
@@ -10,9 +10,10 @@
 namespace algos {
 
 void HyUCC::LoadDataInternal() {
-    relation_ = ColumnLayoutRelationData::CreateFrom(*input_table_);
+    schema_ = RelationalSchema::CreateFrom(*input_table_);
 
-    if (relation_->GetColumnData().empty()) {
+    std::tie(plis_, pli_records_, og_mapping_) = hy::Preprocess(*input_table_);
+    if (plis_->empty()) {
         throw std::runtime_error("Got an empty dataset: UCC mining is meaningless.");
     }
 }
@@ -21,15 +22,11 @@ void HyUCC::ExecuteInternal() {
     using namespace hy;
     using namespace hyucc;
 
-    auto [plis, pli_records, og_mapping] = Preprocess(relation_.get());
-    auto const plis_shared = std::make_shared<PLIs>(std::move(plis));
-    auto const pli_records_shared = std::make_shared<Rows>(std::move(pli_records));
+    hyucc::Sampler sampler(plis_, pli_records_, threads_num_);
 
-    hyucc::Sampler sampler(plis_shared, pli_records_shared, threads_num_);
-
-    auto ucc_tree = std::make_unique<UCCTree>(relation_->GetNumColumns());
+    auto ucc_tree = std::make_unique<UCCTree>(schema_->GetNumColumns());
     Inductor inductor(ucc_tree.get());
-    Validator validator(ucc_tree.get(), plis_shared, pli_records_shared, threads_num_);
+    Validator validator(ucc_tree.get(), plis_, pli_records_, threads_num_);
 
     IdPairs comparison_suggestions;
 
@@ -49,7 +46,7 @@ void HyUCC::ExecuteInternal() {
     }
 
     auto uccs = ucc_tree->FillUCCs();
-    RegisterUCCs(std::move(uccs), og_mapping);
+    RegisterUCCs(std::move(uccs), og_mapping_);
 
     LOG_DEBUG("Mined UCCs:");
     for (model::UCC const& ucc : UCCList()) {
@@ -59,11 +56,10 @@ void HyUCC::ExecuteInternal() {
 
 void HyUCC::RegisterUCCs(std::vector<boost::dynamic_bitset<>>&& uccs,
                          std::vector<hy::ClusterId> const& og_mapping) {
-    std::shared_ptr<RelationalSchema const> const& schema = relation_->GetSharedPtrSchema();
     for (auto&& ucc : uccs) {
         boost::dynamic_bitset<> mapped_ucc =
-                hy::RestoreAgreeSet(ucc, og_mapping, schema->GetNumColumns());
-        ucc_collection_.Register(schema, std::move(mapped_ucc));
+                hy::RestoreAgreeSet(ucc, og_mapping, schema_->GetNumColumns());
+        ucc_collection_.Register(schema_, std::move(mapped_ucc));
     }
 }
 

--- a/src/core/algorithms/ucc/hyucc/hyucc.h
+++ b/src/core/algorithms/ucc/hyucc/hyucc.h
@@ -6,15 +6,19 @@
 #include "core/algorithms/ucc/ucc_algorithm.h"
 #include "core/config/thread_number/option.h"
 #include "core/config/thread_number/type.h"
-#include "core/model/table/column_layout_relation_data.h"
 #include "core/model/table/idataset_stream.h"
+#include "core/model/table/relational_schema.h"
 
 namespace algos {
 
 class HyUCC : public UCCAlgorithm {
 private:
-    std::unique_ptr<ColumnLayoutRelationData> relation_;
+    std::shared_ptr<RelationalSchema const> schema_;
     config::ThreadNumType threads_num_ = 1;
+
+    hy::PLIsPtr plis_;
+    hy::RowsPtr pli_records_;
+    std::vector<hy::ClusterId> og_mapping_;
 
     void LoadDataInternal() override;
     void ExecuteInternal() override;

--- a/src/core/algorithms/ucc/hyucc/validator.cpp
+++ b/src/core/algorithms/ucc/hyucc/validator.cpp
@@ -85,13 +85,13 @@ Validator::UCCValidations Validator::GetValidations(LhsPair const& vertex_and_uc
     bool is_unique;
     if (current_level_number_ == 1) {
         assert(ucc_attr != boost::dynamic_bitset<>::npos);
-        is_unique = (*plis_)[ucc_attr]->AllValuesAreUnique();
+        is_unique = (*plis_)[ucc_attr].AllValuesAreUnique();
     } else {
         ucc.reset(ucc_attr);
         // It's guaranteed that the first cluster has the fewest records because of sorting
         // in the Sampler
-        model::PLI const* pivot_pli = (*plis_)[ucc_attr];
-        is_unique = IsUnique(*pivot_pli, ucc, validations.ComparisonSuggestions());
+        model::PLI const& pivot_pli = (*plis_)[ucc_attr];
+        is_unique = IsUnique(pivot_pli, ucc, validations.ComparisonSuggestions());
         ucc.set(ucc_attr);
     }
 

--- a/src/core/model/table/CMakeLists.txt
+++ b/src/core/model/table/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(
             position_list_index.cpp
             position_list_index_with_singletons.cpp
             relational_schema.cpp
+            to_value_id_columns.cpp
             typed_column_data.cpp
             vertical.cpp
             vertical_map.cpp

--- a/src/core/model/table/CMakeLists.txt
+++ b/src/core/model/table/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(
             column_domain_iterator.cpp
             column_layout_relation_data.cpp
             column_layout_typed_relation_data.cpp
+            create_stripped_partitions.cpp
             dynamic_position_list_index.cpp
             identifier_set.cpp
             position_list_index.cpp

--- a/src/core/model/table/column_layout_relation_data.cpp
+++ b/src/core/model/table/column_layout_relation_data.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "core/model/table/to_value_id_columns.h"
 #include "core/util/logger.h"
 
 std::vector<int> ColumnLayoutRelationData::GetTuple(int tuple_index) const {
@@ -45,42 +46,13 @@ std::shared_ptr<model::PLIWS const> ColumnLayoutRelationData::CalculatePLIWS(
 
 std::unique_ptr<ColumnLayoutRelationData> ColumnLayoutRelationData::CreateFrom(
         model::IDatasetStream& data_stream) {
-    std::unordered_map<std::string, int> value_dictionary;
-    int next_value_id = 0;
     size_t const num_columns = data_stream.GetNumberOfColumns();
-    std::vector<std::vector<int>> column_vectors = std::vector<std::vector<int>>(num_columns);
-    std::vector<std::string> row;
-
-    while (data_stream.HasNextRow()) {
-        row = data_stream.GetNextRow();
-
-        if (row.size() != num_columns) {
-            LOG_WARN(
-                    "Unexpected number of columns for a row, "
-                    "skipping (expected {}, got {})",
-                    num_columns, row.size());
-            continue;
-        }
-
-        for (size_t index = 0; index < row.size(); ++index) {
-            std::string const& field = row[index];
-            auto location = value_dictionary.find(field);
-            int value_id;
-            if (location == value_dictionary.end()) {
-                value_dictionary[field] = next_value_id;
-                value_id = next_value_id;
-                next_value_id++;
-            } else {
-                value_id = location->second;
-            }
-            column_vectors[index].push_back(value_id);
-        }
-    }
+    std::vector<model::ValueIdColumn> value_id_columns = ToValueIdColumns(data_stream);
 
     auto schema = RelationalSchema::CreateFrom(data_stream);
     std::vector<ColumnData> column_data;
     for (size_t i = 0; i < num_columns; ++i) {
-        auto pli = model::PLIWithSingletons::CreateFor(column_vectors[i]);
+        auto pli = model::PLIWithSingletons::CreateFor(value_id_columns[i]);
         column_data.emplace_back(schema->GetColumn(i), std::move(pli));
     }
 

--- a/src/core/model/table/create_stripped_partitions.cpp
+++ b/src/core/model/table/create_stripped_partitions.cpp
@@ -1,0 +1,20 @@
+#include "core/model/table/create_stripped_partitions.h"
+
+#include <utility>
+
+#include "core/model/table/to_value_id_columns.h"
+
+namespace model {
+std::vector<PositionListIndex> CreateStrippedPartitions(
+        std::vector<ValueIdColumn> const& value_id_columns) {
+    std::vector<PositionListIndex> stripped_partitions;
+    for (ValueIdColumn const& value_id_column : value_id_columns) {
+        stripped_partitions.push_back(std::move(*PositionListIndex::CreateFor(value_id_column)));
+    }
+    return stripped_partitions;
+}
+
+std::vector<PositionListIndex> CreateStrippedPartitions(IDatasetStream& data_stream) {
+    return CreateStrippedPartitions(ToValueIdColumns(data_stream));
+}
+}  // namespace model

--- a/src/core/model/table/create_stripped_partitions.h
+++ b/src/core/model/table/create_stripped_partitions.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <vector>
+
+#include "core/model/table/idataset_stream.h"
+#include "core/model/table/position_list_index.h"
+#include "core/model/table/value_id_column.h"
+
+namespace model {
+std::vector<PositionListIndex> CreateStrippedPartitions(
+        std::vector<ValueIdColumn> const& value_id_columns);
+
+std::vector<PositionListIndex> CreateStrippedPartitions(IDatasetStream& data_stream);
+}  // namespace model

--- a/src/core/model/table/position_list_index.cpp
+++ b/src/core/model/table/position_list_index.cpp
@@ -33,7 +33,7 @@ PositionListIndex::PositionListIndex(std::deque<std::vector<int>> index, unsigne
       nep_(nep),
       probing_table_cache_() {}
 
-std::unique_ptr<PositionListIndex> PositionListIndex::CreateFor(std::vector<int>& data) {
+std::unique_ptr<PositionListIndex> PositionListIndex::CreateFor(std::vector<int> const& data) {
     std::unordered_map<int, std::vector<int>> index;
     for (unsigned long position = 0; position < data.size(); ++position) {
         int value_id = data[position];

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -48,7 +48,7 @@ public:
                       unsigned long long nep, unsigned int relation_size,
                       double inverted_entropy = 0, double gini_impurity = 0);
 
-    static std::unique_ptr<PositionListIndex> CreateFor(std::vector<int>& data);
+    static std::unique_ptr<PositionListIndex> CreateFor(std::vector<int> const& data);
 
     static std::unordered_map<int, unsigned> CreateFrequencies(
             Cluster const& cluster, std::vector<int> const& probing_table);

--- a/src/core/model/table/to_value_id_columns.cpp
+++ b/src/core/model/table/to_value_id_columns.cpp
@@ -1,0 +1,38 @@
+#include "core/model/table/to_value_id_columns.h"
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "core/model/index.h"
+#include "core/util/logger.h"
+
+namespace model {
+std::vector<ValueIdColumn> ToValueIdColumns(IDatasetStream& data_stream) {
+    std::unordered_map<std::string, int> value_id_map;
+    int next_value_id = 0;
+    std::size_t const num_columns = data_stream.GetNumberOfColumns();
+    auto value_id_columns = std::vector<ValueIdColumn>(num_columns);
+    std::vector<std::string> row;
+
+    while (data_stream.HasNextRow()) {
+        row = data_stream.GetNextRow();
+
+        if (row.size() != num_columns) {
+            LOG_WARN("Unexpected number of columns for a row, skipping (expected {}, got {})",
+                     num_columns, row.size());
+            continue;
+        }
+
+        for (Index column_index = 0; column_index != num_columns; ++column_index) {
+            auto [it, is_new] =
+                    value_id_map.try_emplace(std::move(row[column_index]), next_value_id);
+            if (is_new) ++next_value_id;
+            value_id_columns[column_index].push_back(it->second);
+        }
+    }
+
+    return value_id_columns;
+}
+}  // namespace model

--- a/src/core/model/table/to_value_id_columns.h
+++ b/src/core/model/table/to_value_id_columns.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vector>
+
+#include "core/model/table/idataset_stream.h"
+#include "core/model/table/value_id_column.h"
+
+namespace model {
+std::vector<ValueIdColumn> ToValueIdColumns(IDatasetStream& data_stream);
+}  // namespace model

--- a/src/core/model/table/value_id_column.h
+++ b/src/core/model/table/value_id_column.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <vector>
+
+namespace model {
+using ValueIdColumn = std::vector<int>;
+}  // namespace model


### PR DESCRIPTION
Depends on #796 

I'm looking to deprecate the class because it obscures what is happening. It also stores RelationalSchema, which I'm also looking to deprecate due to its recursive members, and that will be easier if it's separated from the PLIs instead of in one structure.