### PR TITLE
Make internal methods of Algorithm in Python private

### DIFF
--- a/src/python_bindings/bind_main_classes.cpp
+++ b/src/python_bindings/bind_main_classes.cpp
@@ -45,38 +45,13 @@ void BindMainClasses(py::module_& main_module) {
     py::register_exception<config::ConfigurationError>(main_module, "ConfigurationError",
                                                        PyExc_ValueError);
 
-#define CERTAIN_SCRIPTS_ONLY                                                       \
-    "\nThis option is only expected to be used by Python scripts in which it is\n" \
-    "easier to set all options one by one. For normal use, you may set the\n"      \
-    "algorithms' options using keyword arguments of the load_data and execute\nmethods."
+#define INTERNAL_OPTIONS_METHOD                                                    \
+    "\nThis option is only expected to be used by internal development Python\n"   \
+    "scripts. For normal use, you can set the algorithms' options using keyword\n" \
+    "arguments of the load_data and execute methods."
     py::class_<Algorithm>(main_module, "Algorithm")
             .def(
-                    "load_data",
-                    [](Algorithm& algo, py::kwargs const& kwargs) {
-                        ConfigureAlgo(algo, kwargs);
-                        algo.LoadData();
-                    },
-                    "Load data for execution")
-            .def("get_possible_options", &Algorithm::GetPossibleOptions,
-                 "Get names of options the algorithm may request.")
-            .def("get_description", &Algorithm::GetDescription, "option_name"_a,
-                 "Get description of an option.")
-            .def("get_needed_options", &Algorithm::GetNeededOptions,
-                 "Get names of options the algorithm requires to be set at the "
-                 "moment." CERTAIN_SCRIPTS_ONLY)
-            .def(
-                    "get_option_type",
-                    [](Algorithm const& algo, std::string_view option_name) {
-                        auto type_index = algo.GetTypeIndex(option_name);
-                        if (type_index == kVoidIndex)
-                            throw config::ConfigurationError{std::string{"Option named \""} +
-                                                             option_name.data() +
-                                                             "\" doesn't exist!"};
-                        return GetPyType(type_index);
-                    },
-                    "option_name"_a, "Get info about the option's type.")
-            .def(
-                    "set_option",
+                    "_set_option",
                     [](Algorithm& algorithm, std::string_view option_name,
                        py::handle option_value) {
                         if (option_value.is_none()) {
@@ -90,7 +65,32 @@ void BindMainClasses(py::module_& main_module) {
                     },
                     "option_name"_a, "option_value"_a = py::none(),
                     "Set option value. Passing None means setting the default "
-                    "value." CERTAIN_SCRIPTS_ONLY)
+                    "value." INTERNAL_OPTIONS_METHOD)
+            .def("_get_needed_options", &Algorithm::GetNeededOptions,
+                 "Get names of options the algorithm requires to be set at the "
+                 "moment." INTERNAL_OPTIONS_METHOD)
+            .def(
+                    "_get_option_type",
+                    [](Algorithm const& algo, std::string_view option_name) {
+                        auto type_index = algo.GetTypeIndex(option_name);
+                        if (type_index == kVoidIndex)
+                            throw config::ConfigurationError{std::string{"Option named \""} +
+                                                             option_name.data() +
+                                                             "\" doesn't exist!"};
+                        return GetPyType(type_index);
+                    },
+                    "option_name"_a, "Get info about the option's type." INTERNAL_OPTIONS_METHOD)
+            .def(
+                    "load_data",
+                    [](Algorithm& algo, py::kwargs const& kwargs) {
+                        ConfigureAlgo(algo, kwargs);
+                        algo.LoadData();
+                    },
+                    "Load data for execution")
+            .def("get_possible_options", &Algorithm::GetPossibleOptions,
+                 "Get names of options the algorithm may request.")
+            .def("get_description", &Algorithm::GetDescription, "option_name"_a,
+                 "Get description of an option.")
             .def(
                     "get_opts",
                     [](Algorithm& algorithm) {
@@ -112,6 +112,6 @@ void BindMainClasses(py::module_& main_module) {
                         return algo.Execute();
                     },
                     "Process data.");
-#undef CERTAIN_SCRIPTS_ONLY
+#undef INTERNAL_OPTIONS_METHOD
 }
 }  // namespace python_bindings

--- a/src/python_bindings/test_bindings.py
+++ b/src/python_bindings/test_bindings.py
@@ -28,7 +28,7 @@ def check_metric_verifier_failure(dataset, options) -> bool:
     alg = desb.mfd_verification.algorithms.MetricVerifier()
     alg.load_data(table=(dataset, ",", True))
     for opt_name in options:
-        alg.set_option(opt_name, options[opt_name])
+        alg._set_option(opt_name, options[opt_name])
 
 
 ALGO_CORRECT_OPTIONS_INFO = [
@@ -177,7 +177,7 @@ class TestPythonBindings(unittest.TestCase):
         testing_algo = algo()
         testing_algo.load_data(table=(path, separator, has_header), **options.load_options)
         for name, value in options.execute_options.items():
-            testing_algo.set_option(name, value)
+            testing_algo._set_option(name, value)
 
         algo_option_values = testing_algo.get_opts()
         for name, value in chain(options.execute_options.items(),


### PR DESCRIPTION
Add underscore to the beginning of `set_option`, `get_needed_options` and `get_option_type`, since these methods are not intended to be called by the users, and may give unexpected results if called without deep understanding.
For example `set_option` may fail on complex combinations of conditional options, and `get_option_type` gives types in unconventional format, that is not very useful for end users

Also change their docstrings