### PR TITLE
Use correct option setting logic in Python tests

### DIFF
--- a/src/python_bindings/py_util/opt_to_py.cpp
+++ b/src/python_bindings/py_util/opt_to_py.cpp
@@ -10,6 +10,7 @@
 #include <pybind11/stl.h>
 
 #include "core/algorithms/dd/dd.h"
+#include "core/algorithms/fd/tane/enums.h"
 #include "core/algorithms/gdd/gdd.h"
 #include "core/algorithms/md/hymd/enums.h"
 #include "core/algorithms/metric/enums.h"
@@ -57,7 +58,8 @@ std::unordered_map<std::type_index, ConvFunction> const kConverters{
         kEnumConvPair<model::InputFormatType>,
         kEnumConvPair<algos::hymd::LevelDefinition>,
         kEnumConvPair<algos::des::DifferentialStrategy>,
-        kEnumConvPair<algos::od::Ordering>};
+        kEnumConvPair<algos::od::Ordering>,
+        kEnumConvPair<algos::AfdErrorMeasure>};
 }  // namespace
 
 namespace python_bindings {

--- a/src/python_bindings/test_bindings.py
+++ b/src/python_bindings/test_bindings.py
@@ -170,14 +170,22 @@ METRIC_VERIFIER_FAILURE_CASES = [
 
 
 class TestPythonBindings(unittest.TestCase):
+    def _configure_and_verify_no_extras(self, testing_algo, params):
+        while option_names := testing_algo._get_needed_options():
+            for option_name in option_names:
+                testing_algo._set_option(option_name, params.pop(option_name, None))
+
+        self.assertEqual(params, {})
 
     def _test_correct_option_setting(
         self, algo, path, separator, has_header, options: dict
     ):
         testing_algo = algo()
-        testing_algo.load_data(table=(path, separator, has_header), **options.load_options)
-        for name, value in options.execute_options.items():
-            testing_algo._set_option(name, value)
+        self._configure_and_verify_no_extras(
+                testing_algo,  {'table': (path, separator, has_header)} | options.load_options)
+        testing_algo.load_data()
+
+        self._configure_and_verify_no_extras(testing_algo, options.execute_options)
 
         algo_option_values = testing_algo.get_opts()
         for name, value in chain(options.execute_options.items(),


### PR DESCRIPTION
The previous one did not allow setting default values, requiring to provide all values explicitly, which made it more difficult to test algorithms that had a more complex default value calculation logic, like the domain PAC verifier.