### PR TITLE
Remove Vertical and Column use in Pyro and DFD

### DIFF
--- a/src/core/algorithms/fd/dfd/column_order/column_order.cpp
+++ b/src/core/algorithms/fd/dfd/column_order/column_order.cpp
@@ -20,12 +20,13 @@ ColumnOrder::ColumnOrder(ColumnLayoutRelationData const* const relation_data)
     }
 }
 
-std::vector<int> ColumnOrder::GetOrderHighDistinctCount(Vertical const& columns) const {
-    std::vector<int> order_for_columns(columns.GetArity());
+std::vector<int> ColumnOrder::GetOrderHighDistinctCount(
+        boost::dynamic_bitset<> const& columns) const {
+    std::vector<int> order_for_columns(columns.count());
 
     int current_order_index = 0;
     for (int column_index : order_) {
-        if (columns.GetColumnIndices()[column_index]) {
+        if (columns.test(column_index)) {
             order_for_columns[current_order_index++] = column_index;
         }
     }
@@ -33,13 +34,14 @@ std::vector<int> ColumnOrder::GetOrderHighDistinctCount(Vertical const& columns)
     return order_for_columns;
 }
 
-std::vector<int> ColumnOrder::GetOrderLowDistinctCount(Vertical const& columns) const {
-    std::vector<int> order_for_columns(columns.GetArity());
+std::vector<int> ColumnOrder::GetOrderLowDistinctCount(
+        boost::dynamic_bitset<> const& columns) const {
+    std::vector<int> order_for_columns(columns.count());
 
     assert(!order_.empty());
     int current_order_index = 0;
     for (int i = this->order_.size() - 1; i >= 0; --i) {
-        if (columns.GetColumnIndices()[order_[i]]) {
+        if (columns.test(order_[i])) {
             order_for_columns[current_order_index++] = this->order_[i];
         }
     }

--- a/src/core/algorithms/fd/dfd/column_order/column_order.h
+++ b/src/core/algorithms/fd/dfd/column_order/column_order.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "core/model/table/column_data.h"
-#include "core/model/table/vertical.h"
 
 class ColumnOrder {
 private:
@@ -11,6 +10,6 @@ public:
     explicit ColumnOrder(ColumnLayoutRelationData const* const relation_data);
     ColumnOrder() = default;
 
-    std::vector<int> GetOrderHighDistinctCount(Vertical const& columns) const;
-    std::vector<int> GetOrderLowDistinctCount(Vertical const& columns) const;
+    std::vector<int> GetOrderHighDistinctCount(boost::dynamic_bitset<> const& columns) const;
+    std::vector<int> GetOrderLowDistinctCount(boost::dynamic_bitset<> const& columns) const;
 };

--- a/src/core/algorithms/fd/dfd/dfd.cpp
+++ b/src/core/algorithms/fd/dfd/dfd.cpp
@@ -24,31 +24,31 @@ void DFD::MakeExecuteOptsAvailableFDInternal() {
     MakeOptionsAvailable({config::kThreadNumberOpt.GetName()});
 }
 
-void DFD::ResetStateFd() {
-    unique_columns_.clear();
-}
+void DFD::ResetStateFd() {}
 
 void DFD::ExecuteInternal() {
     auto partition_storage = std::make_unique<PartitionStorage>(relation_.get());
     RelationalSchema const* const schema = relation_->GetSchema();
+    std::vector<boost::dynamic_bitset<>> unique_columns;
 
     // search for unique columns
-    for (auto const& column : schema->GetColumns()) {
-        ColumnData& column_data = relation_->GetColumnData(column->GetIndex());
+    for (model::Index column_index = 0; column_index != schema->GetNumColumns(); ++column_index) {
+        ColumnData& column_data = relation_->GetColumnData(column_index);
         model::PositionListIndex const* const column_pli = column_data.GetPositionListIndex();
 
         if (column_pli->AllValuesAreUnique()) {
-            Vertical const lhs = Vertical(*column);
-            unique_columns_.push_back(lhs);
+            unique_columns.push_back(
+                    std::move(boost::dynamic_bitset<>(schema->GetNumColumns()).set(column_index)));
             // we do not register an FD at once, because we check for FDs with empty LHS later
         }
     }
 
     boost::asio::thread_pool search_space_pool(number_of_threads_);
 
-    for (auto& rhs : schema->GetColumns()) {
-        boost::asio::post(search_space_pool, [this, &rhs, schema, &partition_storage]() {
-            ColumnData const& rhs_data = relation_->GetColumnData(rhs->GetIndex());
+    for (model::Index rhs_index = 0; rhs_index != schema->GetNumColumns(); ++rhs_index) {
+        boost::asio::post(search_space_pool, [this, rhs_index, schema, &partition_storage,
+                                              &unique_columns]() {
+            ColumnData const& rhs_data = relation_->GetColumnData(rhs_index);
             model::PositionListIndex const* const rhs_pli = rhs_data.GetPositionListIndex();
 
             /* if all the rows have the same value, then we register FD with empty LHS
@@ -56,16 +56,18 @@ void DFD::ExecuteInternal() {
              * this RHS, so we register it and move to the next RHS
              * */
             if (rhs_pli->GetNepAsLong() == relation_->GetNumTuplePairs()) {
-                RegisterFd(schema->CreateEmptyVertical(), *rhs, relation_->GetSharedPtrSchema());
+                RegisterFd(schema->CreateEmptyVertical(), *schema->GetColumn(rhs_index),
+                           relation_->GetSharedPtrSchema());
                 return;
             }
 
-            auto search_space = LatticeTraversal(rhs.get(), relation_.get(), unique_columns_,
+            auto search_space = LatticeTraversal(rhs_index, relation_.get(), unique_columns,
                                                  partition_storage.get());
             auto const minimal_deps = search_space.FindLHSs();
 
             for (auto const& minimal_dependency_lhs : minimal_deps) {
-                RegisterFd(minimal_dependency_lhs, *rhs, relation_->GetSharedPtrSchema());
+                RegisterFd(schema->GetVertical(minimal_dependency_lhs),
+                           *schema->GetColumn(rhs_index), relation_->GetSharedPtrSchema());
             }
         });
     }

--- a/src/core/algorithms/fd/dfd/dfd.h
+++ b/src/core/algorithms/fd/dfd/dfd.h
@@ -1,19 +1,15 @@
 #pragma once
 
-#include <random>
-#include <stack>
+#include <boost/dynamic_bitset.hpp>
 
 #include "core/algorithms/fd/dfd/partition_storage/partition_storage.h"
 #include "core/algorithms/fd/pli_based_fd_algorithm.h"
 #include "core/config/thread_number/type.h"
-#include "core/model/table/vertical.h"
 
 namespace algos {
 
 class DFD : public PliBasedFDAlgorithm {
 private:
-    std::vector<Vertical> unique_columns_;
-
     config::ThreadNumType number_of_threads_;
 
     void MakeExecuteOptsAvailableFDInternal() final;

--- a/src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp
+++ b/src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.cpp
@@ -1,20 +1,20 @@
 #include "core/algorithms/fd/dfd/lattice_observations/lattice_observations.h"
 
-NodeCategory LatticeObservations::UpdateDependencyCategory(Vertical const& node) {
+NodeCategory LatticeObservations::UpdateDependencyCategory(boost::dynamic_bitset<> const& node) {
     NodeCategory new_category;
-    if (node.GetArity() <= 1) {
+    if (node.count() <= 1) {
         new_category = NodeCategory::kMinimalDependency;
         (*this)[node] = new_category;
         return new_category;
     }
 
-    auto column_indices = node.GetColumnIndicesRef();  // copy indices
+    auto column_indices = node;  // copy indices
     bool has_unchecked_subset = false;
 
     for (size_t index = column_indices.find_first(); index < column_indices.size();
          index = column_indices.find_next(index)) {
         column_indices[index] = false;  // remove one column
-        auto const subset_node_iter = this->find(Vertical(node.GetSchema(), column_indices));
+        auto const subset_node_iter = this->find(column_indices);
 
         if (subset_node_iter == this->end()) {
             // if we found unchecked subset of this node
@@ -38,9 +38,9 @@ NodeCategory LatticeObservations::UpdateDependencyCategory(Vertical const& node)
     return new_category;
 }
 
-NodeCategory LatticeObservations::UpdateNonDependencyCategory(Vertical const& node,
+NodeCategory LatticeObservations::UpdateNonDependencyCategory(boost::dynamic_bitset<> const& node,
                                                               unsigned int rhs_index) {
-    auto column_indices = node.GetColumnIndicesRef();
+    auto column_indices = node;
     column_indices[rhs_index] = true;
     column_indices.flip();
 
@@ -49,7 +49,7 @@ NodeCategory LatticeObservations::UpdateNonDependencyCategory(Vertical const& no
 
     for (size_t index = column_indices.find_first(); index < column_indices.size();
          index = column_indices.find_next(index)) {
-        auto const superset_node_iter = this->find(node.Union(*node.GetSchema()->GetColumn(index)));
+        auto const superset_node_iter = this->find(boost::dynamic_bitset<>(node).set(index));
 
         if (superset_node_iter == this->end()) {
             // if we found unchecked superset of this node
@@ -71,7 +71,7 @@ NodeCategory LatticeObservations::UpdateNonDependencyCategory(Vertical const& no
     return new_category;
 }
 
-bool LatticeObservations::IsCandidate(Vertical const& node) const {
+bool LatticeObservations::IsCandidate(boost::dynamic_bitset<> const& node) const {
     auto node_iter = this->find(node);
     if (node_iter == this->end()) {
         return false;
@@ -81,14 +81,14 @@ bool LatticeObservations::IsCandidate(Vertical const& node) const {
     }
 }
 
-std::unordered_set<Vertical> LatticeObservations::GetUncheckedSubsets(
-        Vertical const& node, ColumnOrder const& column_order) const {
-    auto indices = node.GetColumnIndices();
-    std::unordered_set<Vertical> unchecked_subsets;
+std::unordered_set<boost::dynamic_bitset<>> LatticeObservations::GetUncheckedSubsets(
+        boost::dynamic_bitset<> const& node, ColumnOrder const& column_order) const {
+    auto indices = node;
+    std::unordered_set<boost::dynamic_bitset<>> unchecked_subsets;
 
     for (int column_index : column_order.GetOrderHighDistinctCount(node)) {
         indices[column_index] = false;
-        Vertical subset_node = Vertical(node.GetSchema(), indices);
+        boost::dynamic_bitset<> subset_node = indices;
         if (this->find(subset_node) == this->end()) {
             unchecked_subsets.insert(std::move(subset_node));
         }
@@ -98,19 +98,19 @@ std::unordered_set<Vertical> LatticeObservations::GetUncheckedSubsets(
     return unchecked_subsets;
 }
 
-std::unordered_set<Vertical> LatticeObservations::GetUncheckedSupersets(
-        Vertical const& node, unsigned int rhs_index, ColumnOrder const& column_order) const {
-    auto flipped_indices = node.GetColumnIndices().flip();
-    std::unordered_set<Vertical> unchecked_supersets;
+std::unordered_set<boost::dynamic_bitset<>> LatticeObservations::GetUncheckedSupersets(
+        boost::dynamic_bitset<> const& node, unsigned int rhs_index,
+        ColumnOrder const& column_order) const {
+    auto flipped_indices = ~node;
+    std::unordered_set<boost::dynamic_bitset<>> unchecked_supersets;
 
     flipped_indices[rhs_index] = false;
 
-    for (int column_index :
-         column_order.GetOrderHighDistinctCount(Vertical(node.GetSchema(), flipped_indices))) {
-        auto indices = node.GetColumnIndices();
+    for (int column_index : column_order.GetOrderHighDistinctCount(flipped_indices)) {
+        auto indices = node;
 
         indices[column_index] = true;
-        Vertical subset_node = Vertical(node.GetSchema(), indices);
+        boost::dynamic_bitset<> subset_node = indices;
         if (this->find(subset_node) == this->end()) {
             unchecked_supersets.insert(std::move(subset_node));
         }

--- a/src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.h
+++ b/src/core/algorithms/fd/dfd/lattice_observations/lattice_observations.h
@@ -4,22 +4,21 @@
 
 #include "core/algorithms/fd/dfd/column_order/column_order.h"
 #include "core/algorithms/fd/dfd/node_category.h"
-#include "core/model/table/vertical.h"
-#include "core/util/custom_hashes.h"
 
-class LatticeObservations : public std::unordered_map<Vertical, NodeCategory> {
+class LatticeObservations : public std::unordered_map<boost::dynamic_bitset<>, NodeCategory> {
 public:
-    bool IsCandidate(Vertical const& node) const;
+    bool IsCandidate(boost::dynamic_bitset<> const& node) const;
 
-    bool IsVisited(Vertical const& node) const {
+    bool IsVisited(boost::dynamic_bitset<> const& node) const {
         return this->find(node) != this->end();
     }
 
-    NodeCategory UpdateDependencyCategory(Vertical const& node);
-    NodeCategory UpdateNonDependencyCategory(Vertical const& node, unsigned int rhs_index);
+    NodeCategory UpdateDependencyCategory(boost::dynamic_bitset<> const& node);
+    NodeCategory UpdateNonDependencyCategory(boost::dynamic_bitset<> const& node,
+                                             unsigned int rhs_index);
 
-    std::unordered_set<Vertical> GetUncheckedSubsets(Vertical const& node,
-                                                     ColumnOrder const&) const;
-    std::unordered_set<Vertical> GetUncheckedSupersets(Vertical const& node, unsigned int rhs_index,
-                                                       ColumnOrder const&) const;
+    std::unordered_set<boost::dynamic_bitset<>> GetUncheckedSubsets(
+            boost::dynamic_bitset<> const& node, ColumnOrder const&) const;
+    std::unordered_set<boost::dynamic_bitset<>> GetUncheckedSupersets(
+            boost::dynamic_bitset<> const& node, unsigned int rhs_index, ColumnOrder const&) const;
 };

--- a/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.cpp
+++ b/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.cpp
@@ -4,11 +4,11 @@
 
 #include "core/model/table/position_list_index.h"
 
-LatticeTraversal::LatticeTraversal(Column const* const rhs,
+LatticeTraversal::LatticeTraversal(model::Index rhs_index,
                                    ColumnLayoutRelationData const* const relation,
-                                   std::vector<Vertical> const& unique_verticals,
+                                   std::vector<boost::dynamic_bitset<>> const& unique_verticals,
                                    PartitionStorage* const partition_storage)
-    : rhs_(rhs),
+    : rhs_index_(rhs_index),
       dependencies_map_(relation->GetSchema()),
       non_dependencies_map_(relation->GetSchema()),
       column_order_(relation),
@@ -17,38 +17,39 @@ LatticeTraversal::LatticeTraversal(Column const* const rhs,
       partition_storage_(partition_storage),
       gen_(rd_()) {}
 
-std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
+std::unordered_set<boost::dynamic_bitset<>> LatticeTraversal::FindLHSs() {
     RelationalSchema const* const schema = relation_->GetSchema();
 
     // processing of found unique columns
     for (auto const& lhs : unique_columns_) {
-        if (!lhs.Contains(*rhs_)) {
+        if (!lhs.test(rhs_index_)) {
             observations_[lhs] = NodeCategory::kMinimalDependency;
             dependencies_map_.AddNewDependency(lhs);
             minimal_deps_.insert(lhs);
         }
     }
 
-    std::stack<Vertical> seeds;
+    std::stack<boost::dynamic_bitset<>> seeds;
 
     /* Temporary fix. I think `GetOrderHighDistinctCount` should return vector of
      * unsigned integers since `order` should be something non-negative.
      */
-    for (unsigned partition_index :
-         column_order_.GetOrderHighDistinctCount(Vertical(*rhs_).Invert())) {
-        if (partition_index != rhs_->GetIndex()) {
-            seeds.push(Vertical(*schema->GetColumn(partition_index)));
+    for (unsigned partition_index : column_order_.GetOrderHighDistinctCount(
+                 ~(boost::dynamic_bitset<>(schema->GetNumColumns()).set(rhs_index_)))) {
+        if (partition_index != rhs_index_) {
+            seeds.push(std::move(
+                    boost::dynamic_bitset<>(schema->GetNumColumns()).set(partition_index)));
         }
     }
 
     do {
         while (!seeds.empty()) {
-            Vertical node;
+            boost::dynamic_bitset<> node;
             if (!seeds.empty()) {
                 node = std::move(seeds.top());
                 seeds.pop();
             } else {
-                node = schema->CreateEmptyVertical();
+                node = boost::dynamic_bitset<>(schema->GetNumColumns());
             }
 
             do {
@@ -63,13 +64,12 @@ std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
                             minimal_deps_.insert(node);
                         }
                     } else if (node_category == NodeCategory::kCandidateMaximalNonDependency) {
-                        node_category =
-                                observations_.UpdateNonDependencyCategory(node, rhs_->GetIndex());
+                        node_category = observations_.UpdateNonDependencyCategory(node, rhs_index_);
                         if (node_category == NodeCategory::kMaximalNonDependency) {
                             maximal_non_deps_.insert(node);
                         }
                     }
-                } else if (!InferCategory(node, rhs_->GetIndex())) {
+                } else if (!InferCategory(node, rhs_index_)) {
                     // if we were not able to infer category, we calculate the partitions
                     auto node_pli = partition_storage_->GetOrCreateFor(node);
                     auto node_pli_pointer =
@@ -78,7 +78,8 @@ std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
                                     : std::get<std::unique_ptr<model::PositionListIndex const>>(
                                               node_pli)
                                               .get();
-                    auto intersected_pli = partition_storage_->GetOrCreateFor(node.Union(*rhs_));
+                    auto intersected_pli = partition_storage_->GetOrCreateFor(
+                            boost::dynamic_bitset<>(node).set(rhs_index_));
                     auto intersected_pli_pointer =
                             std::holds_alternative<model::PositionListIndex const*>(intersected_pli)
                                     ? std::get<model::PositionListIndex const*>(intersected_pli)
@@ -94,7 +95,7 @@ std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
                         }
                         dependencies_map_.AddNewDependency(node);
                     } else {
-                        observations_.UpdateNonDependencyCategory(node, rhs_->GetIndex());
+                        observations_.UpdateNonDependencyCategory(node, rhs_index_);
                         if (observations_[node] == NodeCategory::kMaximalNonDependency) {
                             maximal_non_deps_.insert(node);
                         }
@@ -102,16 +103,16 @@ std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
                     }
                 }
 
-                node = PickNextNode(node, rhs_->GetIndex());
-            } while (!node.IsEmpty());
+                node = PickNextNode(node, rhs_index_);
+            } while (!node.none());
         }
-        seeds = GenerateNextSeeds(rhs_);
+        seeds = GenerateNextSeeds(rhs_index_);
     } while (!seeds.empty());
 
     return minimal_deps_;
 }
 
-bool LatticeTraversal::InferCategory(Vertical const& node, unsigned int rhs_index) {
+bool LatticeTraversal::InferCategory(boost::dynamic_bitset<> const& node, unsigned int rhs_index) {
     if (non_dependencies_map_.CanBePruned(node)) {
         observations_.UpdateNonDependencyCategory(node, rhs_index);
         non_dependencies_map_.AddNewNonDependency(node);
@@ -131,15 +132,17 @@ bool LatticeTraversal::InferCategory(Vertical const& node, unsigned int rhs_inde
     return false;
 }
 
-Vertical const& LatticeTraversal::TakeRandom(std::unordered_set<Vertical>& node_set) {
+boost::dynamic_bitset<> const& LatticeTraversal::TakeRandom(
+        std::unordered_set<boost::dynamic_bitset<>>& node_set) {
     std::uniform_int_distribution<> dis(0, std::distance(node_set.begin(), node_set.end()) - 1);
     auto iterator = node_set.begin();
     std::advance(iterator, dis(this->gen_));
-    Vertical const& node = *iterator;
+    boost::dynamic_bitset<> const& node = *iterator;
     return node;
 }
 
-Vertical LatticeTraversal::PickNextNode(Vertical const& node, unsigned int rhs_index) {
+boost::dynamic_bitset<> LatticeTraversal::PickNextNode(boost::dynamic_bitset<> const& node,
+                                                       unsigned int rhs_index) {
     auto node_iter = observations_.find(node);
 
     if (node_iter != observations_.end()) {
@@ -190,7 +193,7 @@ Vertical LatticeTraversal::PickNextNode(Vertical const& node, unsigned int rhs_i
         }
     }
 
-    Vertical next_node = node.GetSchema()->CreateEmptyVertical();
+    boost::dynamic_bitset<> next_node(node.size());
     if (!trace_.empty()) {
         next_node = trace_.top();
         trace_.pop();
@@ -198,13 +201,14 @@ Vertical LatticeTraversal::PickNextNode(Vertical const& node, unsigned int rhs_i
     return next_node;
 }
 
-std::stack<Vertical> LatticeTraversal::GenerateNextSeeds(Column const* const current_rhs) {
-    std::unordered_set<Vertical> seeds;
-    std::unordered_set<Vertical> new_seeds;
+std::stack<boost::dynamic_bitset<>> LatticeTraversal::GenerateNextSeeds(
+        model::Index const current_rhs) {
+    std::unordered_set<boost::dynamic_bitset<>> seeds;
+    std::unordered_set<boost::dynamic_bitset<>> new_seeds;
 
     for (auto const& non_dep : maximal_non_deps_) {
-        auto complement_indices = non_dep.GetColumnIndicesRef();
-        complement_indices[current_rhs->GetIndex()] = true;
+        auto complement_indices = non_dep;
+        complement_indices[current_rhs] = true;
         complement_indices.flip();
 
         if (seeds.empty()) {
@@ -215,23 +219,23 @@ std::stack<Vertical> LatticeTraversal::GenerateNextSeeds(Column const* const cur
                  column_index < complement_indices.size();
                  column_index = complement_indices.find_next(column_index)) {
                 single_column_bitset[column_index] = true;
-                seeds.emplace(relation_->GetSchema(), single_column_bitset);
+                seeds.insert(single_column_bitset);
                 single_column_bitset[column_index] = false;
             }
         } else {
             for (auto const& dependency : seeds) {
-                auto new_combination = dependency.GetColumnIndicesRef();
+                auto new_combination = dependency;
 
                 for (size_t column_index = complement_indices.find_first();
                      column_index < complement_indices.size();
                      column_index = complement_indices.find_next(column_index)) {
                     new_combination[column_index] = true;
-                    new_seeds.emplace(relation_->GetSchema(), new_combination);
-                    new_combination[column_index] = dependency.GetColumnIndicesRef()[column_index];
+                    new_seeds.emplace(new_combination);
+                    new_combination[column_index] = dependency[column_index];
                 }
             }
 
-            std::list<Vertical> minimized_new_seeds = Minimize(new_seeds);
+            std::list<boost::dynamic_bitset<>> minimized_new_seeds = Minimize(new_seeds);
             seeds.clear();
             for (auto& new_seed : minimized_new_seeds) {
                 seeds.insert(std::move(new_seed));
@@ -248,7 +252,7 @@ std::stack<Vertical> LatticeTraversal::GenerateNextSeeds(Column const* const cur
         }
     }
 
-    std::stack<Vertical> remaining_seeds;
+    std::stack<boost::dynamic_bitset<>> remaining_seeds;
 
     for (auto const& new_seed : seeds) {
         remaining_seeds.push(new_seed);
@@ -257,17 +261,17 @@ std::stack<Vertical> LatticeTraversal::GenerateNextSeeds(Column const* const cur
     return remaining_seeds;
 }
 
-std::list<Vertical> LatticeTraversal::Minimize(
-        std::unordered_set<Vertical> const& node_list) const {
+std::list<boost::dynamic_bitset<>> LatticeTraversal::Minimize(
+        std::unordered_set<boost::dynamic_bitset<>> const& node_list) const {
     unsigned int max_cardinality = 0;
-    std::unordered_map<unsigned int, std::list<Vertical const*>> seeds_by_size(
+    std::unordered_map<unsigned int, std::list<boost::dynamic_bitset<> const*>> seeds_by_size(
             node_list.size() / relation_->GetNumColumns());
 
     for (auto const& seed : node_list) {
-        unsigned int const cardinality_of_seed = seed.GetArity();
+        unsigned int const cardinality_of_seed = seed.count();
         max_cardinality = std::max(max_cardinality, cardinality_of_seed);
         if (seeds_by_size.find(cardinality_of_seed) == seeds_by_size.end()) {
-            seeds_by_size[cardinality_of_seed] = std::list<Vertical const*>();
+            seeds_by_size[cardinality_of_seed] = std::list<boost::dynamic_bitset<> const*>();
         }
         seeds_by_size[cardinality_of_seed].push_back(&seed);
     }
@@ -282,7 +286,7 @@ std::list<Vertical> LatticeTraversal::Minimize(
                     for (auto const& lower_seed : lower_bound_seeds) {
                         for (auto upper_it = upper_bound_seeds.begin();
                              upper_it != upper_bound_seeds.end();) {
-                            if ((*upper_it)->Contains(*lower_seed)) {
+                            if (lower_seed->is_subset_of(**upper_it)) {
                                 upper_it = upper_bound_seeds.erase(upper_it);
                             } else {
                                 ++upper_it;
@@ -294,7 +298,7 @@ std::list<Vertical> LatticeTraversal::Minimize(
         }
     }
 
-    std::list<Vertical> new_seeds;
+    std::list<boost::dynamic_bitset<>> new_seeds;
     for (auto& seed_list : seeds_by_size) {
         for (auto& seed : seed_list.second) {
             new_seeds.push_back(*seed);
@@ -303,8 +307,9 @@ std::list<Vertical> LatticeTraversal::Minimize(
     return new_seeds;
 }
 
-void LatticeTraversal::SubtractSets(std::unordered_set<Vertical>& set,
-                                    std::unordered_set<Vertical> const& set_to_subtract) {
+void LatticeTraversal::SubtractSets(
+        std::unordered_set<boost::dynamic_bitset<>>& set,
+        std::unordered_set<boost::dynamic_bitset<>> const& set_to_subtract) {
     for (auto const& node_to_delete : set_to_subtract) {
         auto found_element_iter = set.find(node_to_delete);
         if (found_element_iter != set.end()) {

--- a/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.cpp
+++ b/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.cpp
@@ -73,15 +73,16 @@ std::unordered_set<Vertical> LatticeTraversal::FindLHSs() {
                     // if we were not able to infer category, we calculate the partitions
                     auto node_pli = partition_storage_->GetOrCreateFor(node);
                     auto node_pli_pointer =
-                            std::holds_alternative<model::PositionListIndex*>(node_pli)
-                                    ? std::get<model::PositionListIndex*>(node_pli)
-                                    : std::get<std::unique_ptr<model::PositionListIndex>>(node_pli)
+                            std::holds_alternative<model::PositionListIndex const*>(node_pli)
+                                    ? std::get<model::PositionListIndex const*>(node_pli)
+                                    : std::get<std::unique_ptr<model::PositionListIndex const>>(
+                                              node_pli)
                                               .get();
                     auto intersected_pli = partition_storage_->GetOrCreateFor(node.Union(*rhs_));
                     auto intersected_pli_pointer =
-                            std::holds_alternative<model::PositionListIndex*>(intersected_pli)
-                                    ? std::get<model::PositionListIndex*>(intersected_pli)
-                                    : std::get<std::unique_ptr<model::PositionListIndex>>(
+                            std::holds_alternative<model::PositionListIndex const*>(intersected_pli)
+                                    ? std::get<model::PositionListIndex const*>(intersected_pli)
+                                    : std::get<std::unique_ptr<model::PositionListIndex const>>(
                                               intersected_pli)
                                               .get();
 

--- a/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.h
+++ b/src/core/algorithms/fd/dfd/lattice_traversal/lattice_traversal.h
@@ -8,40 +8,43 @@
 #include "core/algorithms/fd/dfd/partition_storage/partition_storage.h"
 #include "core/algorithms/fd/dfd/pruning_maps/dependencies_map.h"
 #include "core/algorithms/fd/dfd/pruning_maps/non_dependencies_map.h"
-#include "core/model/table/vertical.h"
+#include "core/model/index.h"
 
 class LatticeTraversal {
 private:
-    Column const* const rhs_;
+    model::Index const rhs_index_;
 
-    std::unordered_set<Vertical> minimal_deps_;
-    std::unordered_set<Vertical> maximal_non_deps_;
+    std::unordered_set<boost::dynamic_bitset<>> minimal_deps_;
+    std::unordered_set<boost::dynamic_bitset<>> maximal_non_deps_;
     DependenciesMap dependencies_map_;
     NonDependenciesMap non_dependencies_map_;
     LatticeObservations observations_;
-    std::stack<Vertical> trace_;
+    std::stack<boost::dynamic_bitset<>> trace_;
     ColumnOrder const column_order_;
 
-    std::vector<Vertical> const& unique_columns_;
+    std::vector<boost::dynamic_bitset<>> const& unique_columns_;
     ColumnLayoutRelationData const* const relation_;
     PartitionStorage* const partition_storage_;
 
     std::random_device rd_;
     std::mt19937 gen_;
 
-    bool InferCategory(Vertical const& node, unsigned int rhs_index);
-    Vertical PickNextNode(Vertical const& node, unsigned int rhs_index);
-    std::stack<Vertical> GenerateNextSeeds(Column const* const current_rhs);
+    bool InferCategory(boost::dynamic_bitset<> const& node, unsigned int rhs_index);
+    boost::dynamic_bitset<> PickNextNode(boost::dynamic_bitset<> const& node,
+                                         unsigned int rhs_index);
+    std::stack<boost::dynamic_bitset<>> GenerateNextSeeds(model::Index const current_rhs);
 
-    std::list<Vertical> Minimize(std::unordered_set<Vertical> const& node_list) const;
-    Vertical const& TakeRandom(std::unordered_set<Vertical>& node_set);
-    static void SubtractSets(std::unordered_set<Vertical>& set,
-                             std::unordered_set<Vertical> const& set_to_subtract);
+    std::list<boost::dynamic_bitset<>> Minimize(
+            std::unordered_set<boost::dynamic_bitset<>> const& node_list) const;
+    boost::dynamic_bitset<> const& TakeRandom(
+            std::unordered_set<boost::dynamic_bitset<>>& node_set);
+    static void SubtractSets(std::unordered_set<boost::dynamic_bitset<>>& set,
+                             std::unordered_set<boost::dynamic_bitset<>> const& set_to_subtract);
 
 public:
-    LatticeTraversal(Column const* const rhs, ColumnLayoutRelationData const* const relation,
-                     std::vector<Vertical> const& unique_verticals,
+    LatticeTraversal(model::Index rhs_index, ColumnLayoutRelationData const* const relation,
+                     std::vector<boost::dynamic_bitset<>> const& unique_verticals,
                      PartitionStorage* const partition_storage);
 
-    std::unordered_set<Vertical> FindLHSs();
+    std::unordered_set<boost::dynamic_bitset<>> FindLHSs();
 };

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -27,7 +27,7 @@ model::PositionListIndex const* PartitionStorage::Get(boost::dynamic_bitset<> co
 PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
     : relation_data_(relation_data),
       index_(std::make_unique<model::BlockingVerticalMap<model::PositionListIndex const>>(
-              relation_data->GetSchema())) {
+              relation_data->GetSchema()->GetNumColumns())) {
     for (model::Index column_index = 0; column_index != relation_data->GetSchema()->GetNumColumns();
          ++column_index) {
         index_->Put(boost::dynamic_bitset<>(relation_data->GetSchema()->GetNumColumns())

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -6,8 +6,21 @@
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
+namespace {
+class PositionListIndexRank {
+public:
+    boost::dynamic_bitset<> const* vertical_;
+    std::shared_ptr<model::PositionListIndex const> pli_;
+    int added_arity_;
+
+    PositionListIndexRank(boost::dynamic_bitset<> const* vertical,
+                          std::shared_ptr<model::PositionListIndex const> pli, int initial_arity)
+        : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
+};
+}  // namespace
+
 model::PositionListIndex const* PartitionStorage::Get(Vertical const& vertical) {
-    return index_->Get(vertical).get();
+    return index_->Get(vertical.GetColumnIndicesRef()).get();
 }
 
 PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
@@ -15,7 +28,7 @@ PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
       index_(std::make_unique<model::BlockingVerticalMap<model::PositionListIndex const>>(
               relation_data->GetSchema())) {
     for (auto& column_ptr : relation_data->GetSchema()->GetColumns()) {
-        index_->Put(static_cast<Vertical>(*column_ptr),
+        index_->Put(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef(),
                     relation_data->GetColumnData(column_ptr->GetIndex()).GetPliOwnership());
     }
 }
@@ -36,12 +49,12 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
         return pli;
     }
     // look for cached PLIs to construct the requested one
-    auto subset_entries = index_->GetSubsetEntries(vertical);
+    auto subset_entries = index_->GetSubsetEntries(vertical.GetColumnIndicesRef());
     boost::optional<PositionListIndexRank> smallest_pli_rank;
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
     for (auto& [sub_vertical, sub_pli_ptr] : subset_entries) {
-        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.GetArity());
+        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.count());
         ranks.push_back(pli_rank);
         if (!smallest_pli_rank || smallest_pli_rank->pli_->GetSize() > pli_rank.pli_->GetSize() ||
             (smallest_pli_rank->pli_->GetSize() == pli_rank.pli_->GetSize() &&
@@ -56,7 +69,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     boost::dynamic_bitset<> cover_tester(relation_data_->GetNumColumns());
     if (smallest_pli_rank) {
         operands.push_back(*smallest_pli_rank);
-        cover |= smallest_pli_rank->vertical_->GetColumnIndices();
+        cover |= *smallest_pli_rank->vertical_;
 
         while (cover.count() < vertical.GetArity() && !ranks.empty()) {
             boost::optional<PositionListIndexRank> best_rank;
@@ -64,7 +77,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
             ranks.erase(std::remove_if(ranks.begin(), ranks.end(),
                                        [&cover_tester, &cover](auto& rank) {
                                            cover_tester.reset();
-                                           cover_tester |= rank.vertical_->GetColumnIndices();
+                                           cover_tester |= *rank.vertical_;
                                            cover_tester -= cover;
                                            rank.added_arity_ = cover_tester.count();
                                            return rank.added_arity_ < 2;
@@ -81,7 +94,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
 
             if (best_rank) {
                 operands.push_back(*best_rank);
-                cover |= best_rank->vertical_->GetColumnIndices();
+                cover |= *best_rank->vertical_;
             }
         }
     }
@@ -91,8 +104,9 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     for (auto& column : vertical.GetColumns()) {
         if (!cover[column->GetIndex()]) {
             vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
-            auto column_pli = index_->Get(**vertical_columns.rbegin());
-            operands.emplace_back(vertical_columns.rbegin()->get(), column_pli, 1);
+            auto column_pli = index_->Get((**vertical_columns.rbegin()).GetColumnIndicesRef());
+            operands.emplace_back(&(**vertical_columns.rbegin()).GetColumnIndicesRef(), column_pli,
+                                  1);
         }
     }
     // sort operands by ascending order
@@ -111,14 +125,18 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     if (operands.size() >= 4) {
         PositionListIndexRank base_pli_rank = operands[0];
         auto intersection_pli = base_pli_rank.pli_->ProbeAll(
-                vertical.Without(*base_pli_rank.vertical_), *relation_data_);
+                vertical.Without(
+                        relation_data_->GetSchema()->GetVertical(*base_pli_rank.vertical_)),
+                *relation_data_);
         variant_intersection_pli = CachingProcess(vertical, std::move(intersection_pli));
     } else {
-        Vertical current_vertical = *operands.begin()->vertical_;
+        Vertical current_vertical =
+                relation_data_->GetSchema()->GetVertical(*operands.begin()->vertical_);
         variant_intersection_pli = operands.begin()->pli_.get();
 
         for (size_t i = 1; i < operands.size(); i++) {
-            current_vertical = current_vertical.Union(*operands[i].vertical_);
+            current_vertical = current_vertical.Union(
+                    relation_data_->GetSchema()->GetVertical(*operands[i].vertical_));
             variant_intersection_pli =
                     std::holds_alternative<model::PositionListIndex const*>(
                             variant_intersection_pli)
@@ -144,6 +162,6 @@ std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionLis
 PartitionStorage::CachingProcess(Vertical const& vertical,
                                  std::unique_ptr<model::PositionListIndex const> pli) {
     auto pli_pointer = pli.get();
-    index_->Put(vertical, std::move(pli));
+    index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
     return pli_pointer;
 }

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -31,7 +31,6 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     // is PLI already cached?
     model::PositionListIndex* pli = Get(vertical);
     if (pli != nullptr) {
-        pli->IncFreq();
         LOG_DEBUG("Served from PLI cache.");
         // addToUsageCounter
         return pli;
@@ -58,7 +57,6 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     boost::dynamic_bitset<> cover(relation_data_->GetNumColumns());
     boost::dynamic_bitset<> cover_tester(relation_data_->GetNumColumns());
     if (smallest_pli_rank) {
-        smallest_pli_rank->pli_->IncFreq();
         operands.push_back(*smallest_pli_rank);
         cover |= smallest_pli_rank->vertical_->GetColumnIndices();
 
@@ -84,7 +82,6 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
             }
 
             if (best_rank) {
-                best_rank->pli_->IncFreq();
                 operands.push_back(*best_rank);
                 cover |= best_rank->vertical_->GetColumnIndices();
             }
@@ -98,7 +95,6 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
             vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
             auto column_pli = index_->Get(**vertical_columns.rbegin());
             operands.emplace_back(vertical_columns.rbegin()->get(), column_pli, 1);
-            column_pli->IncFreq();
         }
     }
     // sort operands by ascending order

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -6,13 +6,13 @@
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
-model::PositionListIndex* PartitionStorage::Get(Vertical const& vertical) {
+model::PositionListIndex const* PartitionStorage::Get(Vertical const& vertical) {
     return index_->Get(vertical).get();
 }
 
 PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
     : relation_data_(relation_data),
-      index_(std::make_unique<model::BlockingVerticalMap<model::PositionListIndex>>(
+      index_(std::make_unique<model::BlockingVerticalMap<model::PositionListIndex const>>(
               relation_data->GetSchema())) {
     for (auto& column_ptr : relation_data->GetSchema()->GetColumns()) {
         index_->Put(static_cast<Vertical>(*column_ptr),
@@ -23,13 +23,13 @@ PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
 PartitionStorage::~PartitionStorage() {}
 
 // obtains or calculates a PositionListIndex using cache
-std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
+std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
 PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     std::scoped_lock lock(getting_pli_mutex_);
     LOG_DEBUG("PLI for {} requested: ", vertical.ToString());
 
     // is PLI already cached?
-    model::PositionListIndex* pli = Get(vertical);
+    model::PositionListIndex const* pli = Get(vertical);
     if (pli != nullptr) {
         LOG_DEBUG("Served from PLI cache.");
         // addToUsageCounter
@@ -108,7 +108,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     }
 
     // Intersect and cache
-    std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
+    std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
             variant_intersection_pli;
     if (operands.size() >= 4) {
         PositionListIndexRank base_pli_rank = operands[0];
@@ -122,15 +122,17 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
         for (size_t i = 1; i < operands.size(); i++) {
             current_vertical = current_vertical.Union(*operands[i].vertical_);
             variant_intersection_pli =
-                    std::holds_alternative<model::PositionListIndex*>(variant_intersection_pli)
-                            ? std::get<model::PositionListIndex*>(variant_intersection_pli)
+                    std::holds_alternative<model::PositionListIndex const*>(
+                            variant_intersection_pli)
+                            ? std::get<model::PositionListIndex const*>(variant_intersection_pli)
                                       ->Intersect(operands[i].pli_.get())
-                            : std::get<std::unique_ptr<model::PositionListIndex>>(
+                            : std::get<std::unique_ptr<model::PositionListIndex const>>(
                                       variant_intersection_pli)
                                       ->Intersect(operands[i].pli_.get());
             variant_intersection_pli = CachingProcess(
-                    current_vertical, std::move(std::get<std::unique_ptr<model::PositionListIndex>>(
-                                              variant_intersection_pli)));
+                    current_vertical,
+                    std::move(std::get<std::unique_ptr<model::PositionListIndex const>>(
+                            variant_intersection_pli)));
         }
     }
 
@@ -140,9 +142,9 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     return variant_intersection_pli;
 }
 
-std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
+std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
 PartitionStorage::CachingProcess(Vertical const& vertical,
-                                 std::unique_ptr<model::PositionListIndex> pli) {
+                                 std::unique_ptr<model::PositionListIndex const> pli) {
     auto pli_pointer = pli.get();
     index_->Put(vertical, std::move(pli));
     return pli_pointer;

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -41,9 +41,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
     for (auto& [sub_vertical, sub_pli_ptr] : subset_entries) {
-        PositionListIndexRank pli_rank(
-                &sub_vertical, std::const_pointer_cast<model::PositionListIndex>(sub_pli_ptr),
-                sub_vertical.GetArity());
+        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.GetArity());
         ranks.push_back(pli_rank);
         if (!smallest_pli_rank || smallest_pli_rank->pli_->GetSize() > pli_rank.pli_->GetSize() ||
             (smallest_pli_rank->pli_->GetSize() == pli_rank.pli_->GetSize() &&

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -140,10 +140,6 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     return variant_intersection_pli;
 }
 
-size_t PartitionStorage::Size() const {
-    return index_->GetSize();
-}
-
 std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
 PartitionStorage::CachingProcess(Vertical const& vertical,
                                  std::unique_ptr<model::PositionListIndex> pli) {

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.cpp
@@ -3,6 +3,7 @@
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 
+#include "core/model/index.h"
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
@@ -19,17 +20,19 @@ public:
 };
 }  // namespace
 
-model::PositionListIndex const* PartitionStorage::Get(Vertical const& vertical) {
-    return index_->Get(vertical.GetColumnIndicesRef()).get();
+model::PositionListIndex const* PartitionStorage::Get(boost::dynamic_bitset<> const& vertical) {
+    return index_->Get(vertical).get();
 }
 
 PartitionStorage::PartitionStorage(ColumnLayoutRelationData* relation_data)
     : relation_data_(relation_data),
       index_(std::make_unique<model::BlockingVerticalMap<model::PositionListIndex const>>(
               relation_data->GetSchema())) {
-    for (auto& column_ptr : relation_data->GetSchema()->GetColumns()) {
-        index_->Put(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef(),
-                    relation_data->GetColumnData(column_ptr->GetIndex()).GetPliOwnership());
+    for (model::Index column_index = 0; column_index != relation_data->GetSchema()->GetNumColumns();
+         ++column_index) {
+        index_->Put(boost::dynamic_bitset<>(relation_data->GetSchema()->GetNumColumns())
+                            .set(column_index),
+                    relation_data->GetColumnData(column_index).GetPliOwnership());
     }
 }
 
@@ -37,9 +40,8 @@ PartitionStorage::~PartitionStorage() {}
 
 // obtains or calculates a PositionListIndex using cache
 std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
-PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
+PartitionStorage::GetOrCreateFor(boost::dynamic_bitset<> const& vertical) {
     std::scoped_lock lock(getting_pli_mutex_);
-    LOG_DEBUG("PLI for {} requested: ", vertical.ToString());
 
     // is PLI already cached?
     model::PositionListIndex const* pli = Get(vertical);
@@ -49,7 +51,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
         return pli;
     }
     // look for cached PLIs to construct the requested one
-    auto subset_entries = index_->GetSubsetEntries(vertical.GetColumnIndicesRef());
+    auto subset_entries = index_->GetSubsetEntries(vertical);
     boost::optional<PositionListIndexRank> smallest_pli_rank;
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
@@ -71,7 +73,7 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
         operands.push_back(*smallest_pli_rank);
         cover |= *smallest_pli_rank->vertical_;
 
-        while (cover.count() < vertical.GetArity() && !ranks.empty()) {
+        while (cover.count() < vertical.count() && !ranks.empty()) {
             boost::optional<PositionListIndexRank> best_rank;
             // erase ranks with low added_arity_
             ranks.erase(std::remove_if(ranks.begin(), ranks.end(),
@@ -99,15 +101,16 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
         }
     }
 
-    std::vector<std::unique_ptr<Vertical>> vertical_columns;
+    std::vector<boost::dynamic_bitset<>> vertical_columns;
 
-    for (auto& column : vertical.GetColumns()) {
-        if (!cover[column->GetIndex()]) {
-            vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
-            auto column_pli = index_->Get((**vertical_columns.rbegin()).GetColumnIndicesRef());
-            operands.emplace_back(&(**vertical_columns.rbegin()).GetColumnIndicesRef(), column_pli,
-                                  1);
-        }
+    util::ForEachIndex(vertical, [&](model::Index column_index) {
+        if (cover.test(column_index)) return;
+        vertical_columns.push_back(
+                boost::dynamic_bitset<>(relation_data_->GetNumColumns()).set(column_index));
+    });
+    for (boost::dynamic_bitset<> const& vertical : vertical_columns) {
+        auto column_pli = index_->Get(vertical);
+        operands.emplace_back(&vertical, std::move(column_pli), 1);
     }
     // sort operands by ascending order
     std::sort(operands.begin(), operands.end(),
@@ -124,19 +127,15 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
             variant_intersection_pli;
     if (operands.size() >= 4) {
         PositionListIndexRank base_pli_rank = operands[0];
-        auto intersection_pli = base_pli_rank.pli_->ProbeAll(
-                vertical.Without(
-                        relation_data_->GetSchema()->GetVertical(*base_pli_rank.vertical_)),
-                *relation_data_);
+        auto intersection_pli =
+                base_pli_rank.pli_->ProbeAll(vertical - *base_pli_rank.vertical_, *relation_data_);
         variant_intersection_pli = CachingProcess(vertical, std::move(intersection_pli));
     } else {
-        Vertical current_vertical =
-                relation_data_->GetSchema()->GetVertical(*operands.begin()->vertical_);
+        boost::dynamic_bitset<> current_vertical = *operands.begin()->vertical_;
         variant_intersection_pli = operands.begin()->pli_.get();
 
         for (size_t i = 1; i < operands.size(); i++) {
-            current_vertical = current_vertical.Union(
-                    relation_data_->GetSchema()->GetVertical(*operands[i].vertical_));
+            current_vertical |= *operands[i].vertical_;
             variant_intersection_pli =
                     std::holds_alternative<model::PositionListIndex const*>(
                             variant_intersection_pli)
@@ -153,15 +152,15 @@ PartitionStorage::GetOrCreateFor(Vertical const& vertical) {
     }
 
     LOG_DEBUG("Calculated from {} sub-PLIs (saved {} intersections).", operands.size(),
-              (vertical.GetArity() - operands.size()));
+              (vertical.count() - operands.size()));
 
     return variant_intersection_pli;
 }
 
 std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
-PartitionStorage::CachingProcess(Vertical const& vertical,
+PartitionStorage::CachingProcess(boost::dynamic_bitset<> const& vertical,
                                  std::unique_ptr<model::PositionListIndex const> pli) {
     auto pli_pointer = pli.get();
-    index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
+    index_->Put(vertical, std::move(pli));
     return pli_pointer;
 }

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
@@ -7,18 +7,6 @@
 
 class PartitionStorage {
 private:
-    class PositionListIndexRank {
-    public:
-        Vertical const* vertical_;
-        std::shared_ptr<model::PositionListIndex const> pli_;
-        int added_arity_;
-
-        PositionListIndexRank(Vertical const* vertical,
-                              std::shared_ptr<model::PositionListIndex const> pli,
-                              int initial_arity)
-            : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
-    };
-
     ColumnLayoutRelationData* relation_data_;
     std::unique_ptr<model::VerticalMap<model::PositionListIndex const>> index_;
 

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
@@ -13,14 +13,15 @@ private:
     mutable std::mutex getting_pli_mutex_;
 
     std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
-    CachingProcess(Vertical const& vertical, std::unique_ptr<model::PositionListIndex const> pli);
+    CachingProcess(boost::dynamic_bitset<> const& vertical,
+                   std::unique_ptr<model::PositionListIndex const> pli);
 
 public:
     PartitionStorage(ColumnLayoutRelationData* relation_data);
 
-    model::PositionListIndex const* Get(Vertical const& vertical);
+    model::PositionListIndex const* Get(boost::dynamic_bitset<> const& vertical);
     std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
-    GetOrCreateFor(Vertical const& vertical);
+    GetOrCreateFor(boost::dynamic_bitset<> const& vertical);
 
     virtual ~PartitionStorage();
 };

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
@@ -10,27 +10,28 @@ private:
     class PositionListIndexRank {
     public:
         Vertical const* vertical_;
-        std::shared_ptr<model::PositionListIndex> pli_;
+        std::shared_ptr<model::PositionListIndex const> pli_;
         int added_arity_;
 
         PositionListIndexRank(Vertical const* vertical,
-                              std::shared_ptr<model::PositionListIndex> pli, int initial_arity)
+                              std::shared_ptr<model::PositionListIndex const> pli,
+                              int initial_arity)
             : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
     };
 
     ColumnLayoutRelationData* relation_data_;
-    std::unique_ptr<model::VerticalMap<model::PositionListIndex>> index_;
+    std::unique_ptr<model::VerticalMap<model::PositionListIndex const>> index_;
 
     mutable std::mutex getting_pli_mutex_;
 
-    std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
-    CachingProcess(Vertical const& vertical, std::unique_ptr<model::PositionListIndex> pli);
+    std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
+    CachingProcess(Vertical const& vertical, std::unique_ptr<model::PositionListIndex const> pli);
 
 public:
     PartitionStorage(ColumnLayoutRelationData* relation_data);
 
-    model::PositionListIndex* Get(Vertical const& vertical);
-    std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
+    model::PositionListIndex const* Get(Vertical const& vertical);
+    std::variant<model::PositionListIndex const*, std::unique_ptr<model::PositionListIndex const>>
     GetOrCreateFor(Vertical const& vertical);
 
     virtual ~PartitionStorage();

--- a/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
+++ b/src/core/algorithms/fd/dfd/partition_storage/partition_storage.h
@@ -33,7 +33,5 @@ public:
     std::variant<model::PositionListIndex*, std::unique_ptr<model::PositionListIndex>>
     GetOrCreateFor(Vertical const& vertical);
 
-    size_t Size() const;
-
     virtual ~PartitionStorage();
 };

--- a/src/core/algorithms/fd/dfd/pruning_maps/dependencies_map.cpp
+++ b/src/core/algorithms/fd/dfd/pruning_maps/dependencies_map.cpp
@@ -2,9 +2,9 @@
 
 DependenciesMap::DependenciesMap(RelationalSchema const* schema) : PruningMap(schema) {}
 
-std::unordered_set<Vertical> DependenciesMap::GetPrunedSubsets(
-        std::unordered_set<Vertical> const& subsets) const {
-    std::unordered_set<Vertical> pruned_subsets;
+std::unordered_set<boost::dynamic_bitset<>> DependenciesMap::GetPrunedSubsets(
+        std::unordered_set<boost::dynamic_bitset<>> const& subsets) const {
+    std::unordered_set<boost::dynamic_bitset<>> pruned_subsets;
     for (auto const& node : subsets) {
         if (CanBePruned(node)) {
             pruned_subsets.insert(node);
@@ -13,21 +13,21 @@ std::unordered_set<Vertical> DependenciesMap::GetPrunedSubsets(
     return pruned_subsets;
 }
 
-void DependenciesMap::AddNewDependency(Vertical const& node_to_add) {
+void DependenciesMap::AddNewDependency(boost::dynamic_bitset<> const& node_to_add) {
     for (auto& map_row : *this) {
-        Vertical const& key = map_row.first;
+        boost::dynamic_bitset<> const& key = map_row.first;
 
-        if (node_to_add.Contains(key)) {
+        if (key.is_subset_of(node_to_add)) {
             auto& deps_for_key = map_row.second;
             bool has_subset_entry = false;
 
             for (auto iter = deps_for_key.begin(); iter != deps_for_key.end();) {
                 // if verticals are the same, then contains == true
-                Vertical const& dep = *iter;
-                if (node_to_add.Contains(dep)) {
+                boost::dynamic_bitset<> const& dep = *iter;
+                if (dep.is_subset_of(node_to_add)) {
                     has_subset_entry = true;
                     break;
-                } else if (dep.Contains(node_to_add)) {
+                } else if (node_to_add.is_subset_of(dep)) {
                     iter = deps_for_key.erase(iter);
                 } else {
                     iter++;
@@ -42,12 +42,12 @@ void DependenciesMap::AddNewDependency(Vertical const& node_to_add) {
     Rebalance();
 }
 
-bool DependenciesMap::CanBePruned(Vertical const& node) const {
+bool DependenciesMap::CanBePruned(boost::dynamic_bitset<> const& node) const {
     for (auto const& map_row : *this) {
-        Vertical const& key = map_row.first;
-        if (node.Contains(key)) {
-            for (Vertical const& dependency : map_row.second) {
-                if (node.Contains(dependency)) {
+        boost::dynamic_bitset<> const& key = map_row.first;
+        if (key.is_subset_of(node)) {
+            for (boost::dynamic_bitset<> const& dependency : map_row.second) {
+                if (dependency.is_subset_of(node)) {
                     return true;
                 }
             }

--- a/src/core/algorithms/fd/dfd/pruning_maps/dependencies_map.h
+++ b/src/core/algorithms/fd/dfd/pruning_maps/dependencies_map.h
@@ -1,15 +1,14 @@
 #pragma once
 
 #include "core/algorithms/fd/dfd/pruning_maps/pruning_map.h"
-#include "core/model/table/vertical.h"
 
 class DependenciesMap : public PruningMap {
 public:
     explicit DependenciesMap(RelationalSchema const* schema);
     DependenciesMap() = default;
 
-    std::unordered_set<Vertical> GetPrunedSubsets(
-            std::unordered_set<Vertical> const& subsets) const;
-    void AddNewDependency(Vertical const& node_to_add);
-    bool CanBePruned(Vertical const& node) const;
+    std::unordered_set<boost::dynamic_bitset<>> GetPrunedSubsets(
+            std::unordered_set<boost::dynamic_bitset<>> const& subsets) const;
+    void AddNewDependency(boost::dynamic_bitset<> const& node_to_add);
+    bool CanBePruned(boost::dynamic_bitset<> const& node) const;
 };

--- a/src/core/algorithms/fd/dfd/pruning_maps/non_dependencies_map.cpp
+++ b/src/core/algorithms/fd/dfd/pruning_maps/non_dependencies_map.cpp
@@ -2,9 +2,9 @@
 
 NonDependenciesMap::NonDependenciesMap(RelationalSchema const* schema) : PruningMap(schema) {}
 
-std::unordered_set<Vertical> NonDependenciesMap::GetPrunedSupersets(
-        std::unordered_set<Vertical> const& supersets) const {
-    std::unordered_set<Vertical> pruned_supersets;
+std::unordered_set<boost::dynamic_bitset<>> NonDependenciesMap::GetPrunedSupersets(
+        std::unordered_set<boost::dynamic_bitset<>> const& supersets) const {
+    std::unordered_set<boost::dynamic_bitset<>> pruned_supersets;
     for (auto const& node : supersets) {
         if (CanBePruned(node)) {
             pruned_supersets.insert(node);
@@ -13,12 +13,12 @@ std::unordered_set<Vertical> NonDependenciesMap::GetPrunedSupersets(
     return pruned_supersets;
 }
 
-bool NonDependenciesMap::CanBePruned(Vertical const& node) const {
+bool NonDependenciesMap::CanBePruned(boost::dynamic_bitset<> const& node) const {
     for (auto const& map_row : *this) {
-        Vertical const& key = map_row.first;
-        if (node.Contains(key)) {
-            for (Vertical const& non_dependency : map_row.second) {
-                if (non_dependency.Contains(node)) {
+        boost::dynamic_bitset<> const& key = map_row.first;
+        if (key.is_subset_of(node)) {
+            for (boost::dynamic_bitset<> const& non_dependency : map_row.second) {
+                if (node.is_subset_of(non_dependency)) {
                     return true;
                 }
             }
@@ -27,21 +27,21 @@ bool NonDependenciesMap::CanBePruned(Vertical const& node) const {
     return false;
 }
 
-void NonDependenciesMap::AddNewNonDependency(Vertical const& node_to_add) {
+void NonDependenciesMap::AddNewNonDependency(boost::dynamic_bitset<> const& node_to_add) {
     for (auto& map_row : *this) {
-        Vertical const& key = map_row.first;
+        boost::dynamic_bitset<> const& key = map_row.first;
 
-        if (node_to_add.Contains(key)) {
+        if (key.is_subset_of(node_to_add)) {
             auto& non_deps_for_key = map_row.second;
             bool has_superset_entry = false;
 
             for (auto iter = non_deps_for_key.begin(); iter != non_deps_for_key.end();) {
                 // if verticals are the same, then contains == true
-                Vertical const& non_dep = *iter;
-                if (non_dep.Contains(node_to_add)) {
+                boost::dynamic_bitset<> const& non_dep = *iter;
+                if (node_to_add.is_subset_of(non_dep)) {
                     has_superset_entry = true;
                     break;
-                } else if (node_to_add.Contains(non_dep)) {
+                } else if (non_dep.is_subset_of(node_to_add)) {
                     iter = non_deps_for_key.erase(iter);
                 } else {
                     iter++;

--- a/src/core/algorithms/fd/dfd/pruning_maps/non_dependencies_map.h
+++ b/src/core/algorithms/fd/dfd/pruning_maps/non_dependencies_map.h
@@ -1,15 +1,14 @@
 #pragma once
 
 #include "core/algorithms/fd/dfd/pruning_maps/pruning_map.h"
-#include "core/model/table/vertical.h"
 
 class NonDependenciesMap : public PruningMap {
 public:
     explicit NonDependenciesMap(RelationalSchema const* schema);
     NonDependenciesMap() = default;
 
-    std::unordered_set<Vertical> GetPrunedSupersets(
-            std::unordered_set<Vertical> const& supersets) const;
-    void AddNewNonDependency(Vertical const& node_to_add);
-    bool CanBePruned(Vertical const& node) const;
+    std::unordered_set<boost::dynamic_bitset<>> GetPrunedSupersets(
+            std::unordered_set<boost::dynamic_bitset<>> const& supersets) const;
+    void AddNewNonDependency(boost::dynamic_bitset<> const& node_to_add);
+    bool CanBePruned(boost::dynamic_bitset<> const& node) const;
 };

--- a/src/core/algorithms/fd/dfd/pruning_maps/pruning_map.cpp
+++ b/src/core/algorithms/fd/dfd/pruning_maps/pruning_map.cpp
@@ -1,8 +1,10 @@
 #include "core/algorithms/fd/dfd/pruning_maps/pruning_map.h"
 
+#include "core/model/index.h"
+
 PruningMap::PruningMap(RelationalSchema const* schema) {
-    for (auto const& column : schema->GetColumns()) {
-        this->insert(std::make_pair(Vertical(*column), std::unordered_set<Vertical>()));
+    for (model::Index column_index = 0; column_index != schema->GetNumColumns(); ++column_index) {
+        try_emplace(std::move(boost::dynamic_bitset<>(schema->GetNumColumns()).set(column_index)));
     }
 }
 
@@ -12,7 +14,7 @@ void PruningMap::Rebalance() {
     do {
         rebalanced_group = false;
         for (auto iter = this->begin(); iter != this->end();) {
-            Vertical const& key = iter->first;
+            boost::dynamic_bitset<> const& key = iter->first;
             auto const& related_verticals = iter->second;
 
             // RebalanceGroup() invalidates this iterator, because it erases the key element
@@ -25,18 +27,18 @@ void PruningMap::Rebalance() {
     } while (rebalanced_group);
 }
 
-void PruningMap::RebalanceGroup(Vertical const& key) {
+void PruningMap::RebalanceGroup(boost::dynamic_bitset<> const& key) {
     auto const& deps_of_group = this->at(key);
-    auto inverted_columns = key.GetColumnIndices().operator~();
+    auto inverted_columns = ~key;
 
     for (size_t column_index = inverted_columns.find_first();
          column_index < inverted_columns.size();
          column_index = inverted_columns.find_next(column_index)) {
-        Vertical new_key = key.Union(*key.GetSchema()->GetColumn(column_index));
-        std::unordered_set<Vertical> new_group;
+        boost::dynamic_bitset<> new_key = boost::dynamic_bitset<>(key).set(column_index);
+        std::unordered_set<boost::dynamic_bitset<>> new_group;
 
         for (auto const& dep_of_group : deps_of_group) {
-            if (dep_of_group.Contains(new_key)) {
+            if (new_key.is_subset_of(dep_of_group)) {
                 new_group.insert(dep_of_group);
             }
         }

--- a/src/core/algorithms/fd/dfd/pruning_maps/pruning_map.h
+++ b/src/core/algorithms/fd/dfd/pruning_maps/pruning_map.h
@@ -4,13 +4,13 @@
 #include <unordered_set>
 
 #include "core/algorithms/fd/dfd/lattice_observations/lattice_observations.h"
-#include "core/model/table/vertical.h"
 
-class PruningMap : public std::unordered_map<Vertical, std::unordered_set<Vertical>> {
+class PruningMap : public std::unordered_map<boost::dynamic_bitset<>,
+                                             std::unordered_set<boost::dynamic_bitset<>>> {
 public:
     PruningMap(RelationalSchema const* schema);
     PruningMap() = default;
 
     void Rebalance();
-    void RebalanceGroup(Vertical const& key);
+    void RebalanceGroup(boost::dynamic_bitset<> const& key);
 };

--- a/src/core/algorithms/fd/hyfd/validator.cpp
+++ b/src/core/algorithms/fd/hyfd/validator.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <future>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -12,6 +13,7 @@
 #include "core/algorithms/fd/hycommon/util/pli_util.h"
 #include "core/algorithms/fd/hycommon/validator_helpers.h"
 #include "core/algorithms/fd/hyfd/hyfd_config.h"
+#include "core/util/bitset_utils.h"
 
 namespace {
 

--- a/src/core/algorithms/fd/pyro/pyro.cpp
+++ b/src/core/algorithms/fd/pyro/pyro.cpp
@@ -17,7 +17,9 @@ Pyro::Pyro() : PliBasedFDAlgorithm() {
     RegisterOptions();
     fd_consumer_ = [this](auto const& fd) {
         this->DiscoverFd(fd);
-        this->FDAlgorithm::RegisterFd(fd.lhs_, fd.rhs_, relation_->GetSharedPtrSchema());
+        this->FDAlgorithm::RegisterFd(relation_->GetSchema()->GetVertical(fd.lhs_),
+                                      *relation_->GetSchema()->GetColumn(fd.rhs_),
+                                      relation_->GetSharedPtrSchema());
     };
     ucc_consumer_ = nullptr;
 }
@@ -56,10 +58,11 @@ void Pyro::ExecuteInternal() {
     }
 
     int next_id = 0;
-    for (auto& rhs : schema->GetColumns()) {
+    for (model::Index rhs_column_index = 0; rhs_column_index != schema->GetNumColumns();
+         ++rhs_column_index) {
         std::unique_ptr<DependencyStrategy> strategy;
         if (parameters_.ucc_error_measure == "g1prime") {
-            strategy = std::make_unique<FdG1Strategy>(rhs.get(), parameters_.max_ucc_error,
+            strategy = std::make_unique<FdG1Strategy>(rhs_column_index, parameters_.max_ucc_error,
                                                       parameters_.error_dev);
         } else {
             throw std::runtime_error("Unknown key error measure.");

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_candidate.cpp
@@ -6,9 +6,9 @@
 // strict weak ordering
 bool DependencyCandidate::ArityComparator(DependencyCandidate const& dc1,
                                           DependencyCandidate const& dc2) {
-    if (dc1.vertical_.GetArity() > dc2.vertical_.GetArity())
+    if (dc1.vertical_.count() > dc2.vertical_.count())
         return true;
-    else if (dc1.vertical_.GetArity() == dc2.vertical_.GetArity())
+    else if (dc1.vertical_.count() == dc2.vertical_.count())
         return (dc1.error_.GetMean() > dc2.error_.GetMean());
     return false;
 }
@@ -18,7 +18,7 @@ bool DependencyCandidate::MinErrorComparator(DependencyCandidate const& dc1,
     if (dc1.error_.GetMin() > dc2.error_.GetMin())
         return true;
     else if (dc1.error_.GetMin() == dc2.error_.GetMin())
-        return (dc1.vertical_.GetArity() > dc2.vertical_.GetArity());
+        return (dc1.vertical_.count() > dc2.vertical_.count());
     return false;
 }
 
@@ -34,11 +34,11 @@ bool DependencyCandidate::FullArityErrorComparator(DependencyCandidate const& dc
     if (dc1.error_.GetMean() < dc2.error_.GetMean())
         return true;
     else if (dc1.error_.GetMean() == dc2.error_.GetMean()) {
-        if (dc1.vertical_.GetArity() < dc2.vertical_.GetArity())
+        if (dc1.vertical_.count() < dc2.vertical_.count())
             return true;
-        else if (dc1.vertical_.GetArity() == dc2.vertical_.GetArity()) {
-            boost::dynamic_bitset<> dc1_cols = dc1.vertical_.GetColumnIndices();
-            boost::dynamic_bitset<> dc2_cols = dc2.vertical_.GetColumnIndices();
+        else if (dc1.vertical_.count() == dc2.vertical_.count()) {
+            boost::dynamic_bitset<> dc1_cols = dc1.vertical_;
+            boost::dynamic_bitset<> dc2_cols = dc2.vertical_;
 
             for (size_t a = dc1_cols.find_first(), b = dc2_cols.find_first(); a < dc1_cols.size();
                  a = dc1_cols.find_next(a), b = dc2_cols.find_next(b))
@@ -52,11 +52,11 @@ bool DependencyCandidate::operator<(DependencyCandidate const& other) const {
     if (error_.GetMean() < other.error_.GetMean())
         return true;
     else if (error_.GetMean() == other.error_.GetMean()) {
-        if (vertical_.GetArity() < other.vertical_.GetArity())
+        if (vertical_.count() < other.vertical_.count())
             return true;
-        else if (vertical_.GetArity() == other.vertical_.GetArity()) {
-            boost::dynamic_bitset<> dc1_cols = vertical_.GetColumnIndices();
-            boost::dynamic_bitset<> dc2_cols = other.vertical_.GetColumnIndices();
+        else if (vertical_.count() == other.vertical_.count()) {
+            boost::dynamic_bitset<> dc1_cols = vertical_;
+            boost::dynamic_bitset<> dc2_cols = other.vertical_;
 
             for (size_t a = dc1_cols.find_first(), b = dc2_cols.find_first(); a < dc1_cols.size();
                  a = dc1_cols.find_next(a), b = dc2_cols.find_next(b))
@@ -65,11 +65,3 @@ bool DependencyCandidate::operator<(DependencyCandidate const& other) const {
     }
     return false;
 }
-
-std::ostream& operator<<(std::ostream& ofs, DependencyCandidate const& dependency_candidate) {
-    return ofs << static_cast<std::string>(dependency_candidate);
-}
-
-/*bool DependencyCandidate::operator==(DependencyCandidate const & other) const {
-    return (*vertical_ == *(other.vertical_) && )
-}*/

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_candidate.h
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_candidate.h
@@ -2,8 +2,9 @@
 #include <functional>
 #include <utility>
 
+#include <boost/dynamic_bitset.hpp>
+
 #include "core/algorithms/fd/pyrocommon/model/confidence_interval.h"
-#include "core/model/table/vertical.h"
 
 class DependencyCandidate {
 private:
@@ -11,15 +12,13 @@ private:
 
 public:
     model::ConfidenceInterval error_;
-    Vertical vertical_;
+    boost::dynamic_bitset<> vertical_;
 
-    DependencyCandidate(Vertical vertical, model::ConfidenceInterval error, bool is_exact)
+    DependencyCandidate(boost::dynamic_bitset<> vertical, model::ConfidenceInterval error,
+                        bool is_exact)
         : is_exact_(is_exact), error_(error), vertical_(std::move(vertical)) {}
 
     bool operator<(DependencyCandidate const& other) const;
-
-    // TODO: implement if used
-    // bool operator==(DependencyCandidate const& other) const;
 
     bool IsExact() const {
         return is_exact_ && error_.IsPoint();
@@ -33,11 +32,4 @@ public:
     // static bool maxErrorComparator(DependencyCandidate const &, DependencyCandidate const &);
     static bool FullArityErrorComparator(DependencyCandidate const&, DependencyCandidate const&);
     static bool FullErrorArityComparator(DependencyCandidate const&, DependencyCandidate const&);
-
-    explicit operator std::string() const {
-        return "Candidate " + static_cast<std::string>(vertical_) +
-               static_cast<std::string>(error_);
-    }
-
-    friend std::ostream& operator<<(std::ostream&, DependencyCandidate const&);
 };

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_consumer.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_consumer.cpp
@@ -1,63 +1,16 @@
 
 #include "core/algorithms/fd/pyrocommon/core/dependency_consumer.h"
 
-PartialFD DependencyConsumer::RegisterFd(Vertical const& lhs, Column const& rhs, double error,
-                                         double score) const {
+PartialFD DependencyConsumer::RegisterFd(boost::dynamic_bitset<> const& lhs, model::Index rhs,
+                                         double error, double score) const {
     PartialFD partial_fd(lhs, rhs, error, score);
     fd_consumer_(partial_fd);
     return partial_fd;
 }
 
-PartialKey DependencyConsumer::RegisterUcc(Vertical const& key_vertical, double error,
-                                           double score) const {
+PartialKey DependencyConsumer::RegisterUcc(boost::dynamic_bitset<> const& key_vertical,
+                                           double error, double score) const {
     PartialKey partial_key(key_vertical, error, score);
     ucc_consumer_(partial_key);
     return partial_key;
-}
-
-std::string DependencyConsumer::FDsToString() const {
-    std::string result;
-    for (auto const& fd : discovered_fds_) {
-        result += fd.ToString() + "\n\r";
-    }
-    return result;
-}
-
-std::string DependencyConsumer::UCCsToString() const {
-    std::string result;
-    for (auto const& ucc : discovered_uccs_) {
-        result += ucc.ToString() + "\n\r";
-    }
-    return result;
-}
-
-std::string DependencyConsumer::GetJsonFDs() {
-    std::string result = "{\"fds\": [";
-    std::list<std::string> discovered_fd_strings;
-    for (auto& fd : discovered_fds_) {
-        discovered_fd_strings.push_back(fd.ToIndicesString());
-    }
-    discovered_fd_strings.sort();
-    for (auto const& fd : discovered_fd_strings) {
-        result += '\"' + fd + "\",";
-    }
-    if (result.back() == ',') {
-        result.erase(result.size() - 1);
-    }
-    result += ']';
-
-    result += ", \"uccs\": [";
-    std::list<std::string> discovered_ucc_strings;
-    for (auto& ucc : discovered_uccs_) {
-        discovered_ucc_strings.push_back(ucc.ToIndicesString());
-    }
-    discovered_ucc_strings.sort();
-    for (auto const& ucc : discovered_ucc_strings) {
-        result += '\"' + ucc + "\",";
-    }
-    if (result.back() == ',') {
-        result.erase(result.size() - 1);
-    }
-    result += "]}";
-    return result;
 }

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_consumer.h
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_consumer.h
@@ -29,13 +29,10 @@ protected:
     }
 
 public:
-    PartialFD RegisterFd(Vertical const& lhs, Column const& rhs, double error, double score) const;
-    PartialKey RegisterUcc(Vertical const& key_vertical, double error, double score) const;
-
-    std::string FDsToString() const;
-    std::string UCCsToString() const;
-
-    virtual std::string GetJsonFDs();
+    PartialFD RegisterFd(boost::dynamic_bitset<> const& lhs, model::Index rhs, double error,
+                         double score) const;
+    PartialKey RegisterUcc(boost::dynamic_bitset<> const& key_vertical, double error,
+                           double score) const;
 
     virtual ~DependencyConsumer() = default;
 };

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.cpp
@@ -10,7 +10,7 @@ bool DependencyStrategy::ShouldResample(Vertical const& vertical, double boost_f
     if (current_sample->IsExact()) return false;
 
     // Get an estimate of the number of equality pairs in the vertical
-    model::PositionListIndex* pli = context_->GetPliCache()->Get(vertical);
+    model::PositionListIndex const* pli = context_->GetPliCache()->Get(vertical);
     double nep = pli != nullptr
                          ? pli->GetNepAsLong()
                          : current_sample->EstimateAgreements(vertical) *

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.cpp
@@ -2,8 +2,9 @@
 
 #include "core/algorithms/fd/pyrocommon/model/pli_cache.h"
 
-bool DependencyStrategy::ShouldResample(Vertical const& vertical, double boost_factor) const {
-    if (context_->GetParameters().sample_size <= 0 || vertical.GetArity() < 1) return false;
+bool DependencyStrategy::ShouldResample(boost::dynamic_bitset<> const& vertical,
+                                        double boost_factor) const {
+    if (context_->GetParameters().sample_size <= 0 || vertical.count() < 1) return false;
 
     // Do we have an exact sample already?
     auto current_sample = context_->GetAgreeSetSample(vertical);

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.h
@@ -2,7 +2,7 @@
 #include "core/algorithms/fd/pyrocommon/core/dependency_candidate.h"
 #include "core/algorithms/fd/pyrocommon/core/dependency_consumer.h"
 #include "core/algorithms/fd/pyrocommon/core/profiling_context.h"
-#include "core/model/table/vertical.h"
+#include "core/model/index.h"
 
 class SearchSpace;
 
@@ -22,23 +22,20 @@ public:
      * Create the initial candidate for the given SearchSpace
      * */
     virtual void EnsureInitialized(SearchSpace* search_space) const = 0;
-    virtual DependencyCandidate CreateDependencyCandidate(Vertical const& candidate) const = 0;
-    virtual double CalculateError(Vertical const& candidate) const = 0;
-    virtual void RegisterDependency(Vertical const& vertical, double error,
+    virtual DependencyCandidate CreateDependencyCandidate(
+            boost::dynamic_bitset<> const& candidate) const = 0;
+    virtual double CalculateError(boost::dynamic_bitset<> const& candidate) const = 0;
+    virtual void RegisterDependency(boost::dynamic_bitset<> const& vertical, double error,
                                     DependencyConsumer const& discovery_unit) const = 0;
     virtual bool IsIrrelevantColumn(unsigned int column_index) const = 0;
     virtual unsigned int GetNumIrrelevantColumns() const = 0;
-    virtual Vertical GetIrrelevantColumns() const = 0;
+    virtual boost::dynamic_bitset<> GetIrrelevantColumns() const = 0;
 
     virtual ~DependencyStrategy() = default;
 
     virtual std::unique_ptr<DependencyStrategy> CreateClone() = 0;
 
-    bool ShouldResample(Vertical const& vertical, double boost_factor) const;
-
-    bool IsIrrelevantColumn(Column const& column) const {
-        return this->IsIrrelevantColumn(column.GetIndex());
-    }
+    bool ShouldResample(boost::dynamic_bitset<> const& vertical, double boost_factor) const;
 
     static double Round(double error) {
         return std::ceil(error * 32768) / 32768;

--- a/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/dependency_strategy.h
@@ -24,8 +24,6 @@ public:
     virtual void EnsureInitialized(SearchSpace* search_space) const = 0;
     virtual DependencyCandidate CreateDependencyCandidate(Vertical const& candidate) const = 0;
     virtual double CalculateError(Vertical const& candidate) const = 0;
-    virtual std::string Format(Vertical const& vertical) const = 0;
-    explicit virtual operator std::string() const = 0;
     virtual void RegisterDependency(Vertical const& vertical, double error,
                                     DependencyConsumer const& discovery_unit) const = 0;
     virtual bool IsIrrelevantColumn(unsigned int column_index) const = 0;

--- a/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.cpp
@@ -9,11 +9,8 @@
 double FdG1Strategy::CalculateG1(model::PositionListIndex const* lhs_pli) const {
     unsigned long long num_violations = 0;
     std::unordered_map<int, int> value_counts;
-    std::vector<int> const& probing_table = context_->GetColumnLayoutRelationData()
-                                                    ->GetColumnData(rhs_->GetIndex())
-                                                    .GetProbingTable();
-
-    LOG_DEBUG("Probing table size for {}: {}", rhs_->ToString(), probing_table.size());
+    std::vector<int> const& probing_table =
+            context_->GetColumnLayoutRelationData()->GetColumnData(rhs_index_).GetProbingTable();
 
     // Perform probing
     int probing_table_value_id;
@@ -48,8 +45,8 @@ double FdG1Strategy::CalculateG1(double num_violating_tuple_pairs) const {
 void FdG1Strategy::EnsureInitialized(SearchSpace* search_space) const {
     if (search_space->is_initialized_) return;
 
-    Vertical empty_vertical =
-            context_->GetColumnLayoutRelationData()->GetSchema()->CreateEmptyVertical();
+    boost::dynamic_bitset<> empty_vertical = boost::dynamic_bitset<>(
+            context_->GetColumnLayoutRelationData()->GetSchema()->GetNumColumns());
     double zero_fd_error = CalculateError(empty_vertical);
     search_space->AddLaunchPad(DependencyCandidate(std::move(empty_vertical),
                                                    model::ConfidenceInterval(zero_fd_error), true));
@@ -57,10 +54,13 @@ void FdG1Strategy::EnsureInitialized(SearchSpace* search_space) const {
     search_space->is_initialized_ = true;
 }
 
-double FdG1Strategy::CalculateError(Vertical const& lhs) const {
+double FdG1Strategy::CalculateError(boost::dynamic_bitset<> const& lhs) const {
     double error = 0;
-    if (lhs.GetArity() == 0) {
-        auto rhs_pli = context_->GetPliCache()->Get(static_cast<Vertical>(*rhs_));
+    if (lhs.count() == 0) {
+        auto rhs_pli = context_->GetPliCache()->Get(
+                boost::dynamic_bitset<>(
+                        context_->GetColumnLayoutRelationData()->GetSchema()->GetNumColumns())
+                        .set(rhs_index_));
         if (rhs_pli == nullptr) {
             throw std::runtime_error(
                     "Couldn't get rhsPLI from PLICache while calculating FD error");
@@ -72,7 +72,7 @@ double FdG1Strategy::CalculateError(Vertical const& lhs) const {
                 std::holds_alternative<model::PositionListIndex const*>(lhs_pli)
                         ? std::get<model::PositionListIndex const*>(lhs_pli)
                         : std::get<std::unique_ptr<model::PositionListIndex const>>(lhs_pli).get();
-        auto joint_pli = context_->GetPliCache()->Get(lhs.Union(static_cast<Vertical>(*rhs_)));
+        auto joint_pli = context_->GetPliCache()->Get(boost::dynamic_bitset<>(lhs).set(rhs_index_));
         error = joint_pli == nullptr
                         ? CalculateG1(lhs_pli_pointer)
                         : CalculateG1(lhs_pli_pointer->GetNepAsLong() - joint_pli->GetNepAsLong());
@@ -88,7 +88,8 @@ model::ConfidenceInterval FdG1Strategy::CalculateG1(
                                      CalculateG1(num_violations.GetMax()));
 }
 
-DependencyCandidate FdG1Strategy::CreateDependencyCandidate(Vertical const& vertical) const {
+DependencyCandidate FdG1Strategy::CreateDependencyCandidate(
+        boost::dynamic_bitset<> const& vertical) const {
     if (context_->IsAgreeSetSamplesEmpty()) {
         return DependencyCandidate(vertical, model::ConfidenceInterval(0, .5, 1), false);
     }
@@ -96,20 +97,24 @@ DependencyCandidate FdG1Strategy::CreateDependencyCandidate(Vertical const& vert
     auto agree_set_sample = context_->GetAgreeSetSample(vertical);
     model::ConfidenceInterval num_violating_tuple_pairs =
             agree_set_sample
-                    ->EstimateMixed(vertical, static_cast<Vertical>(*rhs_),
+                    ->EstimateMixed(vertical,
+                                    boost::dynamic_bitset<>(context_->GetColumnLayoutRelationData()
+                                                                    ->GetSchema()
+                                                                    ->GetNumColumns())
+                                            .set(rhs_index_),
                                     context_->GetParameters().estimate_confidence)
                     .Multiply(context_->GetColumnLayoutRelationData()->GetNumTuplePairs());
     model::ConfidenceInterval g1 = CalculateG1(num_violating_tuple_pairs);
     return DependencyCandidate(vertical, g1, false);
 }
 
-void FdG1Strategy::RegisterDependency(Vertical const& vertical, double error,
+void FdG1Strategy::RegisterDependency(boost::dynamic_bitset<> const& vertical, double error,
                                       DependencyConsumer const& discovery_unit) const {
-    discovery_unit.RegisterFd(vertical, *rhs_, error, 0);  // TODO: calculate score?
+    discovery_unit.RegisterFd(vertical, rhs_index_, error, 0);  // TODO: calculate score?
 }
 
 std::unique_ptr<DependencyStrategy> FdG1Strategy::CreateClone() {
-    return std::make_unique<FdG1Strategy>(rhs_,
+    return std::make_unique<FdG1Strategy>(rhs_index_,
                                           (max_dependency_error_ + min_non_dependency_error_) / 2,
                                           (max_dependency_error_ - min_non_dependency_error_) / 2);
 }

--- a/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.cpp
@@ -6,7 +6,7 @@
 #include "core/algorithms/fd/pyrocommon/model/pli_cache.h"
 #include "core/util/logger.h"
 
-double FdG1Strategy::CalculateG1(model::PositionListIndex* lhs_pli) const {
+double FdG1Strategy::CalculateG1(model::PositionListIndex const* lhs_pli) const {
     unsigned long long num_violations = 0;
     std::unordered_map<int, int> value_counts;
     std::vector<int> const& probing_table = context_->GetColumnLayoutRelationData()
@@ -69,9 +69,9 @@ double FdG1Strategy::CalculateError(Vertical const& lhs) const {
     } else {
         auto lhs_pli = context_->GetPliCache()->GetOrCreateFor(lhs, context_);
         auto lhs_pli_pointer =
-                std::holds_alternative<model::PositionListIndex*>(lhs_pli)
-                        ? std::get<model::PositionListIndex*>(lhs_pli)
-                        : std::get<std::unique_ptr<model::PositionListIndex>>(lhs_pli).get();
+                std::holds_alternative<model::PositionListIndex const*>(lhs_pli)
+                        ? std::get<model::PositionListIndex const*>(lhs_pli)
+                        : std::get<std::unique_ptr<model::PositionListIndex const>>(lhs_pli).get();
         auto joint_pli = context_->GetPliCache()->Get(lhs.Union(static_cast<Vertical>(*rhs_)));
         error = joint_pli == nullptr
                         ? CalculateG1(lhs_pli_pointer)

--- a/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
@@ -20,16 +20,6 @@ public:
     double CalculateError(Vertical const& lhs) const override;
     DependencyCandidate CreateDependencyCandidate(Vertical const& vertical) const override;
 
-    std::string Format(Vertical const& vertical) const override {
-        return (boost::format("%s\u2192%s") % std::string(vertical) % std::string(*rhs_)).str();
-    }
-
-    explicit operator std::string() const override {
-        return (boost::format("FD[RHS=%s, g1\u2264(%.3f..%.3f)]") % rhs_->GetName() %
-                min_non_dependency_error_ % max_dependency_error_)
-                .str();
-    }
-
     // TODO: can it be const though? Dependency registers --> some state somewhere changes.
     // Non-const discovery_unit?
     void RegisterDependency(Vertical const& vertical, double error,

--- a/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
@@ -6,27 +6,28 @@
 
 class FdG1Strategy : public DependencyStrategy {
 private:
-    Column const* rhs_;
+    model::Index rhs_index_;
 
     double CalculateG1(model::PositionListIndex const* lhs_pli) const;
     double CalculateG1(double num_violating_tuple_pairs) const;
     model::ConfidenceInterval CalculateG1(model::ConfidenceInterval const& num_violations) const;
 
 public:
-    FdG1Strategy(Column const* rhs, double max_error, double deviation)
-        : DependencyStrategy(max_error, deviation), rhs_(rhs) {}
+    FdG1Strategy(model::Index rhs_index, double max_error, double deviation)
+        : DependencyStrategy(max_error, deviation), rhs_index_(rhs_index) {}
 
     void EnsureInitialized(SearchSpace* search_space) const override;
-    double CalculateError(Vertical const& lhs) const override;
-    DependencyCandidate CreateDependencyCandidate(Vertical const& vertical) const override;
+    double CalculateError(boost::dynamic_bitset<> const& lhs) const override;
+    DependencyCandidate CreateDependencyCandidate(
+            boost::dynamic_bitset<> const& vertical) const override;
 
     // TODO: can it be const though? Dependency registers --> some state somewhere changes.
     // Non-const discovery_unit?
-    void RegisterDependency(Vertical const& vertical, double error,
+    void RegisterDependency(boost::dynamic_bitset<> const& vertical, double error,
                             DependencyConsumer const& discovery_unit) const override;
 
     bool IsIrrelevantColumn(unsigned int column_index) const override {
-        return rhs_->GetIndex() == column_index;
+        return rhs_index_ == column_index;
     }
 
     unsigned int GetNumIrrelevantColumns() const override {
@@ -35,7 +36,7 @@ public:
 
     std::unique_ptr<DependencyStrategy> CreateClone() override;
 
-    Vertical GetIrrelevantColumns() const override {
-        return static_cast<Vertical>(*rhs_);
+    boost::dynamic_bitset<> GetIrrelevantColumns() const override {
+        return boost::dynamic_bitset<>(context_->GetSchema()->GetNumColumns()).set(rhs_index_);
     }
 };

--- a/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/fd_g1_strategy.h
@@ -8,7 +8,7 @@ class FdG1Strategy : public DependencyStrategy {
 private:
     Column const* rhs_;
 
-    double CalculateG1(model::PositionListIndex* lhs_pli) const;
+    double CalculateG1(model::PositionListIndex const* lhs_pli) const;
     double CalculateG1(double num_violating_tuple_pairs) const;
     model::ConfidenceInterval CalculateG1(model::ConfidenceInterval const& num_violations) const;
 

--- a/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.cpp
@@ -20,16 +20,18 @@ double KeyG1Strategy::CalculateKeyError(double num_violating_tuple_pairs) const 
 void KeyG1Strategy::EnsureInitialized(SearchSpace* search_space) const {
     if (search_space->is_initialized_) return;
 
-    for (auto& column : context_->GetSchema()->GetColumns()) {
-        if (IsIrrelevantColumn(column->GetIndex())) continue;
+    for (model::Index column_index = 0; column_index != context_->GetSchema()->GetNumColumns();
+         ++column_index) {
+        if (IsIrrelevantColumn(column_index)) continue;
 
-        search_space->AddLaunchPad(CreateDependencyCandidate(static_cast<Vertical>(*column)));
+        search_space->AddLaunchPad(CreateDependencyCandidate(
+                boost::dynamic_bitset<>(context_->GetSchema()->GetNumColumns()).set(column_index)));
     }
 
     search_space->is_initialized_ = true;
 }
 
-double KeyG1Strategy::CalculateError(Vertical const& key_candidate) const {
+double KeyG1Strategy::CalculateError(boost::dynamic_bitset<> const& key_candidate) const {
     auto pli = context_->GetPliCache()->GetOrCreateFor(key_candidate, context_);
     auto pli_pointer =
             std::holds_alternative<model::PositionListIndex const*>(pli)
@@ -47,8 +49,9 @@ model::ConfidenceInterval KeyG1Strategy::CalculateKeyError(
                                      CalculateKeyError(num_violations.GetMax()));
 }
 
-DependencyCandidate KeyG1Strategy::CreateDependencyCandidate(Vertical const& vertical) const {
-    if (vertical.GetArity() == 1) {
+DependencyCandidate KeyG1Strategy::CreateDependencyCandidate(
+        boost::dynamic_bitset<> const& vertical) const {
+    if (vertical.count() == 1) {
         auto pli = context_->GetPliCache()->GetOrCreateFor(vertical, context_);
         auto pli_pointer =
                 std::holds_alternative<model::PositionListIndex const*>(pli)
@@ -71,7 +74,7 @@ DependencyCandidate KeyG1Strategy::CreateDependencyCandidate(Vertical const& ver
     return DependencyCandidate(vertical, key_error, false);
 }
 
-void KeyG1Strategy::RegisterDependency(Vertical const& vertical, double error,
+void KeyG1Strategy::RegisterDependency(boost::dynamic_bitset<> const& vertical, double error,
                                        DependencyConsumer const& discovery_unit) const {
     discovery_unit.RegisterUcc(vertical, error, 0);  // TODO: calculate score?
 }

--- a/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.cpp
@@ -5,7 +5,7 @@
 #include "core/algorithms/fd/pyrocommon/core/search_space.h"
 #include "core/algorithms/fd/pyrocommon/model/pli_cache.h"
 
-double KeyG1Strategy::CalculateKeyError(model::PositionListIndex* pli) const {
+double KeyG1Strategy::CalculateKeyError(model::PositionListIndex const* pli) const {
     return CalculateKeyError(pli->GetNepAsLong());
 }
 
@@ -31,9 +31,10 @@ void KeyG1Strategy::EnsureInitialized(SearchSpace* search_space) const {
 
 double KeyG1Strategy::CalculateError(Vertical const& key_candidate) const {
     auto pli = context_->GetPliCache()->GetOrCreateFor(key_candidate, context_);
-    auto pli_pointer = std::holds_alternative<model::PositionListIndex*>(pli)
-                               ? std::get<model::PositionListIndex*>(pli)
-                               : std::get<std::unique_ptr<model::PositionListIndex>>(pli).get();
+    auto pli_pointer =
+            std::holds_alternative<model::PositionListIndex const*>(pli)
+                    ? std::get<model::PositionListIndex const*>(pli)
+                    : std::get<std::unique_ptr<model::PositionListIndex const>>(pli).get();
     double error = CalculateKeyError(pli_pointer);
     calc_count_++;
     return error;
@@ -49,9 +50,10 @@ model::ConfidenceInterval KeyG1Strategy::CalculateKeyError(
 DependencyCandidate KeyG1Strategy::CreateDependencyCandidate(Vertical const& vertical) const {
     if (vertical.GetArity() == 1) {
         auto pli = context_->GetPliCache()->GetOrCreateFor(vertical, context_);
-        auto pli_pointer = std::holds_alternative<model::PositionListIndex*>(pli)
-                                   ? std::get<model::PositionListIndex*>(pli)
-                                   : std::get<std::unique_ptr<model::PositionListIndex>>(pli).get();
+        auto pli_pointer =
+                std::holds_alternative<model::PositionListIndex const*>(pli)
+                        ? std::get<model::PositionListIndex const*>(pli)
+                        : std::get<std::unique_ptr<model::PositionListIndex const>>(pli).get();
         double key_error = CalculateKeyError(pli_pointer->GetNepAsLong());
         return DependencyCandidate(vertical, model::ConfidenceInterval(key_error), true);
     }

--- a/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
@@ -5,7 +5,7 @@
 
 class KeyG1Strategy : public DependencyStrategy {
 private:
-    double CalculateKeyError(model::PositionListIndex* pli) const;
+    double CalculateKeyError(model::PositionListIndex const* pli) const;
     double CalculateKeyError(double num_violating_tuple_pairs) const;
     model::ConfidenceInterval CalculateKeyError(
             model::ConfidenceInterval const& num_violations) const;

--- a/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
@@ -14,10 +14,11 @@ public:
     KeyG1Strategy(double max_error, double deviation) : DependencyStrategy(max_error, deviation) {}
 
     void EnsureInitialized(SearchSpace* search_space) const override;
-    double CalculateError(Vertical const& key_candidate) const override;
-    DependencyCandidate CreateDependencyCandidate(Vertical const& vertical) const override;
+    double CalculateError(boost::dynamic_bitset<> const& key_candidate) const override;
+    DependencyCandidate CreateDependencyCandidate(
+            boost::dynamic_bitset<> const& vertical) const override;
 
-    void RegisterDependency(Vertical const& vertical, double error,
+    void RegisterDependency(boost::dynamic_bitset<> const& vertical, double error,
                             DependencyConsumer const& discovery_unit) const override;
 
     bool IsIrrelevantColumn([[maybe_unused]] unsigned int column_index) const override {
@@ -28,8 +29,9 @@ public:
         return 1;
     }
 
-    Vertical GetIrrelevantColumns() const override {
-        return context_->GetColumnLayoutRelationData()->GetSchema()->CreateEmptyVertical();
+    boost::dynamic_bitset<> GetIrrelevantColumns() const override {
+        return boost::dynamic_bitset<>(
+                context_->GetColumnLayoutRelationData()->GetSchema()->GetNumColumns());
     }
 
     std::unique_ptr<DependencyStrategy> CreateClone() override;

--- a/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
+++ b/src/core/algorithms/fd/pyrocommon/core/key_g1_strategy.h
@@ -17,16 +17,6 @@ public:
     double CalculateError(Vertical const& key_candidate) const override;
     DependencyCandidate CreateDependencyCandidate(Vertical const& vertical) const override;
 
-    std::string Format(Vertical const& vertical) const override {
-        return (boost::format("key(%s)") % std::string(vertical)).str();
-    }
-
-    explicit operator std::string() const override {
-        return (boost::format("key[g1\u2264(%.3f..%.3f)]") % min_non_dependency_error_ %
-                max_dependency_error_)
-                .str();
-    }
-
     void RegisterDependency(Vertical const& vertical, double error,
                             DependencyConsumer const& discovery_unit) const override;
 

--- a/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
@@ -4,6 +4,7 @@
 
 #include "core/algorithms/fd/pyrocommon/model/list_agree_set_sample.h"
 #include "core/algorithms/fd/pyrocommon/model/pli_cache.h"
+#include "core/model/index.h"
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
@@ -32,10 +33,11 @@ ProfilingContext::ProfilingContext(algos::pyro::Parameters parameters,
                 std::make_unique<model::BlockingVerticalMap<model::AgreeSetSample>>(schema);
         // TODO: сделать, чтобы при одном потоке agree_set_samples_ =
         // std::make_unique<VerticalMap<AgreeSetSample>>(schema);
-        for (auto& column : schema->GetColumns()) {
+        for (model::Index column_index = 0; column_index != schema->GetNumColumns();
+             ++column_index) {
             CreateColumnFocusedSample(
-                    static_cast<Vertical>(*column),
-                    relation_data->GetColumnData(column->GetIndex()).GetPositionListIndex(), 1);
+                    boost::dynamic_bitset<>(schema->GetNumColumns()).set(column_index),
+                    relation_data->GetColumnData(column_index).GetPositionListIndex(), 1);
         }
     } else {
         agree_set_samples_ = nullptr;
@@ -135,8 +137,8 @@ double ProfilingContext::SetMaximumEntropy(ColumnLayoutRelationData const* relat
     }
 }
 
-model::AgreeSetSample const* ProfilingContext::CreateFocusedSample(Vertical const& focus,
-                                                                   double boost_factor) {
+model::AgreeSetSample const* ProfilingContext::CreateFocusedSample(
+        boost::dynamic_bitset<> const& focus, double boost_factor) {
     auto pli = pli_cache_->GetOrCreateFor(focus, this);
     auto pli_pointer =
             std::holds_alternative<model::PositionListIndex const*>(pli)
@@ -145,29 +147,26 @@ model::AgreeSetSample const* ProfilingContext::CreateFocusedSample(Vertical cons
     std::unique_ptr<model::ListAgreeSetSample> sample = model::ListAgreeSetSample::CreateFocusedFor(
             relation_data_, focus, pli_pointer, parameters_.sample_size * boost_factor,
             custom_random_);
-    LOG_TRACE("Creating sample focused on: {}", focus.ToString());
     auto sample_ptr = sample.get();
-    agree_set_samples_->Put(focus.GetColumnIndicesRef(), std::move(sample));
+    agree_set_samples_->Put(focus, std::move(sample));
     return sample_ptr;
 }
 
 model::AgreeSetSample const* ProfilingContext::CreateColumnFocusedSample(
-        Vertical const& focus, model::PositionListIndex const* restriction_pli,
+        boost::dynamic_bitset<> const& focus, model::PositionListIndex const* restriction_pli,
         double boost_factor) {
     std::unique_ptr<model::ListAgreeSetSample> sample = model::ListAgreeSetSample::CreateFocusedFor(
             relation_data_, focus, restriction_pli, parameters_.sample_size * boost_factor,
             custom_random_);
-    LOG_TRACE("Creating sample focused on: {}", focus.ToString());
     auto sample_ptr = sample.get();
-    agree_set_samples_->Put(focus.GetColumnIndicesRef(), std::move(sample));
+    agree_set_samples_->Put(focus, std::move(sample));
     return sample_ptr;
 }
 
 shared_ptr<model::AgreeSetSample const> ProfilingContext::GetAgreeSetSample(
-        Vertical const& focus) const {
+        boost::dynamic_bitset<> const& focus) const {
     shared_ptr<model::AgreeSetSample const> sample = nullptr;
-    for (auto& [key, next_sample] :
-         agree_set_samples_->GetSubsetEntries(focus.GetColumnIndicesRef())) {
+    for (auto& [key, next_sample] : agree_set_samples_->GetSubsetEntries(focus)) {
         if (sample == nullptr || next_sample->GetSamplingRatio() > sample->GetSamplingRatio()) {
             sample = next_sample;
         }

--- a/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
@@ -147,7 +147,7 @@ model::AgreeSetSample const* ProfilingContext::CreateFocusedSample(Vertical cons
             custom_random_);
     LOG_TRACE("Creating sample focused on: {}", focus.ToString());
     auto sample_ptr = sample.get();
-    agree_set_samples_->Put(focus, std::move(sample));
+    agree_set_samples_->Put(focus.GetColumnIndicesRef(), std::move(sample));
     return sample_ptr;
 }
 
@@ -159,14 +159,15 @@ model::AgreeSetSample const* ProfilingContext::CreateColumnFocusedSample(
             custom_random_);
     LOG_TRACE("Creating sample focused on: {}", focus.ToString());
     auto sample_ptr = sample.get();
-    agree_set_samples_->Put(focus, std::move(sample));
+    agree_set_samples_->Put(focus.GetColumnIndicesRef(), std::move(sample));
     return sample_ptr;
 }
 
 shared_ptr<model::AgreeSetSample const> ProfilingContext::GetAgreeSetSample(
         Vertical const& focus) const {
     shared_ptr<model::AgreeSetSample const> sample = nullptr;
-    for (auto& [key, next_sample] : agree_set_samples_->GetSubsetEntries(focus)) {
+    for (auto& [key, next_sample] :
+         agree_set_samples_->GetSubsetEntries(focus.GetColumnIndicesRef())) {
         if (sample == nullptr || next_sample->GetSamplingRatio() > sample->GetSamplingRatio()) {
             sample = next_sample;
         }

--- a/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
@@ -29,8 +29,8 @@ ProfilingContext::ProfilingContext(algos::pyro::Parameters parameters,
     //       что надо переделывать
     if (parameters_.sample_size > 0) {
         auto schema = relation_data_->GetSchema();
-        agree_set_samples_ =
-                std::make_unique<model::BlockingVerticalMap<model::AgreeSetSample>>(schema);
+        agree_set_samples_ = std::make_unique<model::BlockingVerticalMap<model::AgreeSetSample>>(
+                schema->GetNumColumns());
         // TODO: сделать, чтобы при одном потоке agree_set_samples_ =
         // std::make_unique<VerticalMap<AgreeSetSample>>(schema);
         for (model::Index column_index = 0; column_index != schema->GetNumColumns();

--- a/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/profiling_context.cpp
@@ -138,9 +138,10 @@ double ProfilingContext::SetMaximumEntropy(ColumnLayoutRelationData const* relat
 model::AgreeSetSample const* ProfilingContext::CreateFocusedSample(Vertical const& focus,
                                                                    double boost_factor) {
     auto pli = pli_cache_->GetOrCreateFor(focus, this);
-    auto pli_pointer = std::holds_alternative<model::PositionListIndex*>(pli)
-                               ? std::get<model::PositionListIndex*>(pli)
-                               : std::get<std::unique_ptr<model::PositionListIndex>>(pli).get();
+    auto pli_pointer =
+            std::holds_alternative<model::PositionListIndex const*>(pli)
+                    ? std::get<model::PositionListIndex const*>(pli)
+                    : std::get<std::unique_ptr<model::PositionListIndex const>>(pli).get();
     std::unique_ptr<model::ListAgreeSetSample> sample = model::ListAgreeSetSample::CreateFocusedFor(
             relation_data_, focus, pli_pointer, parameters_.sample_size * boost_factor,
             custom_random_);

--- a/src/core/algorithms/fd/pyrocommon/core/profiling_context.h
+++ b/src/core/algorithms/fd/pyrocommon/core/profiling_context.h
@@ -33,7 +33,7 @@ private:
     CustomRandom custom_random_;
 
     model::AgreeSetSample const* CreateColumnFocusedSample(
-            Vertical const& focus, model::PositionListIndex const* restriction_pli,
+            boost::dynamic_bitset<> const& focus, model::PositionListIndex const* restriction_pli,
             double boost_factor);
 
 public:
@@ -46,8 +46,10 @@ public:
                      CacheEvictionMethod const& eviction_method, double caching_method_value);
 
     // Non-const as RandomGenerator state gets changed
-    model::AgreeSetSample const* CreateFocusedSample(Vertical const& focus, double boost_factor);
-    std::shared_ptr<model::AgreeSetSample const> GetAgreeSetSample(Vertical const& focus) const;
+    model::AgreeSetSample const* CreateFocusedSample(boost::dynamic_bitset<> const& focus,
+                                                     double boost_factor);
+    std::shared_ptr<model::AgreeSetSample const> GetAgreeSetSample(
+            boost::dynamic_bitset<> const& focus) const;
 
     model::PLICache* GetPliCache() {
         return pli_cache_.get();

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
@@ -10,7 +10,6 @@
 // delete the object - pass empty deleter [](*) {}
 
 void SearchSpace::Discover() {
-    LOG_TRACE("Discovering in: {}", static_cast<std::string>(*strategy_));
     while (true) {  // на второй итерации дропается
         std::optional<DependencyCandidate> launch_pad = PollLaunchPad();
         if (!launch_pad.has_value()) break;
@@ -156,8 +155,6 @@ void SearchSpace::ReturnLaunchPad(DependencyCandidate const& launch_pad, bool is
 }
 
 bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
-    LOG_DEBUG("===== Ascending from {} ======", strategy_->Format(launch_pad.vertical_));
-
     if (strategy_->ShouldResample(launch_pad.vertical_, sample_boost_)) {
         LOG_TRACE("Resampling.");
         context_->CreateFocusedSample(launch_pad.vertical_, sample_boost_);

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
@@ -1,6 +1,7 @@
 #include "core/algorithms/fd/pyrocommon/core/search_space.h"
 
 #include <queue>
+#include <ranges>
 #include <variant>
 
 #include "core/util/logger.h"
@@ -36,20 +37,22 @@ std::optional<DependencyCandidate> SearchSpace::PollLaunchPad() {
         auto launch_pad = launch_pads_.extract(launch_pads_.begin()).value();
 
         // launchPads_.erase(launchPads_.begin());
-        launch_pad_index_->Remove(launch_pad.vertical_);
+        launch_pad_index_->Remove(launch_pad.vertical_.GetColumnIndicesRef());
 
         if (IsImpliedByMinDep(launch_pad.vertical_, global_visitees_.get()) ||
             (local_visitees_ != nullptr &&
              IsImpliedByMinDep(launch_pad.vertical_, local_visitees_.get()))) {
-            launch_pad_index_->Remove(launch_pad.vertical_);
+            launch_pad_index_->Remove(launch_pad.vertical_.GetColumnIndicesRef());
             LOG_TRACE("* Removing subset-pruned launch pad {{{}}}",
                       launch_pad.vertical_.ToString());
             continue;
         }
 
-        auto superset_entries = global_visitees_->GetSupersetEntries(launch_pad.vertical_);
+        auto superset_entries =
+                global_visitees_->GetSupersetEntries(launch_pad.vertical_.GetColumnIndicesRef());
         if (local_visitees_ != nullptr) {
-            auto local_superset_entries = local_visitees_->GetSupersetEntries(launch_pad.vertical_);
+            auto local_superset_entries =
+                    local_visitees_->GetSupersetEntries(launch_pad.vertical_.GetColumnIndicesRef());
             auto end_iterator =
                     std::remove_if(local_superset_entries.begin(), local_superset_entries.end(),
                                    [](auto& entry) { return !entry.second->IsPruningSubsets(); });
@@ -63,7 +66,7 @@ std::optional<DependencyCandidate> SearchSpace::PollLaunchPad() {
         std::vector<Vertical> superset_verticals;
 
         for (auto& entry : superset_entries) {
-            superset_verticals.push_back(entry.first);
+            superset_verticals.push_back(context_->GetSchema()->GetVertical(entry.first));
         }
 
         EscapeLaunchPad(launch_pad.vertical_, std::move(superset_verticals));
@@ -78,14 +81,14 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
                        return superset.Invert().Without(strategy_->GetIrrelevantColumns());
                    });
 
-    std::function<bool(Vertical const&)> pruning_function =
-            [this, &launch_pad](auto const& hitting_set_candidate) -> bool {
+    auto pruning_function = [this, &launch_pad](auto const& hitting_set_candidate) -> bool {
         if (scope_ != nullptr &&
             scope_->GetAnySupersetEntry(hitting_set_candidate).second == nullptr) {
             return true;
         }
 
-        auto launch_pad_candidate = launch_pad.Union(hitting_set_candidate);
+        auto launch_pad_candidate =
+                launch_pad.Union(context_->GetSchema()->GetVertical(hitting_set_candidate));
 
         if ((local_visitees_ == nullptr &&
              IsImpliedByMinDep(launch_pad_candidate, local_visitees_.get())) ||
@@ -93,7 +96,8 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
             return true;
         }
 
-        if (launch_pad_index_->GetAnySubsetEntry(launch_pad_candidate).second != nullptr) {
+        if (launch_pad_index_->GetAnySubsetEntry(launch_pad_candidate.GetColumnIndicesRef())
+                    .second != nullptr) {
             return true;
         }
 
@@ -128,7 +132,7 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
                   escaped_launch_pad.vertical_.GetArity(), context_->GetParameters().max_lhs);
         if (escaped_launch_pad.vertical_.GetArity() <= context_->GetParameters().max_lhs) {
             launch_pads_.insert(escaped_launch_pad);
-            launch_pad_index_->Put(escaped_launch_pad.vertical_,
+            launch_pad_index_->Put(escaped_launch_pad.vertical_.GetColumnIndicesRef(),
                                    std::make_unique<DependencyCandidate>(escaped_launch_pad));
         }
     }
@@ -136,7 +140,8 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
 
 void SearchSpace::AddLaunchPad(DependencyCandidate const& launch_pad) {
     launch_pads_.insert(launch_pad);
-    launch_pad_index_->Put(launch_pad.vertical_, std::make_unique<DependencyCandidate>(launch_pad));
+    launch_pad_index_->Put(launch_pad.vertical_.GetColumnIndicesRef(),
+                           std::make_unique<DependencyCandidate>(launch_pad));
 }
 
 void SearchSpace::ReturnLaunchPad(DependencyCandidate const& launch_pad, bool is_defer) {
@@ -146,7 +151,8 @@ void SearchSpace::ReturnLaunchPad(DependencyCandidate const& launch_pad, bool is
     } else {
         launch_pads_.insert(launch_pad);
     }
-    launch_pad_index_->Put(launch_pad.vertical_, std::make_unique<DependencyCandidate>(launch_pad));
+    launch_pad_index_->Put(launch_pad.vertical_.GetColumnIndicesRef(),
+                           std::make_unique<DependencyCandidate>(launch_pad));
 }
 
 bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
@@ -172,7 +178,7 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
             error = traversal_candidate.error_.Get();
 
             bool can_be_dependency = *error <= strategy_->max_dependency_error_;
-            local_visitees_->Put(traversal_candidate.vertical_,
+            local_visitees_->Put(traversal_candidate.vertical_.GetColumnIndicesRef(),
                                  std::make_unique<VerticalInfo>(can_be_dependency, false, *error));
             if (can_be_dependency) break;
         } else {
@@ -188,7 +194,7 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
                 // double errorDiff = *error - traversal_candidate.error_.GetMean();
 
                 local_visitees_->Put(
-                        traversal_candidate.vertical_,
+                        traversal_candidate.vertical_.GetColumnIndicesRef(),
                         std::make_unique<VerticalInfo>(error <= strategy_->max_dependency_error_,
                                                        false, *error));
 
@@ -218,7 +224,8 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
             auto extended_vertical =
                     traversal_candidate.vertical_.Union(static_cast<Vertical>(*extension_column));
 
-            if (scope_ != nullptr && scope_->GetSupersetEntries(extended_vertical).empty()) {
+            if (scope_ != nullptr &&
+                scope_->GetSupersetEntries(extended_vertical.GetColumnIndicesRef()).empty()) {
                 continue;
             }
 
@@ -262,7 +269,7 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
         if (recursion_depth_ == 0) {
             assert(scope_ == nullptr);
             global_visitees_->Put(
-                    traversal_candidate.vertical_,
+                    traversal_candidate.vertical_.GetColumnIndicesRef(),
                     std::make_unique<VerticalInfo>(VerticalInfo::ForMinimalDependency()));
         }
 
@@ -271,12 +278,12 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
         if (recursion_depth_ == 0) {
             assert(scope_ == nullptr);
             global_visitees_->Put(
-                    traversal_candidate.vertical_,
+                    traversal_candidate.vertical_.GetColumnIndicesRef(),
                     std::make_unique<VerticalInfo>(VerticalInfo::ForMaximalNonDependency()));
             LOG_DEBUG("[---] {} is maximum non-dependency (err={}).",
                       traversal_candidate.vertical_.ToString(), *error);
         } else {
-            local_visitees_->Put(traversal_candidate.vertical_,
+            local_visitees_->Put(traversal_candidate.vertical_.GetColumnIndicesRef(),
                                  std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
             LOG_DEBUG("      {} is local-maximum non-dependency (err={}).",
                       traversal_candidate.vertical_.ToString(), *error);
@@ -352,19 +359,24 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
     for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
         if (info->is_extremal_ && !global_visitees_->ContainsKey(alleged_min_dep)) {
             LOG_DEBUG("[{}] Minimum dependency: {} (error={})", recursion_depth_,
-                      alleged_min_dep.ToString(), info->error_);
+                      main_peak.GetSchema()->GetVertical(alleged_min_dep).ToString(), info->error_);
             // TODO: Костыль -- info в нескольких местах должен храниться. ХЗ, кому он принадлежит,
             // пока копирую
             global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-            strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
+            strategy_->RegisterDependency(main_peak.GetSchema()->GetVertical(alleged_min_dep),
+                                          info->error_, *context_);
         }
     }
 
     auto alleged_min_deps_set = alleged_min_deps->KeySet();
+    auto to_verticals = alleged_min_deps_set |
+                        std::ranges::views::transform([&](boost::dynamic_bitset<> const& bs) {
+                            return context_->GetSchema()->GetVertical(bs);
+                        });
     // TODO: костыль: CalculateHittingSet needs a list, but KeySet returns an unordered_set
     // ещё и морока с transform и unordered_set - мб вообще в лист переделать.
-    auto alleged_max_non_deps_hs = CalculateHittingSet(
-            std::vector<Vertical>(alleged_min_deps_set.begin(), alleged_min_deps_set.end()));
+    auto alleged_max_non_deps_hs =
+            CalculateHittingSet(std::vector<Vertical>(to_verticals.begin(), to_verticals.end()));
     std::unordered_set<Vertical> alleged_max_non_deps;
 
     for (auto& min_leave_out_vertical : alleged_max_non_deps_hs) {
@@ -378,9 +390,11 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
     //         });
 
     // checking the consistency of all data model
-    if (auto alleged_min_deps_key_set = alleged_min_deps->KeySet(); !std::all_of(
-                alleged_min_deps_key_set.begin(), alleged_min_deps_key_set.end(),
-                [main_peak](auto& vertical) -> bool { return main_peak.Contains(vertical); })) {
+    if (auto alleged_min_deps_key_set = alleged_min_deps->KeySet();
+        !std::all_of(alleged_min_deps_key_set.begin(), alleged_min_deps_key_set.end(),
+                     [main_peak](auto& vertical) -> bool {
+                         return vertical.is_subset_of(main_peak.GetColumnIndicesRef());
+                     })) {
         throw std::runtime_error("Main peak should contain all alleged min dependencies");
     }
     if (!std::all_of(
@@ -407,7 +421,7 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
                   alleged_max_non_dep.ToString(), is_non_dep, error);
         if (is_non_dep) {
             maximal_non_deps.insert(alleged_max_non_dep);
-            local_visitees_->Put(alleged_max_non_dep,
+            local_visitees_->Put(alleged_max_non_dep.GetColumnIndicesRef(),
                                  std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
         } else {
             peaks.emplace_back(alleged_max_non_dep, model::ConfidenceInterval(error), true);
@@ -419,12 +433,15 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
         for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
             if (!info->is_extremal_ && !global_visitees_->ContainsKey(alleged_min_dep)) {
                 LOG_DEBUG("[{}] Minimum dependency: {} (error={})", recursion_depth_,
-                          alleged_min_dep.ToString(), info->error_);
+                          strategy_->context_->GetSchema()->GetVertical(alleged_min_dep).ToString(),
+                          info->error_);
                 // TODO: тут надо сделать non-const - костыльный mutable; опять Info в двух местах
                 // хранится
                 info->is_extremal_ = true;
                 global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-                strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
+                strategy_->RegisterDependency(
+                        strategy_->context_->GetSchema()->GetVertical(alleged_min_dep),
+                        info->error_, *context_);
             }
         }
     } else {
@@ -432,7 +449,8 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
         auto new_scope = std::make_unique<model::VerticalMap<Vertical>>(context_->GetSchema());
         std::sort_heap(peaks.begin(), peaks.end(), peaks_comparator);
         for (auto& peak : peaks) {
-            new_scope->Put(peak.vertical_, std::make_unique<Vertical>(peak.vertical_));
+            new_scope->Put(peak.vertical_.GetColumnIndicesRef(),
+                           std::make_unique<Vertical>(peak.vertical_));
         }
 
         double new_sample_boost = sample_boost_ * sample_boost_;
@@ -448,9 +466,9 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
 
         std::unordered_set<Column> scope_columns;
         for (auto& vertical : scope_verticals) {
-            for (auto column : vertical.GetColumns()) {
-                scope_columns.insert(*column);
-            }
+            util::ForEachIndex(vertical, [&](auto i) {
+                scope_columns.insert(*context_->GetSchema()->GetColumn(i));
+            });
         }
         for (auto& scope_column : scope_columns) {
             LOG_TRACE("CreateDependencyCandidate while building a nested search space");
@@ -468,14 +486,18 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
         local_visitees_ = nested_search_space->MoveOutLocalVisitees();
 
         for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
-            if (!IsImpliedByMinDep(alleged_min_dep, global_visitees_.get())) {
+            if (!IsImpliedByMinDep(context_->GetSchema()->GetVertical(alleged_min_dep),
+                                   global_visitees_.get())) {
                 LOG_DEBUG("[{}] Minimum dependency: {} (error={}) (was right after all)",
-                          recursion_depth_, alleged_min_dep.ToString(), info->error_);
+                          recursion_depth_,
+                          context_->GetSchema()->GetVertical(alleged_min_dep).ToString(),
+                          info->error_);
                 // TODO: тут надо сделать non-const - костыльный mutable; опять Info в двух местах
                 // хранится
                 info->is_extremal_ = true;
                 global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-                strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
+                strategy_->RegisterDependency(context_->GetSchema()->GetVertical(alleged_min_dep),
+                                              info->error_, *context_);
             }
         }
     }
@@ -519,7 +541,7 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
                 do {
                     if (parent_candidate.IsExact()) {
                         local_visitees_->Put(
-                                parent_candidate.vertical_,
+                                parent_candidate.vertical_.GetColumnIndicesRef(),
                                 std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
                     } else {
                         alleged_non_deps.insert(parent_candidate.vertical_);
@@ -559,8 +581,8 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
     if (candidate_error <= strategy->max_dependency_error_) {
         LOG_TRACE("* Found {}-ary minimum dependency candidate: {}",
                   min_dep_candidate.vertical_.GetArity(), std::string(min_dep_candidate));
-        alleged_min_deps->RemoveSupersetEntries(min_dep_candidate.vertical_);
-        alleged_min_deps->Put(min_dep_candidate.vertical_,
+        alleged_min_deps->RemoveSupersetEntries(min_dep_candidate.vertical_.GetColumnIndicesRef());
+        alleged_min_deps->Put(min_dep_candidate.vertical_.GetColumnIndicesRef(),
                               std::make_unique<VerticalInfo>(true, are_all_parents_known_non_deps,
                                                              candidate_error));
         if (are_all_parents_known_non_deps && context_->GetParameters().is_check_estimates) {
@@ -570,7 +592,7 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
     } else {
         LOG_TRACE("* Guessed incorrect {}-ary minimum dependency candidate.",
                   min_dep_candidate.vertical_.GetArity());
-        local_visitees_->Put(min_dep_candidate.vertical_,
+        local_visitees_->Put(min_dep_candidate.vertical_.GetColumnIndicesRef(),
                              std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
 
         if (strategy->ShouldResample(min_dep_candidate.vertical_, boost_factor)) {
@@ -585,39 +607,44 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
 std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(std::vector<Vertical> verticals,
                                                               auto pruning_function) const {
     RelationalSchema const* schema = context_->GetSchema();
-    auto arity_comparer = [](Vertical const& vertical1, Vertical const& vertical2) {
-        return vertical1.GetArity() < vertical2.GetArity();
+    auto arity_comparer = [](boost::dynamic_bitset<> const& vertical1,
+                             boost::dynamic_bitset<> const& vertical2) {
+        return vertical1.count() < vertical2.count();
     };
 
-    std::ranges::sort(verticals, arity_comparer);
+    std::ranges::sort(verticals, [](Vertical const& vertical1, Vertical const& vertical2) {
+        return vertical1.GetArity() < vertical2.GetArity();
+    });
     model::VerticalMap<std::monostate> consolidated_verticals(schema);
     model::VerticalMap<std::monostate> hitting_set(schema);
     // TODO: VerticalMap requires `shared_ptr`s, so using this hack with a dummy pointer here.
     auto dummy_ptr = std::make_shared<std::monostate>();
 
-    hitting_set.Put(schema->CreateEmptyVertical(), dummy_ptr);
+    hitting_set.Put(schema->CreateEmptyVertical().GetColumnIndicesRef(), dummy_ptr);
 
     for (Vertical const& vertical : verticals) {
-        if (consolidated_verticals.GetAnySubsetEntry(vertical).second != nullptr) {
+        if (consolidated_verticals.GetAnySubsetEntry(vertical.GetColumnIndicesRef()).second !=
+            nullptr) {
             continue;
         }
-        consolidated_verticals.Put(vertical, dummy_ptr);
+        consolidated_verticals.Put(vertical.GetColumnIndicesRef(), dummy_ptr);
 
-        std::vector<Vertical> invalid_hitting_set_members =
-                hitting_set.GetSubsetKeys(vertical.Invert());
+        std::vector<boost::dynamic_bitset<>> invalid_hitting_set_members =
+                hitting_set.GetSubsetKeys(vertical.Invert().GetColumnIndicesRef());
         std::ranges::sort(invalid_hitting_set_members, arity_comparer);
 
         for (auto& invalid_hitting_set_member : invalid_hitting_set_members) {
             hitting_set.Remove(invalid_hitting_set_member);
         }
 
-        for (Vertical const& invalid_member : invalid_hitting_set_members) {
+        for (boost::dynamic_bitset<> const& invalid_member : invalid_hitting_set_members) {
             boost::dynamic_bitset<> const& column_indices = vertical.GetColumnIndices();
             for (size_t corrective_column_index = column_indices.find_first();
                  corrective_column_index != boost::dynamic_bitset<>::npos;
                  corrective_column_index = column_indices.find_next(corrective_column_index)) {
                 Column const& corrective_column = *schema->GetColumn(corrective_column_index);
-                Vertical corrected_member = invalid_member.Union(corrective_column);
+                boost::dynamic_bitset<> corrected_member =
+                        boost::dynamic_bitset<>(invalid_member).set(corrective_column.GetIndex());
 
                 if (hitting_set.GetAnySubsetEntry(corrected_member).second == nullptr) {
                     bool is_pruned = pruning_function(corrected_member);
@@ -629,7 +656,11 @@ std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(std::vector<Vertic
         }
         if (hitting_set.IsEmpty()) break;
     }
-    return hitting_set.KeySet();
+    auto to_verticals = hitting_set.KeySet() |
+                        std::ranges::views::transform([&](boost::dynamic_bitset<> const& s) {
+                            return schema->GetVertical(s);
+                        });
+    return {to_verticals.begin(), to_verticals.end()};
 }
 
 std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(
@@ -655,7 +686,7 @@ void SearchSpace::RequireMinimalDependency(DependencyStrategy* strategy,
 
 std::vector<Vertical> SearchSpace::GetSubsetDeps(Vertical const& vertical,
                                                  model::VerticalMap<VerticalInfo>* vertical_infos) {
-    auto subset_entries = vertical_infos->GetSubsetEntries(vertical);
+    auto subset_entries = vertical_infos->GetSubsetEntries(vertical.GetColumnIndicesRef());
     auto subset_entries_end =
             std::remove_if(subset_entries.begin(), subset_entries.end(),
                            [](auto& entry) { return !entry.second->is_dependency_; });
@@ -663,7 +694,7 @@ std::vector<Vertical> SearchSpace::GetSubsetDeps(Vertical const& vertical,
 
     std::transform(subset_entries.begin(), subset_entries_end,
                    std::inserter(subset_deps, subset_deps.begin()),
-                   [](auto& entry) { return entry.first; });
+                   [&](auto& entry) { return vertical.GetSchema()->GetVertical(entry.first); });
 
     return subset_deps;
 }
@@ -672,7 +703,7 @@ bool SearchSpace::IsImpliedByMinDep(Vertical const& vertical,
                                     model::VerticalMap<VerticalInfo>* vertical_infos) {
     // TODO: function<bool(Vertical, ...)> --> function<bool(Vertical&, ...)>
     return vertical_infos
-                   ->GetAnySubsetEntry(vertical,
+                   ->GetAnySubsetEntry(vertical.GetColumnIndicesRef(),
                                        []([[maybe_unused]] auto vertical, auto info) {
                                            return info->is_dependency_ && info->is_extremal_;
                                        })
@@ -682,8 +713,10 @@ bool SearchSpace::IsImpliedByMinDep(Vertical const& vertical,
 bool SearchSpace::IsKnownNonDependency(Vertical const& vertical,
                                        model::VerticalMap<VerticalInfo>* vertical_infos) {
     return vertical_infos
-                   ->GetAnySupersetEntry(vertical, []([[maybe_unused]] auto vertical,
-                                                      auto info) { return !info->is_dependency_; })
+                   ->GetAnySupersetEntry(vertical.GetColumnIndicesRef(),
+                                         []([[maybe_unused]] auto vertical, auto info) {
+                                             return !info->is_dependency_;
+                                         })
                    .second != nullptr;
 }
 

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
@@ -36,22 +36,18 @@ std::optional<DependencyCandidate> SearchSpace::PollLaunchPad() {
         auto launch_pad = launch_pads_.extract(launch_pads_.begin()).value();
 
         // launchPads_.erase(launchPads_.begin());
-        launch_pad_index_->Remove(launch_pad.vertical_.GetColumnIndicesRef());
+        launch_pad_index_->Remove(launch_pad.vertical_);
 
         if (IsImpliedByMinDep(launch_pad.vertical_, global_visitees_.get()) ||
             (local_visitees_ != nullptr &&
              IsImpliedByMinDep(launch_pad.vertical_, local_visitees_.get()))) {
-            launch_pad_index_->Remove(launch_pad.vertical_.GetColumnIndicesRef());
-            LOG_TRACE("* Removing subset-pruned launch pad {{{}}}",
-                      launch_pad.vertical_.ToString());
+            launch_pad_index_->Remove(launch_pad.vertical_);
             continue;
         }
 
-        auto superset_entries =
-                global_visitees_->GetSupersetEntries(launch_pad.vertical_.GetColumnIndicesRef());
+        auto superset_entries = global_visitees_->GetSupersetEntries(launch_pad.vertical_);
         if (local_visitees_ != nullptr) {
-            auto local_superset_entries =
-                    local_visitees_->GetSupersetEntries(launch_pad.vertical_.GetColumnIndicesRef());
+            auto local_superset_entries = local_visitees_->GetSupersetEntries(launch_pad.vertical_);
             auto end_iterator =
                     std::remove_if(local_superset_entries.begin(), local_superset_entries.end(),
                                    [](auto& entry) { return !entry.second->IsPruningSubsets(); });
@@ -60,12 +56,10 @@ std::optional<DependencyCandidate> SearchSpace::PollLaunchPad() {
                           [&superset_entries](auto& entry) { superset_entries.push_back(entry); });
         }
         if (superset_entries.empty()) return launch_pad;
-        LOG_TRACE("* Escaping launch_pad {} from: [UNIMPLEMENTED]",
-                  launch_pad.vertical_.ToString());
-        std::vector<Vertical> superset_verticals;
+        std::vector<boost::dynamic_bitset<>> superset_verticals;
 
         for (auto& entry : superset_entries) {
-            superset_verticals.push_back(context_->GetSchema()->GetVertical(entry.first));
+            superset_verticals.push_back(entry.first);
         }
 
         EscapeLaunchPad(launch_pad.vertical_, std::move(superset_verticals));
@@ -73,12 +67,11 @@ std::optional<DependencyCandidate> SearchSpace::PollLaunchPad() {
 }
 
 // this move looks legit IMO
-void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
-                                  std::vector<Vertical> pruning_supersets) {
-    std::transform(pruning_supersets.begin(), pruning_supersets.end(), pruning_supersets.begin(),
-                   [this](auto& superset) {
-                       return superset.Invert().Without(strategy_->GetIrrelevantColumns());
-                   });
+void SearchSpace::EscapeLaunchPad(boost::dynamic_bitset<> const& launch_pad,
+                                  std::vector<boost::dynamic_bitset<>> pruning_supersets) {
+    std::transform(
+            pruning_supersets.begin(), pruning_supersets.end(), pruning_supersets.begin(),
+            [this](auto& superset) { return ~superset - strategy_->GetIrrelevantColumns(); });
 
     auto pruning_function = [this, &launch_pad](auto const& hitting_set_candidate) -> bool {
         if (scope_ != nullptr &&
@@ -86,8 +79,7 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
             return true;
         }
 
-        auto launch_pad_candidate =
-                launch_pad.Union(context_->GetSchema()->GetVertical(hitting_set_candidate));
+        auto launch_pad_candidate = launch_pad | hitting_set_candidate;
 
         if ((local_visitees_ == nullptr &&
              IsImpliedByMinDep(launch_pad_candidate, local_visitees_.get())) ||
@@ -95,43 +87,25 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
             return true;
         }
 
-        if (launch_pad_index_->GetAnySubsetEntry(launch_pad_candidate.GetColumnIndicesRef())
-                    .second != nullptr) {
+        if (launch_pad_index_->GetAnySubsetEntry(launch_pad_candidate).second != nullptr) {
             return true;
         }
 
         return false;
     };
-    {
-        std::string pruning_supersets_str = "[";
-        for (auto& pruning_superset : pruning_supersets) {
-            pruning_supersets_str += pruning_superset.ToString();
-        }
-        pruning_supersets_str += "]";
-        LOG_TRACE("Escaping {} pruned by {}", launch_pad.ToString(), pruning_supersets_str);
-    }
     auto hitting_set = CalculateHittingSet(std::move(pruning_supersets), pruning_function);
-    {
-        std::string hitting_set_str = "[";
-        for (auto& el : hitting_set) {
-            hitting_set_str += el.ToString();
-        }
-        hitting_set_str += "]";
-        LOG_TRACE("* Evaluated hitting set: {}", hitting_set_str);
-    }
     for (auto& escaping : hitting_set) {
-        auto escaped_launch_pad_vertical = launch_pad.Union(escaping);
+        auto escaped_launch_pad_vertical = launch_pad | escaping;
 
         // assert, который не имплементнуть из-за трансформа
         LOG_TRACE("CreateDependencyCandidate while escaping launch pad");
         DependencyCandidate escaped_launch_pad =
                 strategy_->CreateDependencyCandidate(escaped_launch_pad_vertical);
-        LOG_TRACE("Escaped: {}", escaped_launch_pad_vertical.ToString());
         LOG_DEBUG("Proposed launch pad arity: {} should be <= max_lhs: {}",
-                  escaped_launch_pad.vertical_.GetArity(), context_->GetParameters().max_lhs);
-        if (escaped_launch_pad.vertical_.GetArity() <= context_->GetParameters().max_lhs) {
+                  escaped_launch_pad.vertical_.count(), context_->GetParameters().max_lhs);
+        if (escaped_launch_pad.vertical_.count() <= context_->GetParameters().max_lhs) {
             launch_pads_.insert(escaped_launch_pad);
-            launch_pad_index_->Put(escaped_launch_pad.vertical_.GetColumnIndicesRef(),
+            launch_pad_index_->Put(escaped_launch_pad.vertical_,
                                    std::make_unique<DependencyCandidate>(escaped_launch_pad));
         }
     }
@@ -139,19 +113,16 @@ void SearchSpace::EscapeLaunchPad(Vertical const& launch_pad,
 
 void SearchSpace::AddLaunchPad(DependencyCandidate const& launch_pad) {
     launch_pads_.insert(launch_pad);
-    launch_pad_index_->Put(launch_pad.vertical_.GetColumnIndicesRef(),
-                           std::make_unique<DependencyCandidate>(launch_pad));
+    launch_pad_index_->Put(launch_pad.vertical_, std::make_unique<DependencyCandidate>(launch_pad));
 }
 
 void SearchSpace::ReturnLaunchPad(DependencyCandidate const& launch_pad, bool is_defer) {
     if (is_defer && context_->GetParameters().is_defer_failed_launch_pads) {
         deferred_launch_pads_.push_back(launch_pad);
-        LOG_TRACE("Deferred seed {}", launch_pad.vertical_.ToString());
     } else {
         launch_pads_.insert(launch_pad);
     }
-    launch_pad_index_->Put(launch_pad.vertical_.GetColumnIndicesRef(),
-                           std::make_unique<DependencyCandidate>(launch_pad));
+    launch_pad_index_->Put(launch_pad.vertical_, std::make_unique<DependencyCandidate>(launch_pad));
 }
 
 bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
@@ -164,8 +135,6 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
     boost::optional<double> error;
 
     while (true) {
-        LOG_TRACE("-> {}", traversal_candidate.vertical_.ToString());
-
         if (context_->GetParameters().is_check_estimates) {
             CheckEstimate(strategy_.get(), traversal_candidate);
         }
@@ -175,14 +144,11 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
             error = traversal_candidate.error_.Get();
 
             bool can_be_dependency = *error <= strategy_->max_dependency_error_;
-            local_visitees_->Put(traversal_candidate.vertical_.GetColumnIndicesRef(),
+            local_visitees_->Put(traversal_candidate.vertical_,
                                  std::make_unique<VerticalInfo>(can_be_dependency, false, *error));
             if (can_be_dependency) break;
         } else {
             if (traversal_candidate.error_.GetMin() > strategy_->max_dependency_error_) {
-                LOG_TRACE("Skipping check form {} (estimated error: {}).",
-                          traversal_candidate.vertical_.ToString(),
-                          std::string(traversal_candidate.error_));
                 error.reset();
             } else {
                 error = context_->GetParameters().is_estimate_only
@@ -191,7 +157,7 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
                 // double errorDiff = *error - traversal_candidate.error_.GetMean();
 
                 local_visitees_->Put(
-                        traversal_candidate.vertical_.GetColumnIndicesRef(),
+                        traversal_candidate.vertical_,
                         std::make_unique<VerticalInfo>(error <= strategy_->max_dependency_error_,
                                                        false, *error));
 
@@ -204,25 +170,26 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
             }
         }
 
-        if (traversal_candidate.vertical_.GetArity() >=
+        if (traversal_candidate.vertical_.count() >=
                     context_->GetColumnLayoutRelationData()->GetNumColumns() -
                             strategy_->GetNumIrrelevantColumns() ||
-            traversal_candidate.vertical_.GetArity() >= context_->GetParameters().max_lhs) {
+            traversal_candidate.vertical_.count() >= context_->GetParameters().max_lhs) {
             break;
         }
 
         boost::optional<DependencyCandidate> next_candidate;
         int num_seen_elements = is_ascend_randomly_ ? 1 : -1;
-        for (auto& extension_column : context_->GetSchema()->GetColumns()) {
-            if (traversal_candidate.vertical_.GetColumnIndices()[extension_column->GetIndex()] ||
-                strategy_->IsIrrelevantColumn(*extension_column)) {
+        for (model::Index extension_column_index = 0;
+             extension_column_index != context_->GetSchema()->GetNumColumns();
+             ++extension_column_index) {
+            if (traversal_candidate.vertical_[extension_column_index] ||
+                strategy_->IsIrrelevantColumn(extension_column_index)) {
                 continue;
             }
-            auto extended_vertical =
-                    traversal_candidate.vertical_.Union(static_cast<Vertical>(*extension_column));
+            auto extended_vertical = boost::dynamic_bitset<>(traversal_candidate.vertical_)
+                                             .set(extension_column_index);
 
-            if (scope_ != nullptr &&
-                scope_->GetSupersetEntries(extended_vertical.GetColumnIndicesRef()).empty()) {
+            if (scope_ != nullptr && scope_->GetSupersetEntries(extended_vertical).empty()) {
                 continue;
             }
 
@@ -249,24 +216,19 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
         }
     }
 
-    // std::cout << static_cast<std::string>(traversal_candidate) << std::endl;
-
     if (!error) {
-        LOG_TRACE("Hit ceiling at {}.", traversal_candidate.vertical_.ToString());
         error = strategy_->CalculateError(traversal_candidate.vertical_);
         [[maybe_unused]] double error_diff = *error - traversal_candidate.error_.GetMean();
         LOG_TRACE("Checking candidate... actual error: {}", *error);
     }
 
     if (*error <= strategy_->max_dependency_error_) {
-        LOG_TRACE("Key peak in climbing phase e({})={} -> Need to minimize.",
-                  traversal_candidate.vertical_.ToString(), *error);
         TrickleDown(traversal_candidate.vertical_, *error);
 
         if (recursion_depth_ == 0) {
             assert(scope_ == nullptr);
             global_visitees_->Put(
-                    traversal_candidate.vertical_.GetColumnIndicesRef(),
+                    traversal_candidate.vertical_,
                     std::make_unique<VerticalInfo>(VerticalInfo::ForMinimalDependency()));
         }
 
@@ -275,15 +237,11 @@ bool SearchSpace::Ascend(DependencyCandidate const& launch_pad) {
         if (recursion_depth_ == 0) {
             assert(scope_ == nullptr);
             global_visitees_->Put(
-                    traversal_candidate.vertical_.GetColumnIndicesRef(),
+                    traversal_candidate.vertical_,
                     std::make_unique<VerticalInfo>(VerticalInfo::ForMaximalNonDependency()));
-            LOG_DEBUG("[---] {} is maximum non-dependency (err={}).",
-                      traversal_candidate.vertical_.ToString(), *error);
         } else {
-            local_visitees_->Put(traversal_candidate.vertical_.GetColumnIndicesRef(),
+            local_visitees_->Put(traversal_candidate.vertical_,
                                  std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
-            LOG_DEBUG("      {} is local-maximum non-dependency (err={}).",
-                      traversal_candidate.vertical_.ToString(), *error);
         }
     }
     return false;
@@ -294,10 +252,8 @@ void SearchSpace::CheckEstimate([[maybe_unused]] DependencyStrategy* strategy,
     LOG_DEBUG("Stepped into method 'checkEstimate' - not implemented yet being a debug method\n");
 }
 
-void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error) {
-    LOG_DEBUG("====== Trickling down from {} ======", main_peak.ToString());
-
-    std::unordered_set<Vertical> maximal_non_deps;
+void SearchSpace::TrickleDown(boost::dynamic_bitset<> const& main_peak, double main_peak_error) {
+    std::unordered_set<boost::dynamic_bitset<>> maximal_non_deps;
     auto alleged_min_deps =
             std::make_unique<model::VerticalMap<VerticalInfo>>(context_->GetSchema());
     auto peaks_comparator = [](auto& candidate1, auto& candidate2) -> bool {
@@ -307,7 +263,7 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
     std::make_heap(peaks.begin(), peaks.end(), peaks_comparator);
     peaks.emplace_back(main_peak, model::ConfidenceInterval(main_peak_error), true);
     std::push_heap(peaks.begin(), peaks.end(), peaks_comparator);
-    std::unordered_set<Vertical> alleged_non_deps;
+    std::unordered_set<boost::dynamic_bitset<>> alleged_non_deps;
 
     while (!peaks.empty()) {
         auto peak = peaks.front();
@@ -318,14 +274,14 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
             peaks.pop_back();
 
             auto peak_hitting_set = CalculateHittingSet(std::move(subset_deps));
-            std::unordered_set<Vertical> escaped_peak_verticals;
+            std::unordered_set<boost::dynamic_bitset<>> escaped_peak_verticals;
 
             for (auto& vertical : peak_hitting_set) {
-                escaped_peak_verticals.insert(peak.vertical_.Without(vertical));
+                escaped_peak_verticals.insert(peak.vertical_ - vertical);
             }
 
             for (auto& escaped_peak_vertical : escaped_peak_verticals) {
-                if (escaped_peak_vertical.GetArity() > 0 &&
+                if (escaped_peak_vertical.count() > 0 &&
                     alleged_non_deps.find(escaped_peak_vertical) == alleged_non_deps.end()) {
                     LOG_TRACE("CreateDependencyCandidate as an escaped peak while trickling down");
                     auto escaped_peak = strategy_->CreateDependencyCandidate(escaped_peak_vertical);
@@ -355,29 +311,22 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
 
     for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
         if (info->is_extremal_ && !global_visitees_->ContainsKey(alleged_min_dep)) {
-            LOG_DEBUG("[{}] Minimum dependency: {} (error={})", recursion_depth_,
-                      main_peak.GetSchema()->GetVertical(alleged_min_dep).ToString(), info->error_);
             // TODO: Костыль -- info в нескольких местах должен храниться. ХЗ, кому он принадлежит,
             // пока копирую
             global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-            strategy_->RegisterDependency(main_peak.GetSchema()->GetVertical(alleged_min_dep),
-                                          info->error_, *context_);
+            strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
         }
     }
 
     auto alleged_min_deps_set = alleged_min_deps->KeySet();
-    auto to_verticals = alleged_min_deps_set |
-                        std::ranges::views::transform([&](boost::dynamic_bitset<> const& bs) {
-                            return context_->GetSchema()->GetVertical(bs);
-                        });
     // TODO: костыль: CalculateHittingSet needs a list, but KeySet returns an unordered_set
     // ещё и морока с transform и unordered_set - мб вообще в лист переделать.
-    auto alleged_max_non_deps_hs =
-            CalculateHittingSet(std::vector<Vertical>(to_verticals.begin(), to_verticals.end()));
-    std::unordered_set<Vertical> alleged_max_non_deps;
+    auto alleged_max_non_deps_hs = CalculateHittingSet(std::vector<boost::dynamic_bitset<>>(
+            alleged_min_deps_set.begin(), alleged_min_deps_set.end()));
+    std::unordered_set<boost::dynamic_bitset<>> alleged_max_non_deps;
 
     for (auto& min_leave_out_vertical : alleged_max_non_deps_hs) {
-        alleged_max_non_deps.insert(min_leave_out_vertical.Invert(main_peak));
+        alleged_max_non_deps.insert(min_leave_out_vertical ^ main_peak);
     }
 
     LOG_DEBUG("* {} alleged maximum non-dependencies (UNIMPLEMENTED)", alleged_max_non_deps.size());
@@ -387,21 +336,19 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
     //         });
 
     // checking the consistency of all data model
-    if (auto alleged_min_deps_key_set = alleged_min_deps->KeySet();
-        !std::all_of(alleged_min_deps_key_set.begin(), alleged_min_deps_key_set.end(),
-                     [main_peak](auto& vertical) -> bool {
-                         return vertical.is_subset_of(main_peak.GetColumnIndicesRef());
-                     })) {
+    if (auto alleged_min_deps_key_set = alleged_min_deps->KeySet(); !std::all_of(
+                alleged_min_deps_key_set.begin(), alleged_min_deps_key_set.end(),
+                [main_peak](auto& vertical) -> bool { return vertical.is_subset_of(main_peak); })) {
         throw std::runtime_error("Main peak should contain all alleged min dependencies");
     }
     if (!std::all_of(
                 alleged_max_non_deps.begin(), alleged_max_non_deps.end(),
-                [main_peak](auto& vertical) -> bool { return main_peak.Contains(vertical); })) {
+                [main_peak](auto& vertical) -> bool { return vertical.is_subset_of(main_peak); })) {
         throw std::runtime_error("Main peak should contain all alleged max non-dependencies");
     }
 
     for (auto& alleged_max_non_dep : alleged_max_non_deps) {
-        if (alleged_max_non_dep.GetArity() == 0) continue;
+        if (alleged_max_non_dep.count() == 0) continue;
 
         if (maximal_non_deps.find(alleged_max_non_dep) != maximal_non_deps.end() ||
             IsKnownNonDependency(alleged_max_non_dep, local_visitees_.get()) ||
@@ -414,11 +361,9 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
                         ? strategy_->CreateDependencyCandidate(alleged_max_non_dep).error_.GetMean()
                         : strategy_->CalculateError(alleged_max_non_dep);
         bool is_non_dep = error > strategy_->min_non_dependency_error_;
-        LOG_TRACE("* Alleged maximal non-dependency {}: non-dep?: {}, error: {}",
-                  alleged_max_non_dep.ToString(), is_non_dep, error);
         if (is_non_dep) {
             maximal_non_deps.insert(alleged_max_non_dep);
-            local_visitees_->Put(alleged_max_non_dep.GetColumnIndicesRef(),
+            local_visitees_->Put(alleged_max_non_dep,
                                  std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
         } else {
             peaks.emplace_back(alleged_max_non_dep, model::ConfidenceInterval(error), true);
@@ -429,25 +374,21 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
     if (peaks.empty()) {
         for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
             if (!info->is_extremal_ && !global_visitees_->ContainsKey(alleged_min_dep)) {
-                LOG_DEBUG("[{}] Minimum dependency: {} (error={})", recursion_depth_,
-                          strategy_->context_->GetSchema()->GetVertical(alleged_min_dep).ToString(),
-                          info->error_);
                 // TODO: тут надо сделать non-const - костыльный mutable; опять Info в двух местах
                 // хранится
                 info->is_extremal_ = true;
                 global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-                strategy_->RegisterDependency(
-                        strategy_->context_->GetSchema()->GetVertical(alleged_min_dep),
-                        info->error_, *context_);
+                strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
             }
         }
     } else {
         LOG_DEBUG("* {} new peaks (UNIMPLEMENTED)", peaks.size());
-        auto new_scope = std::make_unique<model::VerticalMap<Vertical>>(context_->GetSchema());
+        auto new_scope = std::make_unique<model::VerticalMap<boost::dynamic_bitset<>>>(
+                context_->GetSchema());
         std::sort_heap(peaks.begin(), peaks.end(), peaks_comparator);
         for (auto& peak : peaks) {
-            new_scope->Put(peak.vertical_.GetColumnIndicesRef(),
-                           std::make_unique<Vertical>(peak.vertical_));
+            new_scope->Put(peak.vertical_,
+                           std::make_unique<boost::dynamic_bitset<>>(peak.vertical_));
         }
 
         double new_sample_boost = sample_boost_ * sample_boost_;
@@ -461,18 +402,15 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
                 sample_boost_ * context_->GetParameters().sample_booster);
         nested_search_space->SetContext(context_);
 
-        std::unordered_set<Column> scope_columns;
+        std::unordered_set<model::Index> scope_columns;
         for (auto& vertical : scope_verticals) {
-            util::ForEachIndex(vertical, [&](auto i) {
-                scope_columns.insert(*context_->GetSchema()->GetColumn(i));
-            });
+            util::ForEachIndex(vertical, [&](auto i) { scope_columns.insert(i); });
         }
         for (auto& scope_column : scope_columns) {
             LOG_TRACE("CreateDependencyCandidate while building a nested search space");
-            // TODO: again problems with conversion: Column* -> Vertical*. If this is too
-            // inefficient, consider refactoring
-            nested_search_space->AddLaunchPad(
-                    strategy_->CreateDependencyCandidate(static_cast<Vertical>(scope_column)));
+            nested_search_space->AddLaunchPad(strategy_->CreateDependencyCandidate(
+                    boost::dynamic_bitset<>(context_->GetSchema()->GetNumColumns())
+                            .set(scope_column)));
         }
         num_nested_++;
         // std::cout << static_cast<std::string>(*strategy_) << ' ';
@@ -483,27 +421,21 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
         local_visitees_ = nested_search_space->MoveOutLocalVisitees();
 
         for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
-            if (!IsImpliedByMinDep(context_->GetSchema()->GetVertical(alleged_min_dep),
-                                   global_visitees_.get())) {
-                LOG_DEBUG("[{}] Minimum dependency: {} (error={}) (was right after all)",
-                          recursion_depth_,
-                          context_->GetSchema()->GetVertical(alleged_min_dep).ToString(),
-                          info->error_);
+            if (!IsImpliedByMinDep(alleged_min_dep, global_visitees_.get())) {
                 // TODO: тут надо сделать non-const - костыльный mutable; опять Info в двух местах
                 // хранится
                 info->is_extremal_ = true;
                 global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
-                strategy_->RegisterDependency(context_->GetSchema()->GetVertical(alleged_min_dep),
-                                              info->error_, *context_);
+                strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
             }
         }
     }
 }
 
-std::optional<Vertical> SearchSpace::TrickleDownFrom(
+std::optional<boost::dynamic_bitset<>> SearchSpace::TrickleDownFrom(
         DependencyCandidate min_dep_candidate, DependencyStrategy* strategy,
         model::VerticalMap<VerticalInfo>* alleged_min_deps,
-        std::unordered_set<Vertical>& alleged_non_deps,
+        std::unordered_set<boost::dynamic_bitset<>>& alleged_non_deps,
         model::VerticalMap<VerticalInfo>* global_visitees, double boost_factor) {
     if (min_dep_candidate.error_.GetMin() > strategy->max_dependency_error_) {
         throw std::runtime_error(
@@ -511,24 +443,30 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
     }
 
     bool are_all_parents_known_non_deps = true;
-    if (min_dep_candidate.vertical_.GetArity() > 1) {
+    if (min_dep_candidate.vertical_.count() > 1) {
         std::priority_queue<DependencyCandidate, std::vector<DependencyCandidate>,
                             std::function<bool(DependencyCandidate&, DependencyCandidate&)>>
                 parent_candidates([](auto& candidate1, auto& candidate2) {
                     return DependencyCandidate::MinErrorComparator(candidate1, candidate2);
                 });
-        for (auto& parent_vertical : min_dep_candidate.vertical_.GetParents()) {
+        auto parent_vertical = min_dep_candidate.vertical_;
+        util::ForEachIndex(parent_vertical, [&](model::Index i) {
+            parent_vertical.reset(i);
             if (IsKnownNonDependency(parent_vertical, local_visitees_.get()) ||
-                IsKnownNonDependency(parent_vertical, global_visitees))
-                continue;
+                IsKnownNonDependency(parent_vertical, global_visitees)) {
+                parent_vertical.set(i);
+                return;
+            }
             if (alleged_non_deps.count(parent_vertical) != 0) {
                 are_all_parents_known_non_deps = false;
-                continue;
+                parent_vertical.set(i);
+                return;
             }
             // TODO: construction methods should return unique_ptr<...>
             LOG_TRACE("CreateDependencyCandidate while trickling down from");
             parent_candidates.push(strategy->CreateDependencyCandidate(parent_vertical));
-        }
+            parent_vertical.set(i);
+        });
 
         while (!parent_candidates.empty()) {
             auto parent_candidate = parent_candidates.top();
@@ -538,7 +476,7 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
                 do {
                     if (parent_candidate.IsExact()) {
                         local_visitees_->Put(
-                                parent_candidate.vertical_.GetColumnIndicesRef(),
+                                parent_candidate.vertical_,
                                 std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
                     } else {
                         alleged_non_deps.insert(parent_candidate.vertical_);
@@ -576,10 +514,8 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
                                      : strategy->CalculateError(min_dep_candidate.vertical_);
     [[maybe_unused]] double error_diff = candidate_error - min_dep_candidate.error_.GetMean();
     if (candidate_error <= strategy->max_dependency_error_) {
-        LOG_TRACE("* Found {}-ary minimum dependency candidate: {}",
-                  min_dep_candidate.vertical_.GetArity(), std::string(min_dep_candidate));
-        alleged_min_deps->RemoveSupersetEntries(min_dep_candidate.vertical_.GetColumnIndicesRef());
-        alleged_min_deps->Put(min_dep_candidate.vertical_.GetColumnIndicesRef(),
+        alleged_min_deps->RemoveSupersetEntries(min_dep_candidate.vertical_);
+        alleged_min_deps->Put(min_dep_candidate.vertical_,
                               std::make_unique<VerticalInfo>(true, are_all_parents_known_non_deps,
                                                              candidate_error));
         if (are_all_parents_known_non_deps && context_->GetParameters().is_check_estimates) {
@@ -588,46 +524,46 @@ std::optional<Vertical> SearchSpace::TrickleDownFrom(
         return min_dep_candidate.vertical_;
     } else {
         LOG_TRACE("* Guessed incorrect {}-ary minimum dependency candidate.",
-                  min_dep_candidate.vertical_.GetArity());
-        local_visitees_->Put(min_dep_candidate.vertical_.GetColumnIndicesRef(),
+                  min_dep_candidate.vertical_.count());
+        local_visitees_->Put(min_dep_candidate.vertical_,
                              std::make_unique<VerticalInfo>(VerticalInfo::ForNonDependency()));
 
         if (strategy->ShouldResample(min_dep_candidate.vertical_, boost_factor)) {
             context_->CreateFocusedSample(min_dep_candidate.vertical_, boost_factor);
         }
-        return std::optional<Vertical>();
+        return std::optional<boost::dynamic_bitset<>>();
     }
 }
 
 // TODO: critical part - consider optimization
 // TODO: list -> vector as list doesn't have RAIterators therefore can't be sorted
-std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(std::vector<Vertical> verticals,
-                                                              auto pruning_function) const {
+std::unordered_set<boost::dynamic_bitset<>> SearchSpace::CalculateHittingSet(
+        std::vector<boost::dynamic_bitset<>> verticals, auto pruning_function) const {
     RelationalSchema const* schema = context_->GetSchema();
     auto arity_comparer = [](boost::dynamic_bitset<> const& vertical1,
                              boost::dynamic_bitset<> const& vertical2) {
         return vertical1.count() < vertical2.count();
     };
 
-    std::ranges::sort(verticals, [](Vertical const& vertical1, Vertical const& vertical2) {
-        return vertical1.GetArity() < vertical2.GetArity();
+    std::ranges::sort(verticals, [](boost::dynamic_bitset<> const& vertical1,
+                                    boost::dynamic_bitset<> const& vertical2) {
+        return vertical1.count() < vertical2.count();
     });
     model::VerticalMap<std::monostate> consolidated_verticals(schema);
     model::VerticalMap<std::monostate> hitting_set(schema);
     // TODO: VerticalMap requires `shared_ptr`s, so using this hack with a dummy pointer here.
     auto dummy_ptr = std::make_shared<std::monostate>();
 
-    hitting_set.Put(schema->CreateEmptyVertical().GetColumnIndicesRef(), dummy_ptr);
+    hitting_set.Put(boost::dynamic_bitset<>(schema->GetNumColumns()), dummy_ptr);
 
-    for (Vertical const& vertical : verticals) {
-        if (consolidated_verticals.GetAnySubsetEntry(vertical.GetColumnIndicesRef()).second !=
-            nullptr) {
+    for (boost::dynamic_bitset<> const& vertical : verticals) {
+        if (consolidated_verticals.GetAnySubsetEntry(vertical).second != nullptr) {
             continue;
         }
-        consolidated_verticals.Put(vertical.GetColumnIndicesRef(), dummy_ptr);
+        consolidated_verticals.Put(vertical, dummy_ptr);
 
         std::vector<boost::dynamic_bitset<>> invalid_hitting_set_members =
-                hitting_set.GetSubsetKeys(vertical.Invert().GetColumnIndicesRef());
+                hitting_set.GetSubsetKeys(~vertical);
         std::ranges::sort(invalid_hitting_set_members, arity_comparer);
 
         for (auto& invalid_hitting_set_member : invalid_hitting_set_members) {
@@ -635,13 +571,11 @@ std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(std::vector<Vertic
         }
 
         for (boost::dynamic_bitset<> const& invalid_member : invalid_hitting_set_members) {
-            boost::dynamic_bitset<> const& column_indices = vertical.GetColumnIndices();
-            for (size_t corrective_column_index = column_indices.find_first();
+            for (size_t corrective_column_index = vertical.find_first();
                  corrective_column_index != boost::dynamic_bitset<>::npos;
-                 corrective_column_index = column_indices.find_next(corrective_column_index)) {
-                Column const& corrective_column = *schema->GetColumn(corrective_column_index);
+                 corrective_column_index = vertical.find_next(corrective_column_index)) {
                 boost::dynamic_bitset<> corrected_member =
-                        boost::dynamic_bitset<>(invalid_member).set(corrective_column.GetIndex());
+                        boost::dynamic_bitset<>(invalid_member).set(corrective_column_index);
 
                 if (hitting_set.GetAnySubsetEntry(corrected_member).second == nullptr) {
                     bool is_pruned = pruning_function(corrected_member);
@@ -653,67 +587,63 @@ std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(std::vector<Vertic
         }
         if (hitting_set.IsEmpty()) break;
     }
-    auto to_verticals = hitting_set.KeySet() |
-                        std::ranges::views::transform([&](boost::dynamic_bitset<> const& s) {
-                            return schema->GetVertical(s);
-                        });
-    return {to_verticals.begin(), to_verticals.end()};
+    return hitting_set.KeySet();
 }
 
-std::unordered_set<Vertical> SearchSpace::CalculateHittingSet(
-        std::vector<Vertical> verticals) const {
+std::unordered_set<boost::dynamic_bitset<>> SearchSpace::CalculateHittingSet(
+        std::vector<boost::dynamic_bitset<>> verticals) const {
     return CalculateHittingSet(std::move(verticals), [](auto&&...) { return false; });
 }
 
 void SearchSpace::RequireMinimalDependency(DependencyStrategy* strategy,
-                                           Vertical const& min_dependency) {
+                                           boost::dynamic_bitset<> const& min_dependency) {
     double error = strategy->CalculateError(min_dependency);
     if (error > strategy->max_dependency_error_) {
         throw std::runtime_error("Wrong minimal dependency estimate");
     }
-    if (min_dependency.GetArity() > 1) {
-        for (auto& parent : min_dependency.GetParents()) {
+    if (min_dependency.count() > 1) {
+        boost::dynamic_bitset<> parent = min_dependency;
+        util::ForEachIndex(min_dependency, [&](model::Index i) {
+            parent.reset(i);
             double parent_error = strategy->CalculateError(parent);
+            parent.set(i);
             if (parent_error <= strategy->min_non_dependency_error_) {
                 throw std::runtime_error("Wrong minimal dependency estimate");
             }
-        }
+        });
     }
 }
 
-std::vector<Vertical> SearchSpace::GetSubsetDeps(Vertical const& vertical,
-                                                 model::VerticalMap<VerticalInfo>* vertical_infos) {
-    auto subset_entries = vertical_infos->GetSubsetEntries(vertical.GetColumnIndicesRef());
+std::vector<boost::dynamic_bitset<>> SearchSpace::GetSubsetDeps(
+        boost::dynamic_bitset<> const& vertical, model::VerticalMap<VerticalInfo>* vertical_infos) {
+    auto subset_entries = vertical_infos->GetSubsetEntries(vertical);
     auto subset_entries_end =
             std::remove_if(subset_entries.begin(), subset_entries.end(),
                            [](auto& entry) { return !entry.second->is_dependency_; });
-    std::vector<Vertical> subset_deps;
+    std::vector<boost::dynamic_bitset<>> subset_deps;
 
     std::transform(subset_entries.begin(), subset_entries_end,
                    std::inserter(subset_deps, subset_deps.begin()),
-                   [&](auto& entry) { return vertical.GetSchema()->GetVertical(entry.first); });
+                   [&](auto& entry) { return entry.first; });
 
     return subset_deps;
 }
 
-bool SearchSpace::IsImpliedByMinDep(Vertical const& vertical,
+bool SearchSpace::IsImpliedByMinDep(boost::dynamic_bitset<> const& vertical,
                                     model::VerticalMap<VerticalInfo>* vertical_infos) {
-    // TODO: function<bool(Vertical, ...)> --> function<bool(Vertical&, ...)>
     return vertical_infos
-                   ->GetAnySubsetEntry(vertical.GetColumnIndicesRef(),
+                   ->GetAnySubsetEntry(vertical,
                                        []([[maybe_unused]] auto vertical, auto info) {
                                            return info->is_dependency_ && info->is_extremal_;
                                        })
                    .second != nullptr;
 }
 
-bool SearchSpace::IsKnownNonDependency(Vertical const& vertical,
+bool SearchSpace::IsKnownNonDependency(boost::dynamic_bitset<> const& vertical,
                                        model::VerticalMap<VerticalInfo>* vertical_infos) {
     return vertical_infos
-                   ->GetAnySupersetEntry(vertical.GetColumnIndicesRef(),
-                                         []([[maybe_unused]] auto vertical, auto info) {
-                                             return !info->is_dependency_;
-                                         })
+                   ->GetAnySupersetEntry(vertical, []([[maybe_unused]] auto vertical,
+                                                      auto info) { return !info->is_dependency_; })
                    .second != nullptr;
 }
 
@@ -723,9 +653,4 @@ void SearchSpace::PrintStats() const {
 
 void SearchSpace::EnsureInitialized() {
     strategy_->EnsureInitialized(this);
-    std::string initialized_launch_pads;
-    for (auto const& pad : launch_pads_) {
-        initialized_launch_pads += std::string(pad) + " ";
-    }
-    LOG_TRACE("Initialized with launch pads: {}", initialized_launch_pads);
 }

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
@@ -349,9 +349,6 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
         }
     }
 
-    LOG_DEBUG("* {} alleged minimum dependencies (UNIMPLEMENTED)", alleged_min_deps->GetSize());
-
-    int num_uncertain_min_deps = 0;
     for (auto& [alleged_min_dep, info] : alleged_min_deps->EntrySet()) {
         if (info->is_extremal_ && !global_visitees_->ContainsKey(alleged_min_dep)) {
             LOG_DEBUG("[{}] Minimum dependency: {} (error={})", recursion_depth_,
@@ -361,13 +358,7 @@ void SearchSpace::TrickleDown(Vertical const& main_peak, double main_peak_error)
             global_visitees_->Put(alleged_min_dep, std::make_unique<VerticalInfo>(*info));
             strategy_->RegisterDependency(alleged_min_dep, info->error_, *context_);
         }
-        if (!info->is_extremal_) {
-            num_uncertain_min_deps++;
-        }
     }
-
-    LOG_DEBUG("* {}/{} alleged minimum dependencies might be non-minimal", num_uncertain_min_deps,
-              alleged_min_deps->GetSize());
 
     auto alleged_min_deps_set = alleged_min_deps->KeySet();
     // TODO: костыль: CalculateHittingSet needs a list, but KeySet returns an unordered_set

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.cpp
@@ -15,8 +15,8 @@ void SearchSpace::Discover() {
         if (!launch_pad.has_value()) break;
 
         if (local_visitees_ == nullptr) {
-            local_visitees_ =
-                    std::make_unique<model::VerticalMap<VerticalInfo>>(context_->GetSchema());
+            local_visitees_ = std::make_unique<model::VerticalMap<VerticalInfo>>(
+                    context_->GetSchema()->GetNumColumns());
         }
 
         bool is_dependency_found = Ascend(*launch_pad);
@@ -254,8 +254,8 @@ void SearchSpace::CheckEstimate([[maybe_unused]] DependencyStrategy* strategy,
 
 void SearchSpace::TrickleDown(boost::dynamic_bitset<> const& main_peak, double main_peak_error) {
     std::unordered_set<boost::dynamic_bitset<>> maximal_non_deps;
-    auto alleged_min_deps =
-            std::make_unique<model::VerticalMap<VerticalInfo>>(context_->GetSchema());
+    auto alleged_min_deps = std::make_unique<model::VerticalMap<VerticalInfo>>(
+            context_->GetSchema()->GetNumColumns());
     auto peaks_comparator = [](auto& candidate1, auto& candidate2) -> bool {
         return DependencyCandidate::ArityComparator(candidate1, candidate2);
     };
@@ -384,7 +384,7 @@ void SearchSpace::TrickleDown(boost::dynamic_bitset<> const& main_peak, double m
     } else {
         LOG_DEBUG("* {} new peaks (UNIMPLEMENTED)", peaks.size());
         auto new_scope = std::make_unique<model::VerticalMap<boost::dynamic_bitset<>>>(
-                context_->GetSchema());
+                context_->GetSchema()->GetNumColumns());
         std::sort_heap(peaks.begin(), peaks.end(), peaks_comparator);
         for (auto& peak : peaks) {
             new_scope->Put(peak.vertical_,
@@ -549,8 +549,8 @@ std::unordered_set<boost::dynamic_bitset<>> SearchSpace::CalculateHittingSet(
                                     boost::dynamic_bitset<> const& vertical2) {
         return vertical1.count() < vertical2.count();
     });
-    model::VerticalMap<std::monostate> consolidated_verticals(schema);
-    model::VerticalMap<std::monostate> hitting_set(schema);
+    model::VerticalMap<std::monostate> consolidated_verticals(schema->GetNumColumns());
+    model::VerticalMap<std::monostate> hitting_set(schema->GetNumColumns());
     // TODO: VerticalMap requires `shared_ptr`s, so using this hack with a dummy pointer here.
     auto dummy_ptr = std::make_shared<std::monostate>();
 

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.h
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.h
@@ -89,7 +89,8 @@ public:
         : strategy_(std::move(strategy)),
           global_visitees_(std::move(global_visitees)),
           launch_pads_(dependency_candidate_comparator),
-          launch_pad_index_(std::make_unique<model::VerticalMap<DependencyCandidate>>(schema)),
+          launch_pad_index_(std::make_unique<model::VerticalMap<DependencyCandidate>>(
+                  schema->GetNumColumns())),
           scope_(std::move(scope)),
           sample_boost_(sample_boost),
           recursion_depth_(recursion_depth),
@@ -99,8 +100,8 @@ public:
                 RelationalSchema const* schema,
                 DependencyCandidateComp const& dependency_candidate_comparator)
         : SearchSpace(id, std::move(strategy), nullptr,
-                      std::make_unique<model::VerticalMap<VerticalInfo>>(schema), schema,
-                      dependency_candidate_comparator, 0, 1) {}
+                      std::make_unique<model::VerticalMap<VerticalInfo>>(schema->GetNumColumns()),
+                      schema, dependency_candidate_comparator, 0, 1) {}
 
     void EnsureInitialized();
     void Discover();

--- a/src/core/algorithms/fd/pyrocommon/core/search_space.h
+++ b/src/core/algorithms/fd/pyrocommon/core/search_space.h
@@ -10,7 +10,6 @@
 #include "core/algorithms/fd/pyrocommon/core/profiling_context.h"
 #include "core/algorithms/fd/pyrocommon/core/vertical_info.h"
 #include "core/model/table/relational_schema.h"
-#include "core/model/table/vertical.h"
 #include "core/model/table/vertical_map.h"
 
 class SearchSpace : public std::enable_shared_from_this<SearchSpace> {
@@ -24,7 +23,7 @@ private:
     std::set<DependencyCandidate, DependencyCandidateComp> launch_pads_;
     std::unique_ptr<model::VerticalMap<DependencyCandidate>> launch_pad_index_;
     std::list<DependencyCandidate> deferred_launch_pads_;
-    std::unique_ptr<model::VerticalMap<Vertical>> scope_;
+    std::unique_ptr<model::VerticalMap<boost::dynamic_bitset<>>> scope_;
     double sample_boost_;
     int recursion_depth_;
     bool is_ascend_randomly_ = false;
@@ -33,23 +32,23 @@ private:
 
     // void Discover(std::unique_ptr<VerticalMap<VerticalInfo>> localVisitees);
     std::optional<DependencyCandidate> PollLaunchPad();
-    void EscapeLaunchPad(Vertical const& hitting_set_candidate,
-                         std::vector<Vertical> pruning_supersets);
+    void EscapeLaunchPad(boost::dynamic_bitset<> const& hitting_set_candidate,
+                         std::vector<boost::dynamic_bitset<>> pruning_supersets);
     void ReturnLaunchPad(DependencyCandidate const& launch_pad, bool is_defer);
 
     bool Ascend(DependencyCandidate const& launch_pad);
     void CheckEstimate(DependencyStrategy* strategy,
                        DependencyCandidate const& traversal_candidate);
-    void TrickleDown(Vertical const& main_peak, double main_peak_error);
-    std::optional<Vertical> TrickleDownFrom(DependencyCandidate min_dep_candidate,
-                                            DependencyStrategy* strategy,
-                                            model::VerticalMap<VerticalInfo>* alleged_min_deps,
-                                            std::unordered_set<Vertical>& alleged_non_deps,
-                                            model::VerticalMap<VerticalInfo>* global_visitees,
-                                            double boost_factor);
-    std::unordered_set<Vertical> CalculateHittingSet(std::vector<Vertical> verticals,
-                                                     auto pruning_function) const;
-    std::unordered_set<Vertical> CalculateHittingSet(std::vector<Vertical> verticals) const;
+    void TrickleDown(boost::dynamic_bitset<> const& main_peak, double main_peak_error);
+    std::optional<boost::dynamic_bitset<>> TrickleDownFrom(
+            DependencyCandidate min_dep_candidate, DependencyStrategy* strategy,
+            model::VerticalMap<VerticalInfo>* alleged_min_deps,
+            std::unordered_set<boost::dynamic_bitset<>>& alleged_non_deps,
+            model::VerticalMap<VerticalInfo>* global_visitees, double boost_factor);
+    std::unordered_set<boost::dynamic_bitset<>> CalculateHittingSet(
+            std::vector<boost::dynamic_bitset<>> verticals, auto pruning_function) const;
+    std::unordered_set<boost::dynamic_bitset<>> CalculateHittingSet(
+            std::vector<boost::dynamic_bitset<>> verticals) const;
 
     // CAREFUL: resets globalVisitees_, therefore SearchSpace could become invalidated
     std::unique_ptr<model::VerticalMap<VerticalInfo>> MoveOutGlobalVisitees() {
@@ -66,12 +65,13 @@ private:
     }
 
     static void RequireMinimalDependency(DependencyStrategy* strategy,
-                                         Vertical const& min_dependency);
-    static std::vector<Vertical> GetSubsetDeps(Vertical const& vertical,
-                                               model::VerticalMap<VerticalInfo>* vertical_infos);
-    static bool IsImpliedByMinDep(Vertical const& vertical,
+                                         boost::dynamic_bitset<> const& min_dependency);
+    static std::vector<boost::dynamic_bitset<>> GetSubsetDeps(
+            boost::dynamic_bitset<> const& vertical,
+            model::VerticalMap<VerticalInfo>* vertical_infos);
+    static bool IsImpliedByMinDep(boost::dynamic_bitset<> const& vertical,
                                   model::VerticalMap<VerticalInfo>* vertical_infos);
-    static bool IsKnownNonDependency(Vertical const& vertical,
+    static bool IsKnownNonDependency(boost::dynamic_bitset<> const& vertical,
                                      model::VerticalMap<VerticalInfo>* vertical_infos);
     static std::string FormatArityHistogram() = delete;
     static std::string FormatArityHistogram(model::VerticalMap<int*>) = delete;
@@ -81,7 +81,7 @@ public:
     int id_;
 
     SearchSpace(int id, std::unique_ptr<DependencyStrategy> strategy,
-                std::unique_ptr<model::VerticalMap<Vertical>> scope,
+                std::unique_ptr<model::VerticalMap<boost::dynamic_bitset<>>> scope,
                 std::unique_ptr<model::VerticalMap<VerticalInfo>> global_visitees,
                 RelationalSchema const* schema,
                 DependencyCandidateComp const& dependency_candidate_comparator, int recursion_depth,

--- a/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.cpp
@@ -11,8 +11,9 @@ namespace model {
 
 using namespace std;
 
-AgreeSetSample::AgreeSetSample(ColumnLayoutRelationData const* relation_data, Vertical focus,
-                               unsigned int sample_size, unsigned long long population_size)
+AgreeSetSample::AgreeSetSample(ColumnLayoutRelationData const* relation_data,
+                               boost::dynamic_bitset<> focus, unsigned int sample_size,
+                               unsigned long long population_size)
     : relation_data_(relation_data),
       focus_(std::move(focus)),
       sample_size_(sample_size),
@@ -25,14 +26,15 @@ double AgreeSetSample::CalculateNonNegativeFraction(double a, double b) {
 }
 
 std::unique_ptr<std::vector<unsigned long long>> AgreeSetSample::GetNumAgreeSupersetsExt(
-        Vertical const& agreement, Vertical const& disagreement) const {
+        boost::dynamic_bitset<> const& agreement,
+        boost::dynamic_bitset<> const& disagreement) const {
     return std::make_unique<std::vector<unsigned long long>>(
             std::vector<unsigned long long>{this->GetNumAgreeSupersets(agreement),
                                             this->GetNumAgreeSupersets(agreement, disagreement)});
 }
 
-double AgreeSetSample::EstimateAgreements(Vertical const& agreement) const {
-    if (!agreement.Contains(this->focus_)) {
+double AgreeSetSample::EstimateAgreements(boost::dynamic_bitset<> const& agreement) const {
+    if (!focus_.is_subset_of(agreement)) {
         throw std::runtime_error("An agreement in estimateAgreements should contain the focus");
     }
 
@@ -42,9 +44,9 @@ double AgreeSetSample::EstimateAgreements(Vertical const& agreement) const {
     return ObservationsToRelationRatio(this->GetNumAgreeSupersets(agreement));
 }
 
-ConfidenceInterval AgreeSetSample::EstimateAgreements(Vertical const& agreement,
+ConfidenceInterval AgreeSetSample::EstimateAgreements(boost::dynamic_bitset<> const& agreement,
                                                       double confidence) const {
-    if (!agreement.Contains(this->focus_)) {
+    if (!focus_.is_subset_of(agreement)) {
         throw std::runtime_error(
                 "An agreement in estimateAgreements with confidence should contain the focus");
     }
@@ -58,10 +60,10 @@ ConfidenceInterval AgreeSetSample::EstimateAgreements(Vertical const& agreement,
     return EstimateGivenNumHits(num_hits, confidence);
 }
 
-ConfidenceInterval AgreeSetSample::EstimateMixed(Vertical const& agreement,
-                                                 Vertical const& disagreement,
+ConfidenceInterval AgreeSetSample::EstimateMixed(boost::dynamic_bitset<> const& agreement,
+                                                 boost::dynamic_bitset<> const& disagreement,
                                                  double confidence) const {
-    if (!agreement.Contains(this->focus_)) {
+    if (!focus_.is_subset_of(agreement)) {
         throw std::runtime_error("An agreement in EstimateMixed should contain the focus");
     }
     if (population_size_ == 0) {

--- a/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.h
+++ b/src/core/algorithms/fd/pyrocommon/model/agree_set_sample.h
@@ -9,7 +9,6 @@
 
 #include "core/algorithms/fd/pyrocommon/model/confidence_interval.h"
 #include "core/model/table/column_layout_relation_data.h"
-#include "core/model/table/vertical.h"
 #include "core/util/custom_random.h"
 
 namespace model {
@@ -17,15 +16,20 @@ namespace model {
 // abstract base class for Agree Set Sample implementations (trie <- not used, list)
 class AgreeSetSample {
 public:
-    virtual unsigned long long GetNumAgreeSupersets(Vertical const& agreement) const = 0;
-    virtual unsigned long long GetNumAgreeSupersets(Vertical const& agreement,
-                                                    Vertical const& disagreement) const = 0;
+    virtual unsigned long long GetNumAgreeSupersets(
+            boost::dynamic_bitset<> const& agreement) const = 0;
+    virtual unsigned long long GetNumAgreeSupersets(
+            boost::dynamic_bitset<> const& agreement,
+            boost::dynamic_bitset<> const& disagreement) const = 0;
     virtual std::unique_ptr<std::vector<unsigned long long>> GetNumAgreeSupersetsExt(
-            Vertical const& agreement, Vertical const& disagreement) const;
+            boost::dynamic_bitset<> const& agreement,
+            boost::dynamic_bitset<> const& disagreement) const;
 
-    double EstimateAgreements(Vertical const& agreement) const;
-    ConfidenceInterval EstimateAgreements(Vertical const& agreement, double confidence) const;
-    ConfidenceInterval EstimateMixed(Vertical const& agreement, Vertical const& disagreement,
+    double EstimateAgreements(boost::dynamic_bitset<> const& agreement) const;
+    ConfidenceInterval EstimateAgreements(boost::dynamic_bitset<> const& agreement,
+                                          double confidence) const;
+    ConfidenceInterval EstimateMixed(boost::dynamic_bitset<> const& agreement,
+                                     boost::dynamic_bitset<> const& disagreement,
                                      double confidence) const;
 
     double GetSamplingRatio() const {
@@ -40,15 +44,15 @@ public:
 
 protected:
     ::ColumnLayoutRelationData const* relation_data_;
-    Vertical focus_;
+    boost::dynamic_bitset<> focus_;
     unsigned int sample_size_;
     unsigned long long population_size_;
-    AgreeSetSample(ColumnLayoutRelationData const* relation_data, Vertical focus,
+    AgreeSetSample(ColumnLayoutRelationData const* relation_data, boost::dynamic_bitset<> focus,
                    unsigned int sample_size, unsigned long long population_size);
 
     template <typename T>
     static std::unique_ptr<T> CreateFocusedFor(ColumnLayoutRelationData const* relation,
-                                               Vertical const& restriction_vertical,
+                                               boost::dynamic_bitset<> const& restriction_vertical,
                                                PositionListIndex const* restriction_pli,
                                                unsigned int sample_size, CustomRandom& random);
 

--- a/src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h
+++ b/src/core/algorithms/fd/pyrocommon/model/agree_set_sample_impl.h
@@ -9,11 +9,10 @@
 namespace model {
 
 template <typename T>
-std::unique_ptr<T> AgreeSetSample::CreateFocusedFor(ColumnLayoutRelationData const* relation,
-                                                    Vertical const& restriction_vertical,
-                                                    PositionListIndex const* restriction_pli,
-                                                    unsigned int sample_size,
-                                                    CustomRandom& random) {
+std::unique_ptr<T> AgreeSetSample::CreateFocusedFor(
+        ColumnLayoutRelationData const* relation,
+        boost::dynamic_bitset<> const& restriction_vertical,
+        PositionListIndex const* restriction_pli, unsigned int sample_size, CustomRandom& random) {
     static_assert(std::is_base_of<AgreeSetSample, T>::value);
     // std::random_device rd;
     // std::mt19937 gen(rd());
@@ -21,14 +20,14 @@ std::unique_ptr<T> AgreeSetSample::CreateFocusedFor(ColumnLayoutRelationData con
 
     boost::dynamic_bitset<> free_column_indices(relation->GetNumColumns());
     free_column_indices.set();
-    free_column_indices &= ~restriction_vertical.GetColumnIndices();
+    free_column_indices &= ~restriction_vertical;
     std::vector<std::reference_wrapper<ColumnData const>> relevant_column_data;
     for (size_t column_index = free_column_indices.find_first();
          column_index != boost::dynamic_bitset<>::npos;
          column_index = free_column_indices.find_next(column_index)) {
         relevant_column_data.emplace_back(relation->GetColumnData(column_index));
     }
-    boost::dynamic_bitset<> agree_set_prototype(restriction_vertical.GetColumnIndices());
+    boost::dynamic_bitset<> agree_set_prototype(restriction_vertical);
     std::unordered_map<boost::dynamic_bitset<>, int> agree_set_counters;
 
     unsigned long long restriction_nep = restriction_pli->GetNepAsLong();

--- a/src/core/algorithms/fd/pyrocommon/model/list_agree_set_sample.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/list_agree_set_sample.cpp
@@ -5,7 +5,8 @@
 namespace model {
 
 std::unique_ptr<ListAgreeSetSample> ListAgreeSetSample::CreateFocusedFor(
-        ColumnLayoutRelationData const* relation, Vertical const& restriction_vertical,
+        ColumnLayoutRelationData const* relation,
+        boost::dynamic_bitset<> const& restriction_vertical,
         PositionListIndex const* restriction_p_li, unsigned int sample_size, CustomRandom& random) {
     return AgreeSetSample::CreateFocusedFor<ListAgreeSetSample>(
             relation, restriction_vertical, restriction_p_li, sample_size, random);
@@ -24,8 +25,8 @@ std::unique_ptr<std::vector<unsigned long long>> ListAgreeSetSample::BitSetToLon
 }
 
 ListAgreeSetSample::ListAgreeSetSample(
-        ColumnLayoutRelationData const* relation, Vertical const& focus, unsigned int sample_size,
-        unsigned long long population_size,
+        ColumnLayoutRelationData const* relation, boost::dynamic_bitset<> const& focus,
+        unsigned int sample_size, unsigned long long population_size,
         std::unordered_map<boost::dynamic_bitset<>, int> const& agree_set_counters)
     : AgreeSetSample(relation, focus, sample_size, population_size) {
     for (auto& el : agree_set_counters) {
@@ -33,10 +34,10 @@ ListAgreeSetSample::ListAgreeSetSample(
     }
 }
 
-unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(Vertical const& agreement) const {
+unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(
+        boost::dynamic_bitset<> const& agreement) const {
     unsigned long long count = 0;
-    std::vector<unsigned long long> min_agree_set =
-            *BitSetToLongLongVector(agreement.GetColumnIndices());
+    std::vector<unsigned long long> min_agree_set = *BitSetToLongLongVector(agreement);
 
     for (auto const& agree_set_counter : agree_set_counters_) {
         std::vector<unsigned long long> agree_set = *agree_set_counter.agree_set;
@@ -57,13 +58,12 @@ unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(Vertical const& agre
     return count;
 }
 
-unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(Vertical const& agreement,
-                                                            Vertical const& disagreement) const {
+unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(
+        boost::dynamic_bitset<> const& agreement,
+        boost::dynamic_bitset<> const& disagreement) const {
     unsigned long long count = 0;
-    std::vector<unsigned long long> min_agree_set =
-            *BitSetToLongLongVector(agreement.GetColumnIndices());
-    std::vector<unsigned long long> min_disagree_set =
-            *BitSetToLongLongVector(disagreement.GetColumnIndices());
+    std::vector<unsigned long long> min_agree_set = *BitSetToLongLongVector(agreement);
+    std::vector<unsigned long long> min_disagree_set = *BitSetToLongLongVector(disagreement);
     // std::cout << "-----------------------------------\n";
     for (auto const& agree_set_counter : agree_set_counters_) {
         /*for (auto const& el : *agree_set_counter.agreeSet_)
@@ -93,21 +93,15 @@ unsigned long long ListAgreeSetSample::GetNumAgreeSupersets(Vertical const& agre
     Entries:
         continue;
     }
-    LOG_DEBUG("AgreeSetSample for {} against {} returned {} ", agreement.ToString(),
-              disagreement.ToString(), count);
-    // std::cout << '\n';
-    //_numQueries
-    //_nanoQueries
     return count;
 }
 
 std::unique_ptr<std::vector<unsigned long long>> ListAgreeSetSample::GetNumAgreeSupersetsExt(
-        Vertical const& agreement, Vertical const& disagreement) const {
+        boost::dynamic_bitset<> const& agreement,
+        boost::dynamic_bitset<> const& disagreement) const {
     unsigned long long count = 0, count_agreements = 0;
-    std::vector<unsigned long long> min_agree_set =
-            *BitSetToLongLongVector(agreement.GetColumnIndices());
-    std::vector<unsigned long long> min_disagree_set =
-            *BitSetToLongLongVector(disagreement.GetColumnIndices());
+    std::vector<unsigned long long> min_agree_set = *BitSetToLongLongVector(agreement);
+    std::vector<unsigned long long> min_disagree_set = *BitSetToLongLongVector(disagreement);
 
     for (auto const& agree_set_counter : agree_set_counters_) {
         std::vector<unsigned long long> agree_set = *agree_set_counter.agree_set;

--- a/src/core/algorithms/fd/pyrocommon/model/list_agree_set_sample.h
+++ b/src/core/algorithms/fd/pyrocommon/model/list_agree_set_sample.h
@@ -26,19 +26,24 @@ public:
             boost::dynamic_bitset<> const& bitset);
 
     static std::unique_ptr<ListAgreeSetSample> CreateFocusedFor(
-            ColumnLayoutRelationData const* relation, Vertical const& restriction_vertical,
+            ColumnLayoutRelationData const* relation,
+            boost::dynamic_bitset<> const& restriction_vertical,
             PositionListIndex const* restriction_p_li, unsigned int sample_size,
             CustomRandom& random);
 
-    ListAgreeSetSample(ColumnLayoutRelationData const* relation, Vertical const& focus,
-                       unsigned int sample_size, unsigned long long population_size,
+    ListAgreeSetSample(ColumnLayoutRelationData const* relation,
+                       boost::dynamic_bitset<> const& focus, unsigned int sample_size,
+                       unsigned long long population_size,
                        std::unordered_map<boost::dynamic_bitset<>, int> const& agree_set_counters);
 
-    unsigned long long GetNumAgreeSupersets(Vertical const& agreement) const override;
-    unsigned long long GetNumAgreeSupersets(Vertical const& agreement,
-                                            Vertical const& disagreement) const override;
+    unsigned long long GetNumAgreeSupersets(
+            boost::dynamic_bitset<> const& agreement) const override;
+    unsigned long long GetNumAgreeSupersets(
+            boost::dynamic_bitset<> const& agreement,
+            boost::dynamic_bitset<> const& disagreement) const override;
     std::unique_ptr<std::vector<unsigned long long>> GetNumAgreeSupersetsExt(
-            Vertical const& agreement, Vertical const& disagreement) const override;
+            boost::dynamic_bitset<> const& agreement,
+            boost::dynamic_bitset<> const& disagreement) const override;
 };
 
 }  // namespace model

--- a/src/core/algorithms/fd/pyrocommon/model/partial_fd.h
+++ b/src/core/algorithms/fd/pyrocommon/model/partial_fd.h
@@ -1,34 +1,25 @@
 #pragma once
 
+#include <boost/dynamic_bitset.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include "core/model/table/column.h"
-#include "core/model/table/vertical.h"
+#include "core/model/index.h"
 
 class PartialFD {
 public:
     double error_;
-    Vertical lhs_;
-    Column rhs_;
+    boost::dynamic_bitset<> lhs_;
+    model::Index rhs_;
     double score_;
 
-    PartialFD(Vertical lhs, Column rhs, double error, double score)
+    PartialFD(boost::dynamic_bitset<> lhs, model::Index rhs, double error, double score)
         : error_(error), lhs_(std::move(lhs)), rhs_(std::move(rhs)), score_(score) {}
-
-    std::string ToIndicesString() const {
-        return lhs_.ToIndicesString() + " - " + rhs_.ToIndicesString();
-    }
-
-    std::string ToString() const {
-        return lhs_.ToString() + "~>" + rhs_.ToString() + boost::lexical_cast<std::string>(error_) +
-               boost::lexical_cast<std::string>(score_);
-    }
 
     double GetError() const {
         return error_;
     }
 
     int GetArity() const {
-        return lhs_.GetColumns().size();
+        return lhs_.count();
     }
 };

--- a/src/core/algorithms/fd/pyrocommon/model/partial_key.h
+++ b/src/core/algorithms/fd/pyrocommon/model/partial_key.h
@@ -1,25 +1,14 @@
 #pragma once
 
+#include <boost/dynamic_bitset.hpp>
 #include <boost/lexical_cast.hpp>
-
-#include "core/model/table/column.h"
-#include "core/model/table/vertical.h"
 
 class PartialKey {
 public:
     double error_;
-    Vertical vertical_;
+    boost::dynamic_bitset<> vertical_;
     double score_;
 
-    PartialKey(Vertical vertical, double error, double score)
+    PartialKey(boost::dynamic_bitset<> vertical, double error, double score)
         : error_(error), vertical_(std::move(vertical)), score_(score) {}
-
-    std::string ToIndicesString() const {
-        return vertical_.ToIndicesString();
-    }
-
-    std::string ToString() const {
-        return vertical_.ToString() + "~>" + boost::lexical_cast<std::string>(error_) +
-               boost::lexical_cast<std::string>(score_);
-    }
 };

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -52,7 +52,6 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
     // is PLI already cached?
     PositionListIndex* pli = Get(vertical);
     if (pli != nullptr) {
-        pli->IncFreq();
         LOG_DEBUG("Served from PLI cache.");
         // addToUsageCounter
         return pli;
@@ -80,7 +79,6 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
     boost::dynamic_bitset<> cover(relation_data_->GetNumColumns());
     boost::dynamic_bitset<> cover_tester(relation_data_->GetNumColumns());
     if (smallest_pli_rank) {
-        smallest_pli_rank->pli_->IncFreq();
         operands.push_back(*smallest_pli_rank);
         cover |= smallest_pli_rank->vertical_->GetColumnIndices();
 
@@ -106,7 +104,6 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
             }
 
             if (best_rank) {
-                best_rank->pli_->IncFreq();
                 operands.push_back(*best_rank);
                 cover |= best_rank->vertical_->GetColumnIndices();
             }
@@ -121,7 +118,6 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
             vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
             auto column_pli = index_->Get(**vertical_columns.rbegin());
             operands.emplace_back(vertical_columns.rbegin()->get(), column_pli, 1);
-            column_pli->IncFreq();
         }
     }
     // sort operands by ascending order

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -5,10 +5,23 @@
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
+namespace {
+class PositionListIndexRank {
+public:
+    boost::dynamic_bitset<> const* vertical_;
+    std::shared_ptr<model::PositionListIndex const> pli_;
+    int added_arity_;
+
+    PositionListIndexRank(boost::dynamic_bitset<> const* vertical,
+                          std::shared_ptr<model::PositionListIndex const> pli, int initial_arity)
+        : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
+};
+}  // namespace
+
 namespace model {
 
 PositionListIndex const* PLICache::Get(Vertical const& vertical) {
-    return index_->Get(vertical).get();
+    return index_->Get(vertical.GetColumnIndicesRef()).get();
 }
 
 PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod caching_method,
@@ -31,7 +44,7 @@ PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod cachin
       median_gini_(median_gini),
       median_inverted_entropy_(median_inverted_entropy) {
     for (auto& column_ptr : relation_data->GetSchema()->GetColumns()) {
-        index_->Put(static_cast<Vertical>(*column_ptr),
+        index_->Put(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef(),
                     relation_data->GetColumnData(column_ptr->GetIndex()).GetPliOwnership());
     }
 }
@@ -39,7 +52,7 @@ PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod cachin
 PLICache::~PLICache() {
     for (auto& column_ptr : relation_data_->GetSchema()->GetColumns()) {
         // auto PLI =
-        index_->Remove(static_cast<Vertical>(*column_ptr));
+        index_->Remove(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef());
         // relation_data_->GetColumnData(column_ptr->getIndex()).getPLI(std::move(PLI));
     }
 }
@@ -57,12 +70,12 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
         return pli;
     }
     // look for cached PLIs to construct the requested one
-    auto subset_entries = index_->GetSubsetEntries(vertical);
+    auto subset_entries = index_->GetSubsetEntries(vertical.GetColumnIndicesRef());
     boost::optional<PositionListIndexRank> smallest_pli_rank;
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
     for (auto& [sub_vertical, sub_pli_ptr] : subset_entries) {
-        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.GetArity());
+        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.count());
         ranks.push_back(pli_rank);
         if (!smallest_pli_rank || smallest_pli_rank->pli_->GetSize() > pli_rank.pli_->GetSize() ||
             (smallest_pli_rank->pli_->GetSize() == pli_rank.pli_->GetSize() &&
@@ -77,7 +90,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
     boost::dynamic_bitset<> cover_tester(relation_data_->GetNumColumns());
     if (smallest_pli_rank) {
         operands.push_back(*smallest_pli_rank);
-        cover |= smallest_pli_rank->vertical_->GetColumnIndices();
+        cover |= *smallest_pli_rank->vertical_;
 
         while (cover.count() < vertical.GetArity() && !ranks.empty()) {
             boost::optional<PositionListIndexRank> best_rank;
@@ -85,7 +98,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
             ranks.erase(std::remove_if(ranks.begin(), ranks.end(),
                                        [&cover_tester, &cover](auto& rank) {
                                            cover_tester.reset();
-                                           cover_tester |= rank.vertical_->GetColumnIndices();
+                                           cover_tester |= *rank.vertical_;
                                            cover_tester -= cover;
                                            rank.added_arity_ = cover_tester.count();
                                            return rank.added_arity_ < 2;
@@ -102,7 +115,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
 
             if (best_rank) {
                 operands.push_back(*best_rank);
-                cover |= best_rank->vertical_->GetColumnIndices();
+                cover |= *best_rank->vertical_;
             }
         }
     }
@@ -113,8 +126,9 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
     for (auto& column : vertical.GetColumns()) {
         if (!cover[column->GetIndex()]) {
             vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
-            auto column_pli = index_->Get(**vertical_columns.rbegin());
-            operands.emplace_back(vertical_columns.rbegin()->get(), column_pli, 1);
+            auto column_pli = index_->Get((**vertical_columns.rbegin()).GetColumnIndicesRef());
+            operands.emplace_back(&(**vertical_columns.rbegin()).GetColumnIndicesRef(), column_pli,
+                                  1);
         }
     }
     // sort operands by ascending order
@@ -136,15 +150,19 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
     if (operands.size() >= profiling_context->GetParameters().nary_intersection_size) {
         PositionListIndexRank base_pli_rank = operands[0];
         auto intersection_pli = base_pli_rank.pli_->ProbeAll(
-                vertical.Without(*base_pli_rank.vertical_), *relation_data_);
+                vertical.Without(
+                        relation_data_->GetSchema()->GetVertical(*base_pli_rank.vertical_)),
+                *relation_data_);
         variant_intersection_pli =
                 CachingProcess(vertical, std::move(intersection_pli), profiling_context);
     } else {
-        Vertical current_vertical = *operands.begin()->vertical_;
+        Vertical current_vertical =
+                relation_data_->GetSchema()->GetVertical(*operands.begin()->vertical_);
         variant_intersection_pli = operands.begin()->pli_.get();
 
         for (size_t i = 1; i < operands.size(); i++) {
-            current_vertical = current_vertical.Union(*operands[i].vertical_);
+            current_vertical = current_vertical.Union(
+                    relation_data_->GetSchema()->GetVertical(*operands[i].vertical_));
             variant_intersection_pli =
                     std::holds_alternative<PositionListIndex const*>(variant_intersection_pli)
                             ? std::get<PositionListIndex const*>(variant_intersection_pli)
@@ -174,7 +192,7 @@ PLICache::CachingProcess(Vertical const& vertical, std::unique_ptr<PositionListI
         case CachingMethod::kCoin:
             if (profiling_context->NextDouble() <
                 profiling_context->GetParameters().caching_probability) {
-                index_->Put(vertical, std::move(pli));
+                index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
                 return pli_pointer;
             } else {
                 return pli;
@@ -182,7 +200,7 @@ PLICache::CachingProcess(Vertical const& vertical, std::unique_ptr<PositionListI
         case CachingMethod::kNoCaching:
             return pli;
         case CachingMethod::kAllCaching:
-            index_->Put(vertical, std::move(pli));
+            index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
             return pli_pointer;
         default:
             throw std::runtime_error(

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -62,10 +62,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
     for (auto& [sub_vertical, sub_pli_ptr] : subset_entries) {
-        // TODO: избавиться от таких const_cast, которые сбрасывают константность
-        PositionListIndexRank pli_rank(&sub_vertical,
-                                       std::const_pointer_cast<PositionListIndex>(sub_pli_ptr),
-                                       sub_vertical.GetArity());
+        PositionListIndexRank pli_rank(&sub_vertical, sub_pli_ptr, sub_vertical.GetArity());
         ranks.push_back(pli_rank);
         if (!smallest_pli_rank || smallest_pli_rank->pli_->GetSize() > pli_rank.pli_->GetSize() ||
             (smallest_pli_rank->pli_->GetSize() == pli_rank.pli_->GetSize() &&

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -34,7 +34,7 @@ PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod cachin
       // index_(std::make_unique<VerticalMap<PositionListIndex>>(relation_data->GetSchema())) при
       // одном потоке
       index_(std::make_unique<BlockingVerticalMap<PositionListIndex const>>(
-              relation_data->GetSchema())),
+              relation_data->GetSchema()->GetNumColumns())),
       caching_method_(caching_method),
       eviction_method_(eviction_method),
       caching_method_value_(caching_method_value),

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -7,7 +7,7 @@
 
 namespace model {
 
-PositionListIndex* PLICache::Get(Vertical const& vertical) {
+PositionListIndex const* PLICache::Get(Vertical const& vertical) {
     return index_->Get(vertical).get();
 }
 
@@ -19,7 +19,8 @@ PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod cachin
       // TODO: сделать
       // index_(std::make_unique<VerticalMap<PositionListIndex>>(relation_data->GetSchema())) при
       // одном потоке
-      index_(std::make_unique<BlockingVerticalMap<PositionListIndex>>(relation_data->GetSchema())),
+      index_(std::make_unique<BlockingVerticalMap<PositionListIndex const>>(
+              relation_data->GetSchema())),
       caching_method_(caching_method),
       eviction_method_(eviction_method),
       caching_method_value_(caching_method_value),
@@ -44,16 +45,15 @@ PLICache::~PLICache() {
 }
 
 // obtains or calculates a PositionListIndex using cache
-std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::GetOrCreateFor(
-        Vertical const& vertical, ProfilingContext* profiling_context) {
+std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>>
+PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_context) {
     std::scoped_lock lock(getting_pli_mutex_);
     LOG_DEBUG("PLI for {} requested: ", vertical.ToString());
 
     // is PLI already cached?
-    PositionListIndex* pli = Get(vertical);
+    PositionListIndex const* pli = Get(vertical);
     if (pli != nullptr) {
         LOG_DEBUG("Served from PLI cache.");
-        // addToUsageCounter
         return pli;
     }
     // look for cached PLIs to construct the requested one
@@ -134,7 +134,8 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
     // TODO: тут не очень понятно: CachingProcess может забрать себе PLI, а может и отдать обратно,
     //  поэтому приходится через variant разбирать. Проверить, насколько много платим за обёртку.
     // Intersect and cache
-    std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> variant_intersection_pli;
+    std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>>
+            variant_intersection_pli;
     if (operands.size() >= profiling_context->GetParameters().nary_intersection_size) {
         PositionListIndexRank base_pli_rank = operands[0];
         auto intersection_pli = base_pli_rank.pli_->ProbeAll(
@@ -148,16 +149,17 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
         for (size_t i = 1; i < operands.size(); i++) {
             current_vertical = current_vertical.Union(*operands[i].vertical_);
             variant_intersection_pli =
-                    std::holds_alternative<PositionListIndex*>(variant_intersection_pli)
-                            ? std::get<PositionListIndex*>(variant_intersection_pli)
+                    std::holds_alternative<PositionListIndex const*>(variant_intersection_pli)
+                            ? std::get<PositionListIndex const*>(variant_intersection_pli)
                                       ->Intersect(operands[i].pli_.get())
-                            : std::get<std::unique_ptr<PositionListIndex>>(variant_intersection_pli)
+                            : std::get<std::unique_ptr<PositionListIndex const>>(
+                                      variant_intersection_pli)
                                       ->Intersect(operands[i].pli_.get());
-            variant_intersection_pli = CachingProcess(
-                    current_vertical,
-                    std::move(
-                            std::get<std::unique_ptr<PositionListIndex>>(variant_intersection_pli)),
-                    profiling_context);
+            variant_intersection_pli =
+                    CachingProcess(current_vertical,
+                                   std::move(std::get<std::unique_ptr<PositionListIndex const>>(
+                                           variant_intersection_pli)),
+                                   profiling_context);
         }
     }
 
@@ -167,9 +169,9 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
     return variant_intersection_pli;
 }
 
-std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::CachingProcess(
-        Vertical const& vertical, std::unique_ptr<PositionListIndex> pli,
-        ProfilingContext* profiling_context) {
+std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>>
+PLICache::CachingProcess(Vertical const& vertical, std::unique_ptr<PositionListIndex const> pli,
+                         ProfilingContext* profiling_context) {
     auto pli_pointer = pli.get();
     switch (caching_method_) {
         case CachingMethod::kCoin:

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/optional.hpp>
 
+#include "core/model/index.h"
 #include "core/model/table/vertical_map.h"
 #include "core/util/logger.h"
 
@@ -20,8 +21,8 @@ public:
 
 namespace model {
 
-PositionListIndex const* PLICache::Get(Vertical const& vertical) {
-    return index_->Get(vertical.GetColumnIndicesRef()).get();
+PositionListIndex const* PLICache::Get(boost::dynamic_bitset<> const& vertical) {
+    return index_->Get(vertical).get();
 }
 
 PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod caching_method,
@@ -43,25 +44,27 @@ PLICache::PLICache(ColumnLayoutRelationData* relation_data, CachingMethod cachin
       median_entropy_(median_entropy),
       median_gini_(median_gini),
       median_inverted_entropy_(median_inverted_entropy) {
-    for (auto& column_ptr : relation_data->GetSchema()->GetColumns()) {
-        index_->Put(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef(),
-                    relation_data->GetColumnData(column_ptr->GetIndex()).GetPliOwnership());
+    for (model::Index column_index = 0;
+         column_index != relation_data_->GetSchema()->GetNumColumns(); ++column_index) {
+        index_->Put(boost::dynamic_bitset<>(relation_data_->GetSchema()->GetNumColumns())
+                            .set(column_index),
+                    relation_data->GetColumnData(column_index).GetPliOwnership());
     }
 }
 
 PLICache::~PLICache() {
-    for (auto& column_ptr : relation_data_->GetSchema()->GetColumns()) {
-        // auto PLI =
-        index_->Remove(static_cast<Vertical>(*column_ptr).GetColumnIndicesRef());
-        // relation_data_->GetColumnData(column_ptr->getIndex()).getPLI(std::move(PLI));
+    for (model::Index column_index = 0;
+         column_index != relation_data_->GetSchema()->GetNumColumns(); ++column_index) {
+        index_->Remove(boost::dynamic_bitset<>(relation_data_->GetSchema()->GetNumColumns())
+                               .set(column_index));
     }
 }
 
 // obtains or calculates a PositionListIndex using cache
 std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>>
-PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_context) {
+PLICache::GetOrCreateFor(boost::dynamic_bitset<> const& vertical,
+                         ProfilingContext* profiling_context) {
     std::scoped_lock lock(getting_pli_mutex_);
-    LOG_DEBUG("PLI for {} requested: ", vertical.ToString());
 
     // is PLI already cached?
     PositionListIndex const* pli = Get(vertical);
@@ -70,7 +73,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
         return pli;
     }
     // look for cached PLIs to construct the requested one
-    auto subset_entries = index_->GetSubsetEntries(vertical.GetColumnIndicesRef());
+    auto subset_entries = index_->GetSubsetEntries(vertical);
     boost::optional<PositionListIndexRank> smallest_pli_rank;
     std::vector<PositionListIndexRank> ranks;
     ranks.reserve(subset_entries.size());
@@ -92,7 +95,7 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
         operands.push_back(*smallest_pli_rank);
         cover |= *smallest_pli_rank->vertical_;
 
-        while (cover.count() < vertical.GetArity() && !ranks.empty()) {
+        while (cover.count() < vertical.count() && !ranks.empty()) {
             boost::optional<PositionListIndexRank> best_rank;
             // erase ranks with low added_arity_
             ranks.erase(std::remove_if(ranks.begin(), ranks.end(),
@@ -120,16 +123,16 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
         }
     }
 
-    // TODO: конкретные костыли, надо делать Column : Vertical
-    std::vector<std::unique_ptr<Vertical>> vertical_columns;
+    std::vector<boost::dynamic_bitset<>> vertical_columns;
 
-    for (auto& column : vertical.GetColumns()) {
-        if (!cover[column->GetIndex()]) {
-            vertical_columns.push_back(std::make_unique<Vertical>(static_cast<Vertical>(*column)));
-            auto column_pli = index_->Get((**vertical_columns.rbegin()).GetColumnIndicesRef());
-            operands.emplace_back(&(**vertical_columns.rbegin()).GetColumnIndicesRef(), column_pli,
-                                  1);
-        }
+    util::ForEachIndex(vertical, [&](model::Index column_index) {
+        if (cover.test(column_index)) return;
+        vertical_columns.push_back(
+                boost::dynamic_bitset<>(relation_data_->GetNumColumns()).set(column_index));
+    });
+    for (boost::dynamic_bitset<> const& vertical : vertical_columns) {
+        auto column_pli = index_->Get(vertical);
+        operands.emplace_back(&vertical, std::move(column_pli), 1);
     }
     // sort operands by ascending order
     std::sort(operands.begin(), operands.end(),
@@ -149,20 +152,16 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
             variant_intersection_pli;
     if (operands.size() >= profiling_context->GetParameters().nary_intersection_size) {
         PositionListIndexRank base_pli_rank = operands[0];
-        auto intersection_pli = base_pli_rank.pli_->ProbeAll(
-                vertical.Without(
-                        relation_data_->GetSchema()->GetVertical(*base_pli_rank.vertical_)),
-                *relation_data_);
+        auto intersection_pli =
+                base_pli_rank.pli_->ProbeAll(vertical - *base_pli_rank.vertical_, *relation_data_);
         variant_intersection_pli =
                 CachingProcess(vertical, std::move(intersection_pli), profiling_context);
     } else {
-        Vertical current_vertical =
-                relation_data_->GetSchema()->GetVertical(*operands.begin()->vertical_);
+        boost::dynamic_bitset<> current_vertical = *operands.begin()->vertical_;
         variant_intersection_pli = operands.begin()->pli_.get();
 
         for (size_t i = 1; i < operands.size(); i++) {
-            current_vertical = current_vertical.Union(
-                    relation_data_->GetSchema()->GetVertical(*operands[i].vertical_));
+            current_vertical |= *operands[i].vertical_;
             variant_intersection_pli =
                     std::holds_alternative<PositionListIndex const*>(variant_intersection_pli)
                             ? std::get<PositionListIndex const*>(variant_intersection_pli)
@@ -179,20 +178,21 @@ PLICache::GetOrCreateFor(Vertical const& vertical, ProfilingContext* profiling_c
     }
 
     LOG_DEBUG("Calculated from {} sub-PLIs (saved {} intersections).", operands.size(),
-              (vertical.GetArity() - operands.size()));
+              (vertical.count() - operands.size()));
 
     return variant_intersection_pli;
 }
 
 std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>>
-PLICache::CachingProcess(Vertical const& vertical, std::unique_ptr<PositionListIndex const> pli,
+PLICache::CachingProcess(boost::dynamic_bitset<> const& vertical,
+                         std::unique_ptr<PositionListIndex const> pli,
                          ProfilingContext* profiling_context) {
     auto pli_pointer = pli.get();
     switch (caching_method_) {
         case CachingMethod::kCoin:
             if (profiling_context->NextDouble() <
                 profiling_context->GetParameters().caching_probability) {
-                index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
+                index_->Put(vertical, std::move(pli));
                 return pli_pointer;
             } else {
                 return pli;
@@ -200,7 +200,7 @@ PLICache::CachingProcess(Vertical const& vertical, std::unique_ptr<PositionListI
         case CachingMethod::kNoCaching:
             return pli;
         case CachingMethod::kAllCaching:
-            index_->Put(vertical.GetColumnIndicesRef(), std::move(pli));
+            index_->Put(vertical, std::move(pli));
             return pli_pointer;
         default:
             throw std::runtime_error(

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.cpp
@@ -167,10 +167,6 @@ std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::G
     return variant_intersection_pli;
 }
 
-size_t PLICache::Size() const {
-    return index_->GetSize();
-}
-
 std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> PLICache::CachingProcess(
         Vertical const& vertical, std::unique_ptr<PositionListIndex> pli,
         ProfilingContext* profiling_context) {

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
@@ -38,7 +38,7 @@ private:
     MAYBE_UNUSED_PRIVATE_FIELD double median_inverted_entropy_;
 
     std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>> CachingProcess(
-            Vertical const& vertical, std::unique_ptr<PositionListIndex const> pli,
+            boost::dynamic_bitset<> const& vertical, std::unique_ptr<PositionListIndex const> pli,
             ProfilingContext* profiling_context);
 
 public:
@@ -47,9 +47,9 @@ public:
              double mean_entropy, double median_entropy, double maximum_entropy, double median_gini,
              double median_inverted_entropy);
 
-    PositionListIndex const* Get(Vertical const& vertical);
+    PositionListIndex const* Get(boost::dynamic_bitset<> const& vertical);
     std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>> GetOrCreateFor(
-            Vertical const& vertical, ProfilingContext* profiling_context);
+            boost::dynamic_bitset<> const& vertical, ProfilingContext* profiling_context);
 
     void SetMaximumEntropy(double e) {
         maximum_entropy_ = e;

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
@@ -14,17 +14,6 @@ namespace model {
 
 class PLICache {
 private:
-    class PositionListIndexRank {
-    public:
-        Vertical const* vertical_;
-        std::shared_ptr<PositionListIndex const> pli_;
-        int added_arity_;
-
-        PositionListIndexRank(Vertical const* vertical,
-                              std::shared_ptr<PositionListIndex const> pli, int initial_arity)
-            : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
-    };
-
     ColumnLayoutRelationData* relation_data_;
     std::unique_ptr<VerticalMap<PositionListIndex const>> index_;
     // usageCounter - for parallelism

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
@@ -67,8 +67,6 @@ public:
         maximum_entropy_ = e;
     }
 
-    size_t Size() const;
-
     // returns ownership of single column PLIs back to ColumnLayoutRelationData
     virtual ~PLICache();
 };

--- a/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
+++ b/src/core/algorithms/fd/pyrocommon/model/pli_cache.h
@@ -17,17 +17,16 @@ private:
     class PositionListIndexRank {
     public:
         Vertical const* vertical_;
-        std::shared_ptr<PositionListIndex> pli_;
+        std::shared_ptr<PositionListIndex const> pli_;
         int added_arity_;
 
-        PositionListIndexRank(Vertical const* vertical, std::shared_ptr<PositionListIndex> pli,
-                              int initial_arity)
+        PositionListIndexRank(Vertical const* vertical,
+                              std::shared_ptr<PositionListIndex const> pli, int initial_arity)
             : vertical_(vertical), pli_(pli), added_arity_(initial_arity) {}
     };
 
-    // using CacheMap = VerticalMap<PositionListIndex>;
     ColumnLayoutRelationData* relation_data_;
-    std::unique_ptr<VerticalMap<PositionListIndex>> index_;
+    std::unique_ptr<VerticalMap<PositionListIndex const>> index_;
     // usageCounter - for parallelism
 
     // All these MAYBE_UNUSED_PRIVATE_FIELD variables are required to support Pyro's caching
@@ -49,8 +48,8 @@ private:
     MAYBE_UNUSED_PRIVATE_FIELD double median_gini_;
     MAYBE_UNUSED_PRIVATE_FIELD double median_inverted_entropy_;
 
-    std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> CachingProcess(
-            Vertical const& vertical, std::unique_ptr<PositionListIndex> pli,
+    std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>> CachingProcess(
+            Vertical const& vertical, std::unique_ptr<PositionListIndex const> pli,
             ProfilingContext* profiling_context);
 
 public:
@@ -59,8 +58,8 @@ public:
              double mean_entropy, double median_entropy, double maximum_entropy, double median_gini,
              double median_inverted_entropy);
 
-    PositionListIndex* Get(Vertical const& vertical);
-    std::variant<PositionListIndex*, std::unique_ptr<PositionListIndex>> GetOrCreateFor(
+    PositionListIndex const* Get(Vertical const& vertical);
+    std::variant<PositionListIndex const*, std::unique_ptr<PositionListIndex const>> GetOrCreateFor(
             Vertical const& vertical, ProfilingContext* profiling_context);
 
     void SetMaximumEntropy(double e) {

--- a/src/core/algorithms/ucc/hyucc/validator.cpp
+++ b/src/core/algorithms/ucc/hyucc/validator.cpp
@@ -8,6 +8,7 @@
 #include "core/algorithms/fd/hycommon/efficiency_threshold.h"
 #include "core/algorithms/fd/hycommon/validator_helpers.h"
 #include "core/algorithms/ucc/hyucc/model/ucc_tree_vertex.h"
+#include "core/util/bitset_utils.h"
 
 namespace {
 

--- a/src/core/model/table/dynamic_position_list_index.cpp
+++ b/src/core/model/table/dynamic_position_list_index.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <stack>
+#include <unordered_set>
 #include <utility>
 
 #include <boost/dynamic_bitset.hpp>

--- a/src/core/model/table/dynamic_position_list_index.h
+++ b/src/core/model/table/dynamic_position_list_index.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "core/algorithms/cind/condition_miners/position_lists_set.h"
-#include "core/model/table/column.h"
 
 class ColumnLayoutRelationData;
 

--- a/src/core/model/table/position_list_index.cpp
+++ b/src/core/model/table/position_list_index.cpp
@@ -184,7 +184,7 @@ std::unique_ptr<PositionListIndex> PositionListIndex::Probe(
 }
 
 std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
-        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) {
+        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) const {
     assert(this->relation_size_ == relation_data.GetNumRows());
     std::deque<std::vector<int>> new_index;
     unsigned int new_size = 0;

--- a/src/core/model/table/position_list_index.cpp
+++ b/src/core/model/table/position_list_index.cpp
@@ -15,7 +15,6 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "core/model/table/column_layout_relation_data.h"
-#include "core/model/table/vertical.h"
 #include "core/util/logger.h"
 
 namespace model {
@@ -227,11 +226,6 @@ std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
                                                this->relation_size_, this->relation_size_);
 }
 
-std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
-        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) const {
-    return ProbeAll(probing_columns.GetColumnIndicesRef(), relation_data);
-}
-
 bool PositionListIndex::TakeProbe(int position, ColumnLayoutRelationData& relation_data,
                                   boost::dynamic_bitset<> const& probing_columns,
                                   std::vector<int>& probe) {
@@ -242,11 +236,6 @@ bool PositionListIndex::TakeProbe(int position, ColumnLayoutRelationData& relati
         probe.push_back(value);
     }
     return true;
-}
-
-bool PositionListIndex::TakeProbe(int position, ColumnLayoutRelationData& relation_data,
-                                  Vertical const& probing_columns, std::vector<int>& probe) {
-    return TakeProbe(position, relation_data, probing_columns.GetColumnIndicesRef(), probe);
 }
 
 std::string PositionListIndex::ToString() const {

--- a/src/core/model/table/position_list_index.cpp
+++ b/src/core/model/table/position_list_index.cpp
@@ -184,7 +184,8 @@ std::unique_ptr<PositionListIndex> PositionListIndex::Probe(
 }
 
 std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
-        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) const {
+        boost::dynamic_bitset<> const& probing_columns,
+        ColumnLayoutRelationData& relation_data) const {
     assert(this->relation_size_ == relation_data.GetNumRows());
     std::deque<std::vector<int>> new_index;
     unsigned int new_size = 0;
@@ -226,16 +227,26 @@ std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
                                                this->relation_size_, this->relation_size_);
 }
 
+std::unique_ptr<PositionListIndex> PositionListIndex::ProbeAll(
+        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) const {
+    return ProbeAll(probing_columns.GetColumnIndicesRef(), relation_data);
+}
+
 bool PositionListIndex::TakeProbe(int position, ColumnLayoutRelationData& relation_data,
-                                  Vertical const& probing_columns, std::vector<int>& probe) {
-    boost::dynamic_bitset<> probing_indices = probing_columns.GetColumnIndices();
-    for (unsigned long index = probing_indices.find_first(); index < probing_indices.size();
-         index = probing_indices.find_next(index)) {
+                                  boost::dynamic_bitset<> const& probing_columns,
+                                  std::vector<int>& probe) {
+    for (unsigned long index = probing_columns.find_first(); index < probing_columns.size();
+         index = probing_columns.find_next(index)) {
         int value = relation_data.GetColumnData(index).GetProbingTableValue(position);
         if (value == PositionListIndex::kSingletonValueId) return false;
         probe.push_back(value);
     }
     return true;
+}
+
+bool PositionListIndex::TakeProbe(int position, ColumnLayoutRelationData& relation_data,
+                                  Vertical const& probing_columns, std::vector<int>& probe) {
+    return TakeProbe(position, relation_data, probing_columns.GetColumnIndicesRef(), probe);
 }
 
 std::string PositionListIndex::ToString() const {

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "core/model/table/column.h"
+#include <boost/dynamic_bitset.hpp>
 
 class ColumnLayoutRelationData;
 
@@ -32,8 +32,6 @@ protected:
     static void SortClusters(std::deque<Cluster>& clusters);
     static bool TakeProbe(int position, ColumnLayoutRelationData& relation_data,
                           boost::dynamic_bitset<> const& probing_columns, std::vector<int>& probe);
-    static bool TakeProbe(int position, ColumnLayoutRelationData& relation_data,
-                          Vertical const& probing_columns, std::vector<int>& probe);
 
 private:
     double entropy_;
@@ -139,8 +137,6 @@ public:
     std::unique_ptr<PositionListIndex> Probe(
             std::shared_ptr<std::vector<int> const> probing_table) const;
     std::unique_ptr<PositionListIndex> ProbeAll(boost::dynamic_bitset<> const& probing_columns,
-                                                ColumnLayoutRelationData& relation_data) const;
-    std::unique_ptr<PositionListIndex> ProbeAll(Vertical const& probing_columns,
                                                 ColumnLayoutRelationData& relation_data) const;
     std::string ToString() const;
 };

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -137,7 +137,7 @@ public:
     std::unique_ptr<PositionListIndex> Probe(
             std::shared_ptr<std::vector<int> const> probing_table) const;
     std::unique_ptr<PositionListIndex> ProbeAll(Vertical const& probing_columns,
-                                                ColumnLayoutRelationData& relation_data);
+                                                ColumnLayoutRelationData& relation_data) const;
     std::string ToString() const;
 };
 

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -31,6 +31,8 @@ protected:
 
     static void SortClusters(std::deque<Cluster>& clusters);
     static bool TakeProbe(int position, ColumnLayoutRelationData& relation_data,
+                          boost::dynamic_bitset<> const& probing_columns, std::vector<int>& probe);
+    static bool TakeProbe(int position, ColumnLayoutRelationData& relation_data,
                           Vertical const& probing_columns, std::vector<int>& probe);
 
 private:
@@ -136,6 +138,8 @@ public:
     std::unique_ptr<PositionListIndex> Intersect(PositionListIndex const* that) const;
     std::unique_ptr<PositionListIndex> Probe(
             std::shared_ptr<std::vector<int> const> probing_table) const;
+    std::unique_ptr<PositionListIndex> ProbeAll(boost::dynamic_bitset<> const& probing_columns,
+                                                ColumnLayoutRelationData& relation_data) const;
     std::unique_ptr<PositionListIndex> ProbeAll(Vertical const& probing_columns,
                                                 ColumnLayoutRelationData& relation_data) const;
     std::string ToString() const;

--- a/src/core/model/table/position_list_index.h
+++ b/src/core/model/table/position_list_index.h
@@ -39,7 +39,6 @@ private:
     double gini_impurity_;
     unsigned long long nep_;
     std::shared_ptr<std::vector<int> const> probing_table_cache_;
-    unsigned int freq_ = 0;
 
 public:
     static constexpr int kSingletonValueId = 0;
@@ -98,10 +97,6 @@ public:
         return index_.size() + relation_size_ - size_;
     }
 
-    unsigned int GetFreq() const {
-        return freq_;
-    }
-
     unsigned int GetSize() const {
         return size_;
     }
@@ -136,10 +131,6 @@ public:
 
     bool IsConstant() const {
         return relation_size_ <= 1 || (GetNumNonSingletonCluster() == 1 && size_ == relation_size_);
-    }
-
-    void IncFreq() {
-        freq_++;
     }
 
     std::unique_ptr<PositionListIndex> Intersect(PositionListIndex const* that) const;

--- a/src/core/model/table/position_list_index_with_singletons.cpp
+++ b/src/core/model/table/position_list_index_with_singletons.cpp
@@ -13,8 +13,6 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include "core/model/table/column_layout_relation_data.h"
-#include "core/model/table/vertical.h"
 #include "core/util/logger.h"
 
 namespace model {
@@ -135,56 +133,6 @@ std::unique_ptr<PLIWithSingletons> PLIWithSingletons::Probe(
     return std::make_unique<PLIWithSingletons>(std::move(new_index), std::move(singletons),
                                                new_size, new_entropy, new_nep, relation_size_,
                                                relation_size_);
-}
-
-std::unique_ptr<PLIWithSingletons> PLIWithSingletons::ProbeAll(
-        Vertical const& probing_columns, ColumnLayoutRelationData& relation_data) {
-    if (this->relation_size_ != relation_data.GetNumRows())
-        throw std::invalid_argument("received different number of rows");
-    std::deque<std::vector<int>> new_index;
-    std::deque<std::vector<int>> singletons(singletons_);
-    unsigned int new_size = 0;
-    double new_key_gap = 0.0;
-    unsigned long long new_nep = 0;
-
-    std::map<std::vector<int>, std::vector<int>> partial_index;
-    std::vector<int> probe;
-
-    for (auto& cluster : this->index_) {
-        for (int position : cluster) {
-            if (!TakeProbe(position, relation_data, probing_columns, probe)) {
-                partial_index[{kSingletonValueId}].push_back(position);
-                probe.clear();
-                continue;
-            }
-
-            partial_index[probe].push_back(position);
-            probe.clear();
-        }
-
-        for (auto& iter : partial_index) {
-            auto& new_cluster = iter.second;
-            if (new_cluster.size() <= 1 || iter.first == std::vector<int>{kSingletonValueId}) {
-                singletons.push_back(std::move(cluster));
-                continue;
-            }
-
-            new_size += new_cluster.size();
-            new_key_gap += new_cluster.size() * log(new_cluster.size());
-            new_nep += CalculateNep(new_cluster.size());
-
-            new_index.emplace_back(std::move(new_cluster));
-        }
-        partial_index.clear();
-    }
-
-    double new_entropy = log(this->relation_size_) - new_key_gap / this->relation_size_;
-
-    SortClusters(new_index);
-
-    return std::make_unique<PLIWithSingletons>(std::move(new_index), std::move(singletons),
-                                               new_size, new_entropy, new_nep, this->relation_size_,
-                                               this->relation_size_);
 }
 
 std::unique_ptr<PLIWithSingletons> PLIWithSingletons::Intersect(

--- a/src/core/model/table/position_list_index_with_singletons.h
+++ b/src/core/model/table/position_list_index_with_singletons.h
@@ -5,13 +5,9 @@
 #pragma once
 #include <deque>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
-#include "core/model/table/column.h"
 #include "core/model/table/position_list_index.h"
-
-class ColumnLayoutRelationData;
 
 namespace model {
 
@@ -34,9 +30,6 @@ public:
         all_clusters.insert(all_clusters.end(), singletons_.begin(), singletons_.end());
         return all_clusters;
     }
-
-    std::unique_ptr<PLIWithSingletons> ProbeAll(Vertical const& probing_columns,
-                                                ColumnLayoutRelationData& relation_data);
 
     std::unique_ptr<PLIWithSingletons> Probe(
             std::shared_ptr<std::vector<int> const> probing_table) const;

--- a/src/core/model/table/vertical.cpp
+++ b/src/core/model/table/vertical.cpp
@@ -125,20 +125,6 @@ std::string Vertical::ToIndicesString() const {
     return result;
 }
 
-std::vector<Vertical> Vertical::GetParents() const {
-    if (GetArity() < 2) return std::vector<Vertical>();
-    std::vector<Vertical> parents(GetArity());
-    int i = 0;
-    for (size_t column_index = column_indices_.find_first();
-         column_index != boost::dynamic_bitset<>::npos;
-         column_index = column_indices_.find_next(column_index)) {
-        auto parent_column_indices = column_indices_;
-        parent_column_indices.reset(column_index);
-        parents[i++] = GetSchema()->GetVertical(std::move(parent_column_indices));
-    }
-    return parents;
-}
-
 bool Vertical::operator<(Vertical const& rhs) const {
     assert(*schema_ == *rhs.schema_);
     if (this->column_indices_ == rhs.column_indices_) return false;

--- a/src/core/model/table/vertical.h
+++ b/src/core/model/table/vertical.h
@@ -87,7 +87,6 @@ public:
 
     std::vector<Column const*> GetColumns() const;
     std::vector<unsigned> GetColumnIndicesAsVector() const;
-    std::vector<Vertical> GetParents() const;
 
     std::string ToString() const;
     std::string ToIndicesString() const;

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -226,7 +226,7 @@ bool VerticalMap<Value>::SetTrie::CollectRestrictedSupersetKeys(
 template <class Value>
 auto VerticalMap<Value>::GetSubsetKeys(Bitset const& bitset) const -> std::vector<Bitset> {
     std::vector<Bitset> subset_keys;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.CollectSubsetKeys(bitset, 0, subset_key,
                                 [&subset_keys](auto& indices, [[maybe_unused]] auto value) {
                                     subset_keys.push_back(indices);
@@ -239,7 +239,7 @@ template <class Value>
 std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetSubsetEntries(
         Bitset const& bitset) const {
     std::vector<typename VerticalMap<Value>::Entry> entries;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.CollectSubsetKeys(bitset, 0, subset_key, [&entries](auto& indices, auto value) {
         entries.emplace_back(indices, value);
         return true;
@@ -252,7 +252,7 @@ template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySubsetEntry(
         Bitset const& bitset) const {
     typename VerticalMap<Value>::Entry entry;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.CollectSubsetKeys(bitset, 0, subset_key, [&entry](auto& indices, auto value) {
         entry = {indices, value};
         return false;
@@ -265,7 +265,7 @@ typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySubsetEntry(
         Bitset const& bitset,
         std::function<bool(Bitset const*, std::shared_ptr<Value const>)> const& condition) const {
     typename VerticalMap<Value>::Entry entry;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.CollectSubsetKeys(bitset, 0, subset_key,
                                 [&entry, &condition](auto& indices, auto value) {
                                     if (condition(&indices, value)) {
@@ -282,7 +282,7 @@ template <class Value>
 std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetSupersetEntries(
         Bitset const& bitset) const {
     std::vector<typename VerticalMap<Value>::Entry> entries;
-    Bitset superset_key(relation_->GetNumColumns());
+    Bitset superset_key(num_columns_);
     set_trie_.CollectSupersetKeys(bitset, 0, superset_key, [&entries](auto& indices, auto value) {
         entries.emplace_back(indices, value);
         return true;
@@ -294,7 +294,7 @@ template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySupersetEntry(
         Bitset const& bitset) const {
     typename VerticalMap<Value>::Entry entry;
-    Bitset superset_key(relation_->GetNumColumns());
+    Bitset superset_key(num_columns_);
     set_trie_.CollectSupersetKeys(bitset, 0, superset_key, [&entry](auto& indices, auto value) {
         entry = {indices, value};
         return false;
@@ -307,7 +307,7 @@ typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySupersetEntry(
         Bitset const& bitset,
         std::function<bool(Bitset const*, std::shared_ptr<Value const>)> condition) const {
     typename VerticalMap<Value>::Entry entry;
-    Bitset superset_key(relation_->GetNumColumns());
+    Bitset superset_key(num_columns_);
     set_trie_.CollectSupersetKeys(bitset, 0, superset_key,
                                   [&entry, &condition](auto& indices, auto value) {
                                       if (condition(&indices, value)) {
@@ -329,7 +329,7 @@ std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetRestricte
                 "restriction");
 
     std::vector<typename VerticalMap<Value>::Entry> entries;
-    Bitset superset_key(relation_->GetNumColumns());
+    Bitset superset_key(num_columns_);
     set_trie_.CollectRestrictedSupersetKeys(bitset, exclusion, 0, superset_key,
                                             [&entries](auto& indices, auto value) {
                                                 entries.emplace_back(indices, value);
@@ -350,7 +350,7 @@ bool VerticalMap<Value>::RemoveSupersetEntries(Bitset const& key) {
 template <class Value>
 auto VerticalMap<Value>::KeySet() -> std::unordered_set<Bitset> {
     std::unordered_set<Bitset> key_set;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.TraverseEntries(subset_key,
                               [&key_set](auto& k, [[maybe_unused]] auto v) { key_set.insert(k); });
     return key_set;
@@ -359,7 +359,7 @@ auto VerticalMap<Value>::KeySet() -> std::unordered_set<Bitset> {
 template <class Value>
 std::vector<std::shared_ptr<Value const>> VerticalMap<Value>::Values() {
     std::vector<std::shared_ptr<Value const>> values;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.TraverseEntries(subset_key, [&values]([[maybe_unused]] auto& k, auto v) -> void {
         values.push_back(v);
     });
@@ -369,7 +369,7 @@ std::vector<std::shared_ptr<Value const>> VerticalMap<Value>::Values() {
 template <class Value>
 auto VerticalMap<Value>::EntrySet() -> std::vector<Entry> {
     std::vector<Entry> entry_set;
-    Bitset subset_key(relation_->GetNumColumns());
+    Bitset subset_key(num_columns_);
     set_trie_.TraverseEntries(
             subset_key, [&entry_set](auto& k, auto v) -> void { entry_set.emplace_back(k, v); });
     return entry_set;

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -435,12 +435,6 @@ template class VerticalMap<Vertical>;
 template class VerticalMap<std::monostate>;
 
 template <class V>
-size_t BlockingVerticalMap<V>::GetSize() const {
-    std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetSize();
-}
-
-template <class V>
 bool BlockingVerticalMap<V>::IsEmpty() const {
     std::shared_lock read_lock(read_write_mutex_);
     return VerticalMap<V>::IsEmpty();

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -355,15 +355,6 @@ bool VerticalMap<Value>::RemoveSupersetEntries(Vertical const& key) {
 }
 
 template <class Value>
-bool VerticalMap<Value>::RemoveSubsetEntries(Vertical const& key) {
-    std::vector<typename VerticalMap<Value>::Entry> subset_entries = GetSubsetEntries(key);
-    for (auto subset_entry : subset_entries) {
-        Remove(subset_entry.first);
-    }
-    return !subset_entries.empty();
-}
-
-template <class Value>
 std::unordered_set<Vertical> VerticalMap<Value>::KeySet() {
     std::unordered_set<Vertical> key_set;
     Bitset subset_key(relation_->GetNumColumns());
@@ -394,12 +385,6 @@ std::unordered_set<typename VerticalMap<Value>::Entry> VerticalMap<Value>::Entry
 }
 
 template <class Value>
-unsigned int VerticalMap<Value>::RemoveFromUsageCounter(
-        std::unordered_map<Vertical, unsigned int>& usage_counter, Vertical const& key) {
-    return usage_counter.erase(key);
-}
-
-template <class Value>
 std::shared_ptr<Value> VerticalMap<Value>::Remove(Vertical const& key) {
     auto removed_value = set_trie_.Remove(key.GetColumnIndices(), 0);
     if (removed_value != nullptr) size_--;
@@ -411,83 +396,6 @@ std::shared_ptr<Value> VerticalMap<Value>::Remove(VerticalMap::Bitset const& key
     auto removed_value = set_trie_.Remove(key, 0);
     if (removed_value != nullptr) size_--;
     return removed_value;
-}
-
-// comparator is of Compare type - check ascending/descending issues
-template <class Value>
-void VerticalMap<Value>::Shrink(double factor, std::function<bool(Entry, Entry)> const& compare,
-                                std::function<bool(Entry)> const& can_remove) {
-    // some logging
-
-    std::priority_queue<Entry, std::vector<Entry>, std::function<bool(Entry, Entry)>> key_queue(
-            compare, std::vector<Entry>(size_));
-    Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.TraverseEntries(subset_key, [&key_queue, this, &can_remove](auto& k, auto v) {
-        if (Entry entry(relation_->GetVertical(k), v); can_remove(entry)) {
-            key_queue.push(entry);
-        }
-    });
-    // unsigned int num_of_removed = 0;
-    unsigned int target_size = size_ * factor;
-    while (!key_queue.empty() && size_ > target_size) {
-        auto key = key_queue.top().first;
-        key_queue.pop();
-
-        // insert additional logging
-
-        // num_of_removed++;
-        Remove(key);
-    }
-    shrink_invocations_++;
-    time_spent_on_shrinking_ += 1;  // haven't implemented time measuring yet
-}
-
-template <class Value>
-void VerticalMap<Value>::Shrink(std::unordered_map<Vertical, unsigned int>& usage_counter,
-                                std::function<bool(Entry)> const& can_remove) {
-    // some logging
-
-    std::vector<int> usage_counters(usage_counter.size());
-    for (auto& [first, second] : usage_counter) {
-        usage_counters.push_back(second);
-    }
-    std::sort(usage_counters.begin(), usage_counters.end());
-    unsigned int median_of_usage = usage_counters.size() % 2 == 0
-                                           ? (usage_counters[usage_counters.size() / 2 + 1] +
-                                              usage_counters[usage_counters.size() / 2]) /
-                                                     2
-                                           : usage_counters[usage_counters.size() / 2];
-
-    std::queue<Entry> key_queue;
-    Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.TraverseEntries(
-            subset_key,
-            [&key_queue, this, &can_remove, &usage_counter, median_of_usage](auto& k,
-                                                                             auto v) -> void {
-                if (Entry entry(relation_->GetVertical(k), v);
-                    can_remove(entry) && usage_counter.at(entry.first) <= median_of_usage) {
-                    key_queue.push(entry);
-                }
-            });
-    // unsigned int num_of_removed = 0;
-    while (!key_queue.empty()) {
-        auto key = key_queue.front().first;
-        key_queue.pop();
-
-        // insert additional logging
-
-        // num_of_removed++;
-        Remove(key);
-        RemoveFromUsageCounter(usage_counter, key);
-    }
-
-    // TODO: what do we want to accomplish here? - looks ok btw
-    for (auto& [first, second] : usage_counter) {
-        second = 0;
-    }
-
-    shrink_invocations_++;
-    time_spent_on_shrinking_ += 1;  // haven't implemented time measuring yet
 }
 
 template <class Value>
@@ -660,38 +568,6 @@ template <class V>
 bool BlockingVerticalMap<V>::RemoveSupersetEntries(Vertical const& key) {
     std::scoped_lock write_lock(read_write_mutex_);
     return VerticalMap<V>::RemoveSupersetEntries(key);
-}
-
-template <class V>
-bool BlockingVerticalMap<V>::RemoveSubsetEntries(Vertical const& key) {
-    std::scoped_lock write_lock(read_write_mutex_);
-    return VerticalMap<V>::RemoveSubsetEntries(key);
-}
-
-template <class V>
-void BlockingVerticalMap<V>::Shrink(double factor, std::function<bool(Entry, Entry)> const& compare,
-                                    std::function<bool(Entry)> const& can_remove) {
-    std::scoped_lock write_lock(read_write_mutex_);
-    VerticalMap<V>::Shrink(factor, compare, can_remove);
-}
-
-template <class V>
-void BlockingVerticalMap<V>::Shrink(std::unordered_map<Vertical, unsigned int>& usage_counter,
-                                    std::function<bool(Entry)> const& can_remove) {
-    std::scoped_lock write_lock(read_write_mutex_);
-    VerticalMap<V>::Shrink(usage_counter, can_remove);
-}
-
-template <class V>
-long long BlockingVerticalMap<V>::GetShrinkInvocations() {
-    std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetShrinkInvocations();
-}
-
-template <class V>
-long long BlockingVerticalMap<V>::GetTimeSpentOnShrinking() {
-    std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetTimeSpentOnShrinking();
 }
 
 template class BlockingVerticalMap<PositionListIndex>;

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -224,12 +224,12 @@ bool VerticalMap<Value>::SetTrie::CollectRestrictedSupersetKeys(
 }
 
 template <class Value>
-std::vector<Vertical> VerticalMap<Value>::GetSubsetKeys(Vertical const& vertical) const {
-    std::vector<Vertical> subset_keys;
+auto VerticalMap<Value>::GetSubsetKeys(Bitset const& bitset) const -> std::vector<Bitset> {
+    std::vector<Bitset> subset_keys;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.CollectSubsetKeys(vertical.GetColumnIndices(), 0, subset_key,
-                                [&subset_keys, this](auto& indices, [[maybe_unused]] auto value) {
-                                    subset_keys.push_back(relation_->GetVertical(indices));
+    set_trie_.CollectSubsetKeys(bitset, 0, subset_key,
+                                [&subset_keys](auto& indices, [[maybe_unused]] auto value) {
+                                    subset_keys.push_back(indices);
                                     return true;
                                 });
     return subset_keys;
@@ -237,42 +237,39 @@ std::vector<Vertical> VerticalMap<Value>::GetSubsetKeys(Vertical const& vertical
 
 template <class Value>
 std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetSubsetEntries(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::vector<typename VerticalMap<Value>::Entry> entries;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.CollectSubsetKeys(vertical.GetColumnIndices(), 0, subset_key,
-                                [&entries, this](auto& indices, auto value) {
-                                    entries.emplace_back(relation_->GetVertical(indices), value);
-                                    return true;
-                                });
+    set_trie_.CollectSubsetKeys(bitset, 0, subset_key, [&entries](auto& indices, auto value) {
+        entries.emplace_back(indices, value);
+        return true;
+    });
     return entries;
 }
 
 // returns an empty pair if no entry is found
 template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySubsetEntry(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     typename VerticalMap<Value>::Entry entry;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.CollectSubsetKeys(vertical.GetColumnIndices(), 0, subset_key,
-                                [&entry, this](auto& indices, auto value) {
-                                    entry = {relation_->GetVertical(indices), value};
-                                    return false;
-                                });
+    set_trie_.CollectSubsetKeys(bitset, 0, subset_key, [&entry](auto& indices, auto value) {
+        entry = {indices, value};
+        return false;
+    });
     return entry;
 }
 
 template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySubsetEntry(
-        Vertical const& vertical,
-        std::function<bool(Vertical const*, std::shared_ptr<Value const>)> const& condition) const {
+        Bitset const& bitset,
+        std::function<bool(Bitset const*, std::shared_ptr<Value const>)> const& condition) const {
     typename VerticalMap<Value>::Entry entry;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.CollectSubsetKeys(vertical.GetColumnIndices(), 0, subset_key,
-                                [&entry, this, &condition](auto& indices, auto value) {
-                                    auto kv = relation_->GetVertical(indices);
-                                    if (condition(&kv, value)) {
-                                        entry = {kv, value};
+    set_trie_.CollectSubsetKeys(bitset, 0, subset_key,
+                                [&entry, &condition](auto& indices, auto value) {
+                                    if (condition(&indices, value)) {
+                                        entry = {indices, value};
                                         return false;
                                     } else {
                                         return true;
@@ -283,41 +280,38 @@ typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySubsetEntry(
 
 template <class Value>
 std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetSupersetEntries(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::vector<typename VerticalMap<Value>::Entry> entries;
     Bitset superset_key(relation_->GetNumColumns());
-    set_trie_.CollectSupersetKeys(vertical.GetColumnIndices(), 0, superset_key,
-                                  [&entries, this](auto& indices, auto value) {
-                                      entries.emplace_back(relation_->GetVertical(indices), value);
-                                      return true;
-                                  });
+    set_trie_.CollectSupersetKeys(bitset, 0, superset_key, [&entries](auto& indices, auto value) {
+        entries.emplace_back(indices, value);
+        return true;
+    });
     return entries;
 }
 
 template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySupersetEntry(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     typename VerticalMap<Value>::Entry entry;
     Bitset superset_key(relation_->GetNumColumns());
-    set_trie_.CollectSupersetKeys(vertical.GetColumnIndices(), 0, superset_key,
-                                  [&entry, this](auto& indices, auto value) {
-                                      entry = {relation_->GetVertical(indices), value};
-                                      return false;
-                                  });
+    set_trie_.CollectSupersetKeys(bitset, 0, superset_key, [&entry](auto& indices, auto value) {
+        entry = {indices, value};
+        return false;
+    });
     return entry;
 }
 
 template <class Value>
 typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySupersetEntry(
-        Vertical const& vertical,
-        std::function<bool(Vertical const*, std::shared_ptr<Value const>)> condition) const {
+        Bitset const& bitset,
+        std::function<bool(Bitset const*, std::shared_ptr<Value const>)> condition) const {
     typename VerticalMap<Value>::Entry entry;
     Bitset superset_key(relation_->GetNumColumns());
-    set_trie_.CollectSupersetKeys(vertical.GetColumnIndices(), 0, superset_key,
-                                  [&entry, this, &condition](auto& indices, auto value) {
-                                      auto kv = relation_->GetVertical(indices);
-                                      if (condition(&kv, value)) {
-                                          entry = {kv, value};
+    set_trie_.CollectSupersetKeys(bitset, 0, superset_key,
+                                  [&entry, &condition](auto& indices, auto value) {
+                                      if (condition(&indices, value)) {
+                                          entry = {indices, value};
                                           return false;
                                       } else {
                                           return true;
@@ -328,25 +322,24 @@ typename VerticalMap<Value>::Entry VerticalMap<Value>::GetAnySupersetEntry(
 
 template <class Value>
 std::vector<typename VerticalMap<Value>::Entry> VerticalMap<Value>::GetRestrictedSupersetEntries(
-        Vertical const& vertical, Vertical const& exclusion) const {
-    if (vertical.GetColumnIndices().intersects(exclusion.GetColumnIndices()))
+        Bitset const& bitset, Bitset const& exclusion) const {
+    if (bitset.intersects(exclusion))
         throw std::runtime_error(
                 "Error in GetRestrictedSupersetEntries: a vertical shouldn't intersect with a "
                 "restriction");
 
     std::vector<typename VerticalMap<Value>::Entry> entries;
     Bitset superset_key(relation_->GetNumColumns());
-    set_trie_.CollectRestrictedSupersetKeys(
-            vertical.GetColumnIndices(), exclusion.GetColumnIndices(), 0, superset_key,
-            [&entries, this](auto& indices, auto value) {
-                entries.emplace_back(relation_->GetVertical(indices), value);
-                return true;
-            });
+    set_trie_.CollectRestrictedSupersetKeys(bitset, exclusion, 0, superset_key,
+                                            [&entries](auto& indices, auto value) {
+                                                entries.emplace_back(indices, value);
+                                                return true;
+                                            });
     return entries;
 }
 
 template <class Value>
-bool VerticalMap<Value>::RemoveSupersetEntries(Vertical const& key) {
+bool VerticalMap<Value>::RemoveSupersetEntries(Bitset const& key) {
     std::vector<typename VerticalMap<Value>::Entry> superset_entries = GetSupersetEntries(key);
     for (auto superset_entry : superset_entries) {
         Remove(superset_entry.first);
@@ -355,12 +348,11 @@ bool VerticalMap<Value>::RemoveSupersetEntries(Vertical const& key) {
 }
 
 template <class Value>
-std::unordered_set<Vertical> VerticalMap<Value>::KeySet() {
-    std::unordered_set<Vertical> key_set;
+auto VerticalMap<Value>::KeySet() -> std::unordered_set<Bitset> {
+    std::unordered_set<Bitset> key_set;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.TraverseEntries(subset_key, [&key_set, this](auto& k, [[maybe_unused]] auto v) {
-        key_set.insert(relation_->GetVertical(k));
-    });
+    set_trie_.TraverseEntries(subset_key,
+                              [&key_set](auto& k, [[maybe_unused]] auto v) { key_set.insert(k); });
     return key_set;
 }
 
@@ -375,40 +367,27 @@ std::vector<std::shared_ptr<Value const>> VerticalMap<Value>::Values() {
 }
 
 template <class Value>
-std::unordered_set<typename VerticalMap<Value>::Entry> VerticalMap<Value>::EntrySet() {
-    std::unordered_set<typename VerticalMap<Value>::Entry> entry_set;
+auto VerticalMap<Value>::EntrySet() -> std::vector<Entry> {
+    std::vector<Entry> entry_set;
     Bitset subset_key(relation_->GetNumColumns());
-    set_trie_.TraverseEntries(subset_key, [&entry_set, this](auto& k, auto v) -> void {
-        entry_set.emplace(relation_->GetVertical(k), v);
-    });
+    set_trie_.TraverseEntries(
+            subset_key, [&entry_set](auto& k, auto v) -> void { entry_set.emplace_back(k, v); });
     return entry_set;
 }
 
 template <class Value>
-std::shared_ptr<Value> VerticalMap<Value>::Remove(Vertical const& key) {
-    auto removed_value = set_trie_.Remove(key.GetColumnIndices(), 0);
-    if (removed_value != nullptr) size_--;
-    return removed_value;
-}
-
-template <class Value>
-std::shared_ptr<Value> VerticalMap<Value>::Remove(VerticalMap::Bitset const& key) {
+std::shared_ptr<Value> VerticalMap<Value>::Remove(Bitset const& key) {
     auto removed_value = set_trie_.Remove(key, 0);
     if (removed_value != nullptr) size_--;
     return removed_value;
 }
 
 template <class Value>
-std::shared_ptr<Value> VerticalMap<Value>::Put(Vertical const& key, std::shared_ptr<Value> value) {
-    auto old_value = set_trie_.Associate(key.GetColumnIndices(), 0, std::move(value));
+std::shared_ptr<Value> VerticalMap<Value>::Put(Bitset const& key, std::shared_ptr<Value> value) {
+    auto old_value = set_trie_.Associate(key, 0, std::move(value));
     if (old_value == nullptr) size_++;
 
     return old_value;
-}
-
-template <class Value>
-std::shared_ptr<Value const> VerticalMap<Value>::Get(Vertical const& key) const {
-    return set_trie_.Get(key.GetColumnIndices(), 0);
 }
 
 template <class Value>
@@ -436,33 +415,21 @@ bool BlockingVerticalMap<V>::IsEmpty() const {
 }
 
 template <class V>
-std::shared_ptr<V const> BlockingVerticalMap<V>::Get(Vertical const& key) const {
-    std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::Get(key);
-}
-
-template <class V>
 std::shared_ptr<V const> BlockingVerticalMap<V>::Get(Bitset const& key) const {
     std::shared_lock read_lock(read_write_mutex_);
     return VerticalMap<V>::Get(key);
 }
 
 template <class V>
-bool BlockingVerticalMap<V>::ContainsKey(Vertical const& key) const {
+bool BlockingVerticalMap<V>::ContainsKey(Bitset const& key) const {
     std::shared_lock read_lock(read_write_mutex_);
     return VerticalMap<V>::ContainsKey(key);
 }
 
 template <class V>
-std::shared_ptr<V> BlockingVerticalMap<V>::Put(Vertical const& key, std::shared_ptr<V> value) {
+std::shared_ptr<V> BlockingVerticalMap<V>::Put(Bitset const& key, std::shared_ptr<V> value) {
     std::scoped_lock write_lock(read_write_mutex_);
     return VerticalMap<V>::Put(key, value);
-}
-
-template <class V>
-std::shared_ptr<V> BlockingVerticalMap<V>::Remove(Vertical const& key) {
-    std::scoped_lock write_lock(read_write_mutex_);
-    return VerticalMap<V>::Remove(key);
 }
 
 template <class V>
@@ -472,7 +439,7 @@ std::shared_ptr<V> BlockingVerticalMap<V>::Remove(Bitset const& key) {
 }
 
 template <class V>
-std::unordered_set<Vertical> BlockingVerticalMap<V>::KeySet() {
+auto BlockingVerticalMap<V>::KeySet() -> std::unordered_set<Bitset> {
     std::shared_lock read_lock(read_write_mutex_);
     return VerticalMap<V>::KeySet();
 }
@@ -484,71 +451,71 @@ std::vector<std::shared_ptr<V const>> BlockingVerticalMap<V>::Values() {
 }
 
 template <class V>
-std::unordered_set<typename BlockingVerticalMap<V>::Entry> BlockingVerticalMap<V>::EntrySet() {
+auto BlockingVerticalMap<V>::EntrySet() -> std::vector<Entry> {
     std::shared_lock read_lock(read_write_mutex_);
     return VerticalMap<V>::EntrySet();
 }
 
 template <class V>
-std::vector<Vertical> BlockingVerticalMap<V>::GetSubsetKeys(Vertical const& vertical) const {
+auto BlockingVerticalMap<V>::GetSubsetKeys(Bitset const& bitset) const -> std::vector<Bitset> {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetSubsetKeys(vertical);
+    return VerticalMap<V>::GetSubsetKeys(bitset);
 }
 
 template <class V>
 std::vector<typename BlockingVerticalMap<V>::Entry> BlockingVerticalMap<V>::GetSubsetEntries(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetSubsetEntries(vertical);
+    return VerticalMap<V>::GetSubsetEntries(bitset);
 }
 
 template <class V>
 typename BlockingVerticalMap<V>::Entry BlockingVerticalMap<V>::GetAnySubsetEntry(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetAnySubsetEntry(vertical);
+    return VerticalMap<V>::GetAnySubsetEntry(bitset);
 }
 
 template <class V>
 typename BlockingVerticalMap<V>::Entry BlockingVerticalMap<V>::GetAnySubsetEntry(
-        Vertical const& vertical,
-        std::function<bool(Vertical const*, std::shared_ptr<V const>)> const& condition) const {
+        Bitset const& bitset,
+        std::function<bool(Bitset const*, std::shared_ptr<V const>)> const& condition) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetAnySubsetEntry(vertical, condition);
+    return VerticalMap<V>::GetAnySubsetEntry(bitset, condition);
 }
 
 template <class V>
 std::vector<typename BlockingVerticalMap<V>::Entry> BlockingVerticalMap<V>::GetSupersetEntries(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetSupersetEntries(vertical);
+    return VerticalMap<V>::GetSupersetEntries(bitset);
 }
 
 template <class V>
 typename BlockingVerticalMap<V>::Entry BlockingVerticalMap<V>::GetAnySupersetEntry(
-        Vertical const& vertical) const {
+        Bitset const& bitset) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetAnySupersetEntry(vertical);
+    return VerticalMap<V>::GetAnySupersetEntry(bitset);
 }
 
 template <class V>
 typename BlockingVerticalMap<V>::Entry BlockingVerticalMap<V>::GetAnySupersetEntry(
-        Vertical const& vertical,
-        std::function<bool(Vertical const*, std::shared_ptr<V const>)> condition) const {
+        Bitset const& bitset,
+        std::function<bool(Bitset const*, std::shared_ptr<V const>)> condition) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetAnySupersetEntry(vertical, condition);
+    return VerticalMap<V>::GetAnySupersetEntry(bitset, condition);
 }
 
 template <class V>
 std::vector<typename BlockingVerticalMap<V>::Entry>
-BlockingVerticalMap<V>::GetRestrictedSupersetEntries(Vertical const& vertical,
-                                                     Vertical const& exclusion) const {
+BlockingVerticalMap<V>::GetRestrictedSupersetEntries(Bitset const& bitset,
+                                                     Bitset const& exclusion) const {
     std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::GetRestrictedSupersetEntries(vertical, exclusion);
+    return VerticalMap<V>::GetRestrictedSupersetEntries(bitset, exclusion);
 }
 
 template <class V>
-bool BlockingVerticalMap<V>::RemoveSupersetEntries(Vertical const& key) {
+bool BlockingVerticalMap<V>::RemoveSupersetEntries(Bitset const& key) {
     std::scoped_lock write_lock(read_write_mutex_);
     return VerticalMap<V>::RemoveSupersetEntries(key);
 }

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -404,7 +404,7 @@ template class VerticalMap<DependencyCandidate>;
 
 template class VerticalMap<VerticalInfo>;
 
-template class VerticalMap<Vertical>;
+template class VerticalMap<boost::dynamic_bitset<>>;
 
 template class VerticalMap<std::monostate>;
 
@@ -528,6 +528,6 @@ template class BlockingVerticalMap<DependencyCandidate>;
 
 template class BlockingVerticalMap<VerticalInfo>;
 
-template class BlockingVerticalMap<Vertical>;
+template class BlockingVerticalMap<boost::dynamic_bitset<>>;
 
 }  // namespace model

--- a/src/core/model/table/vertical_map.cpp
+++ b/src/core/model/table/vertical_map.cpp
@@ -412,17 +412,12 @@ std::shared_ptr<Value const> VerticalMap<Value>::Get(Vertical const& key) const 
 }
 
 template <class Value>
-std::shared_ptr<Value> VerticalMap<Value>::Get(Vertical const& key) {
-    return std::const_pointer_cast<Value>(set_trie_.Get(key.GetColumnIndices(), 0));
-}
-
-template <class Value>
 std::shared_ptr<Value const> VerticalMap<Value>::Get(Bitset const& key) const {
     return set_trie_.Get(key, 0);
 }
 
 // explicitly instantiate to solve template implementation linking issues
-template class VerticalMap<PositionListIndex>;
+template class VerticalMap<PositionListIndex const>;
 
 template class VerticalMap<AgreeSetSample>;
 
@@ -474,12 +469,6 @@ template <class V>
 std::shared_ptr<V> BlockingVerticalMap<V>::Remove(Bitset const& key) {
     std::scoped_lock write_lock(read_write_mutex_);
     return VerticalMap<V>::Remove(key);
-}
-
-template <class V>
-std::shared_ptr<V> BlockingVerticalMap<V>::Get(Vertical const& key) {
-    std::shared_lock read_lock(read_write_mutex_);
-    return VerticalMap<V>::Get(key);
 }
 
 template <class V>
@@ -564,7 +553,7 @@ bool BlockingVerticalMap<V>::RemoveSupersetEntries(Vertical const& key) {
     return VerticalMap<V>::RemoveSupersetEntries(key);
 }
 
-template class BlockingVerticalMap<PositionListIndex>;
+template class BlockingVerticalMap<PositionListIndex const>;
 
 template class BlockingVerticalMap<AgreeSetSample>;
 

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -8,7 +8,7 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-#include "core/util/custom_hashes.h"
+#include "core/model/table/relational_schema.h"
 
 namespace model {
 

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -91,12 +91,7 @@ protected:
 
     RelationalSchema const* relation_;
     size_t size_ = 0;
-    long long shrink_invocations_ = 0;
-    long long time_spent_on_shrinking_ = 0;
     SetTrie set_trie_;
-
-    unsigned int RemoveFromUsageCounter(std::unordered_map<Vertical, unsigned int>& usage_counter,
-                                        Vertical const& key);
 
 public:
     using Entry = std::pair<Vertical, std::shared_ptr<Value const>>;
@@ -148,23 +143,6 @@ public:
     virtual std::vector<Entry> GetRestrictedSupersetEntries(Vertical const& vertical,
                                                             Vertical const& exclusion) const;
     virtual bool RemoveSupersetEntries(Vertical const& key);
-    virtual bool RemoveSubsetEntries(Vertical const& key);
-
-    /* methods to shrink the map by deleting removable entries
-     * !!! Untested yet - use carefully
-     * */
-    virtual void Shrink(double factor, std::function<bool(Entry, Entry)> const& compare,
-                        std::function<bool(Entry)> const& can_remove);
-    virtual void Shrink(std::unordered_map<Vertical, unsigned int>& usage_counter,
-                        std::function<bool(Entry)> const& can_remove);
-
-    virtual long long GetShrinkInvocations() {
-        return shrink_invocations_;
-    }
-
-    virtual long long GetTimeSpentOnShrinking() {
-        return time_spent_on_shrinking_;
-    }
 
     virtual ~VerticalMap() = default;
 };
@@ -215,15 +193,6 @@ public:
     virtual std::vector<Entry> GetRestrictedSupersetEntries(
             Vertical const& vertical, Vertical const& exclusion) const override;
     virtual bool RemoveSupersetEntries(Vertical const& key) override;
-    virtual bool RemoveSubsetEntries(Vertical const& key) override;
-
-    virtual void Shrink(double factor, std::function<bool(Entry, Entry)> const& compare,
-                        std::function<bool(Entry)> const& can_remove) override;
-    virtual void Shrink(std::unordered_map<Vertical, unsigned int>& usage_counter,
-                        std::function<bool(Entry)> const& can_remove) override;
-
-    virtual long long GetShrinkInvocations() override;
-    virtual long long GetTimeSpentOnShrinking() override;
 
     virtual ~BlockingVerticalMap() = default;
 };

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -115,9 +115,6 @@ public:
     virtual std::shared_ptr<Value> Remove(Vertical const& key);
     virtual std::shared_ptr<Value> Remove(Bitset const& key);
 
-    // non-const version of get() for костыль purposes
-    virtual std::shared_ptr<Value> Get(Vertical const& key);
-
     // get all keys/values/entries for traversing
     virtual std::unordered_set<Vertical> KeySet();
     virtual std::vector<std::shared_ptr<Value const>> Values();
@@ -166,8 +163,6 @@ public:
     virtual std::shared_ptr<V> Put(Vertical const& key, std::shared_ptr<V> value) override;
     virtual std::shared_ptr<V> Remove(Vertical const& key) override;
     virtual std::shared_ptr<V> Remove(Bitset const& key) override;
-
-    virtual std::shared_ptr<V> Get(Vertical const& key) override;
 
     virtual std::unordered_set<Vertical> KeySet() override;
     virtual std::vector<std::shared_ptr<V const>> Values() override;

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -21,15 +21,13 @@ class VerticalMap {
 protected:
     using Bitset = boost::dynamic_bitset<>;
 
-    // typename std::shared_ptr<Value> shared_ptr<Value>;
-
     // Each node corresponds to a bit in a bitset. Each node also has a vector of the possible
     // consequent set bits.
     class SetTrie {
     private:
         size_t offset_;
         size_t dimension_;
-        std::vector<std::unique_ptr<SetTrie>> subtries_;  // unique_ptr?
+        std::vector<std::unique_ptr<SetTrie>> subtries_;
         std::shared_ptr<Value> value_;
 
         bool IsEmpty() const;
@@ -94,7 +92,7 @@ protected:
     SetTrie set_trie_;
 
 public:
-    using Entry = std::pair<Vertical, std::shared_ptr<Value const>>;
+    using Entry = std::pair<Bitset, std::shared_ptr<Value const>>;
 
     explicit VerticalMap(RelationalSchema const* relation)
         : relation_(relation), set_trie_(relation->GetNumColumns()) {}
@@ -104,38 +102,36 @@ public:
     }
 
     // basic get-check-insert-remove operations
-    virtual std::shared_ptr<Value const> Get(Vertical const& key) const;
     virtual std::shared_ptr<Value const> Get(Bitset const& key) const;
 
-    virtual bool ContainsKey(Vertical const& key) const {
+    virtual bool ContainsKey(Bitset const& key) const {
         return Get(key) != nullptr;
     }
 
-    virtual std::shared_ptr<Value> Put(Vertical const& key, std::shared_ptr<Value> value);
-    virtual std::shared_ptr<Value> Remove(Vertical const& key);
+    virtual std::shared_ptr<Value> Put(Bitset const& key, std::shared_ptr<Value> value);
     virtual std::shared_ptr<Value> Remove(Bitset const& key);
 
     // get all keys/values/entries for traversing
-    virtual std::unordered_set<Vertical> KeySet();
+    virtual std::unordered_set<Bitset> KeySet();
     virtual std::vector<std::shared_ptr<Value const>> Values();
-    virtual std::unordered_set<Entry> EntrySet();
+    virtual std::vector<Entry> EntrySet();
 
     // get specific entries for traversing
-    virtual std::vector<Vertical> GetSubsetKeys(Vertical const& vertical) const;
-    virtual std::vector<Entry> GetSubsetEntries(Vertical const& vertical) const;
-    virtual Entry GetAnySubsetEntry(Vertical const& vertical) const;
+    virtual std::vector<Bitset> GetSubsetKeys(Bitset const& vertical) const;
+    virtual std::vector<Entry> GetSubsetEntries(Bitset const& vertical) const;
+    virtual Entry GetAnySubsetEntry(Bitset const& vertical) const;
     virtual Entry GetAnySubsetEntry(
-            Vertical const& vertical,
-            std::function<bool(Vertical const*, std::shared_ptr<Value const>)> const& condition)
+            Bitset const& vertical,
+            std::function<bool(Bitset const*, std::shared_ptr<Value const>)> const& condition)
             const;
-    virtual std::vector<Entry> GetSupersetEntries(Vertical const& vertical) const;
-    virtual Entry GetAnySupersetEntry(Vertical const& vertical) const;
+    virtual std::vector<Entry> GetSupersetEntries(Bitset const& vertical) const;
+    virtual Entry GetAnySupersetEntry(Bitset const& vertical) const;
     virtual Entry GetAnySupersetEntry(
-            Vertical const& vertical,
-            std::function<bool(Vertical const*, std::shared_ptr<Value const>)> condition) const;
-    virtual std::vector<Entry> GetRestrictedSupersetEntries(Vertical const& vertical,
-                                                            Vertical const& exclusion) const;
-    virtual bool RemoveSupersetEntries(Vertical const& key);
+            Bitset const& vertical,
+            std::function<bool(Bitset const*, std::shared_ptr<Value const>)> condition) const;
+    virtual std::vector<Entry> GetRestrictedSupersetEntries(Bitset const& vertical,
+                                                            Bitset const& exclusion) const;
+    virtual bool RemoveSupersetEntries(Bitset const& key);
 
     virtual ~VerticalMap() = default;
 };
@@ -157,32 +153,30 @@ public:
 
     virtual bool IsEmpty() const override;
 
-    virtual std::shared_ptr<V const> Get(Vertical const& key) const override;
     virtual std::shared_ptr<V const> Get(Bitset const& key) const override;
-    virtual bool ContainsKey(Vertical const& key) const override;
-    virtual std::shared_ptr<V> Put(Vertical const& key, std::shared_ptr<V> value) override;
-    virtual std::shared_ptr<V> Remove(Vertical const& key) override;
+    virtual bool ContainsKey(Bitset const& key) const override;
+    virtual std::shared_ptr<V> Put(Bitset const& key, std::shared_ptr<V> value) override;
     virtual std::shared_ptr<V> Remove(Bitset const& key) override;
 
-    virtual std::unordered_set<Vertical> KeySet() override;
+    virtual std::unordered_set<Bitset> KeySet() override;
     virtual std::vector<std::shared_ptr<V const>> Values() override;
-    virtual std::unordered_set<Entry> EntrySet() override;
+    virtual std::vector<Entry> EntrySet() override;
 
-    virtual std::vector<Vertical> GetSubsetKeys(Vertical const& vertical) const override;
-    virtual std::vector<Entry> GetSubsetEntries(Vertical const& vertical) const override;
-    virtual Entry GetAnySubsetEntry(Vertical const& vertical) const override;
+    virtual std::vector<Bitset> GetSubsetKeys(Bitset const& vertical) const override;
+    virtual std::vector<Entry> GetSubsetEntries(Bitset const& vertical) const override;
+    virtual Entry GetAnySubsetEntry(Bitset const& vertical) const override;
     virtual Entry GetAnySubsetEntry(
-            Vertical const& vertical,
-            std::function<bool(Vertical const*, std::shared_ptr<V const>)> const& condition)
+            Bitset const& vertical,
+            std::function<bool(Bitset const*, std::shared_ptr<V const>)> const& condition)
             const override;
-    virtual std::vector<Entry> GetSupersetEntries(Vertical const& vertical) const override;
-    virtual Entry GetAnySupersetEntry(Vertical const& vertical) const override;
-    virtual Entry GetAnySupersetEntry(Vertical const& vertical,
-                                      std::function<bool(Vertical const*, std::shared_ptr<V const>)>
-                                              condition) const override;
-    virtual std::vector<Entry> GetRestrictedSupersetEntries(
-            Vertical const& vertical, Vertical const& exclusion) const override;
-    virtual bool RemoveSupersetEntries(Vertical const& key) override;
+    virtual std::vector<Entry> GetSupersetEntries(Bitset const& vertical) const override;
+    virtual Entry GetAnySupersetEntry(Bitset const& vertical) const override;
+    virtual Entry GetAnySupersetEntry(
+            Bitset const& vertical,
+            std::function<bool(Bitset const*, std::shared_ptr<V const>)> condition) const override;
+    virtual std::vector<Entry> GetRestrictedSupersetEntries(Bitset const& vertical,
+                                                            Bitset const& exclusion) const override;
+    virtual bool RemoveSupersetEntries(Bitset const& key) override;
 
     virtual ~BlockingVerticalMap() = default;
 };

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <shared_mutex>
@@ -7,8 +9,6 @@
 #include <vector>
 
 #include <boost/dynamic_bitset.hpp>
-
-#include "core/model/table/relational_schema.h"
 
 namespace model {
 
@@ -87,15 +87,15 @@ protected:
                 std::function<void(Bitset const&, std::shared_ptr<Value const>)> collector) const;
     };
 
-    RelationalSchema const* relation_;
+    std::size_t num_columns_;
     size_t size_ = 0;
     SetTrie set_trie_;
 
 public:
     using Entry = std::pair<Bitset, std::shared_ptr<Value const>>;
 
-    explicit VerticalMap(RelationalSchema const* relation)
-        : relation_(relation), set_trie_(relation->GetNumColumns()) {}
+    explicit VerticalMap(std::size_t num_columns)
+        : num_columns_(num_columns), set_trie_(num_columns) {}
 
     virtual bool IsEmpty() const {
         return size_ == 0;
@@ -149,7 +149,7 @@ public:
     using typename VerticalMap<V>::Entry;
     using typename VerticalMap<V>::Bitset;
 
-    explicit BlockingVerticalMap(RelationalSchema const* relation) : VerticalMap<V>(relation) {}
+    explicit BlockingVerticalMap(std::size_t num_columns) : VerticalMap<V>(num_columns) {}
 
     virtual bool IsEmpty() const override;
 

--- a/src/core/model/table/vertical_map.h
+++ b/src/core/model/table/vertical_map.h
@@ -99,10 +99,6 @@ public:
     explicit VerticalMap(RelationalSchema const* relation)
         : relation_(relation), set_trie_(relation->GetNumColumns()) {}
 
-    virtual size_t GetSize() const {
-        return size_;
-    }
-
     virtual bool IsEmpty() const {
         return size_ == 0;
     }
@@ -162,7 +158,6 @@ public:
 
     explicit BlockingVerticalMap(RelationalSchema const* relation) : VerticalMap<V>(relation) {}
 
-    virtual size_t GetSize() const override;
     virtual bool IsEmpty() const override;
 
     virtual std::shared_ptr<V const> Get(Vertical const& key) const override;


### PR DESCRIPTION
Depends on #812 
Vertical and Column are useless abstractions. Inside algorithms, they correspond to a bitset and an integer. Vertical also encourages copying the bitset excessively as it doesn't allow modifying it directly.