### PR TITLE
Explicitly specify clang++ for clang-tidy-check

### DIFF
--- a/.github/workflows/check-codestyle.yml
+++ b/.github/workflows/check-codestyle.yml
@@ -66,8 +66,10 @@ jobs:
       - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
-          apt_packages: python3-dev,libboost1.88-all-dev
-          cmake_command: cmake . -B build -DCMAKE_BUILD_TYPE=Debug -Dgtest_disable_pthreads=OFF -DDESBORDANTE_BINDINGS=BUILD -DDESBORDANTE_BUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCPM_SOURCE_CACHE=cmake/cpm-cache
+          # Using Clang for compile commands generation to avoid parsing issues
+          # https://clangd.llvm.org/design/compile-commands#subtle-parsing-problems
+          apt_packages: python3-dev,libboost1.88-all-dev,clang
+          cmake_command: cmake . -B build -DCMAKE_BUILD_TYPE=Debug -Dgtest_disable_pthreads=OFF -DDESBORDANTE_BINDINGS=BUILD -DDESBORDANTE_BUILD_BENCHMARKS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCPM_SOURCE_CACHE=cmake/cpm-cache -DCMAKE_CXX_COMPILER=clang++
           build_dir: build
           config_file: '.clang-tidy'
           include: "*.c,*.cc,*.cpp,*.cxx"


### PR DESCRIPTION
The compiler that gets chosen in CI for compile_commands.json generation is GCC, which means the compiler options are generated for it. In particular, CMake does not specify the C++ standard, because the standard we are using is the default in GCC. But clang uses C++17 by default, which leads to it getting confused by the C++20 syntax.

I also have to install clang here because I've not found a supported way to force CMake to emit commands for a compiler that is not installed.

Clangd wants compile_commands to be generated for clang, otherwise parsing issues can happen https://clangd.llvm.org/design/compile-commands#subtle-parsing-problems