### PR TITLE
Rename _Find_xx to FindXx in "self-hosted" bitset

### DIFF
--- a/src/core/algorithms/dc/FastADC/util/evidence_set_builder.h
+++ b/src/core/algorithms/dc/FastADC/util/evidence_set_builder.h
@@ -7,6 +7,7 @@
 
 #include "core/algorithms/dc/FastADC/model/evidence_set.h"
 #include "core/algorithms/dc/FastADC/util/clue_set_builder.h"
+#include "core/model/types/bitset.h"
 #include "core/util/logger.h"
 #include "core/util/worker_thread_pool.h"
 
@@ -27,8 +28,8 @@ public:
             clues_.reserve(clue_set.size());
             for (auto const& [clue, count] : clue_set) {
                 PredicateBitset bitset;
-                for (size_t pos = clue._Find_first(); pos < clue.size();
-                     pos = clue._Find_next(pos)) {
+                for (size_t pos = model::FindFirst(clue); pos < clue.size();
+                     pos = model::FindNext(clue, pos)) {
                     bitset.set(pos);
                 }
                 clues_.emplace_back(bitset, count);

--- a/src/core/algorithms/dc/FastADC/util/predicate_organizer.h
+++ b/src/core/algorithms/dc/FastADC/util/predicate_organizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/algorithms/dc/FastADC/model/evidence_set.h"
+#include "core/model/types/bitset.h"
 
 namespace algos::fastadc {
 
@@ -76,7 +77,8 @@ private:
 
         for (auto const& evidence : evidence_set_) {
             PredicateBitset bitset = evidence.evidence;
-            for (size_t i = bitset._Find_first(); i != bitset.size(); i = bitset._Find_next(i)) {
+            for (size_t i = model::FindFirst(bitset); i != bitset.size();
+                 i = model::FindNext(bitset, i)) {
                 counts[i]++;
             }
         }

--- a/src/core/algorithms/fd/fdep/fd_tree_element.cpp
+++ b/src/core/algorithms/fd/fdep/fd_tree_element.cpp
@@ -45,7 +45,7 @@ bool FDTreeElement::ContainsGeneralization(model::Bitset<FDTreeElement::kMaxAttr
         return true;
     }
 
-    size_t next_set_attr = lhs._Find_next(current_attr);
+    size_t next_set_attr = model::FindNext(lhs, current_attr);
     if (next_set_attr == kMaxAttrNum) {
         return false;
     }
@@ -71,7 +71,7 @@ bool FDTreeElement::GetGeneralizationAndDelete(
         return true;
     }
 
-    size_t next_set_attr = lhs._Find_next(current_attr);
+    size_t next_set_attr = model::FindNext(lhs, current_attr);
     if (next_set_attr == kMaxAttrNum) {
         return false;
     }
@@ -104,7 +104,7 @@ bool FDTreeElement::GetSpecialization(
 
     bool found = false;
     size_t attr = (current_attr > 1 ? current_attr : 1);
-    size_t next_set_attr = lhs._Find_next(current_attr);
+    size_t next_set_attr = model::FindNext(lhs, current_attr);
 
     if (next_set_attr == kMaxAttrNum) {
         while (!found && attr <= this->max_attribute_number_) {
@@ -154,7 +154,7 @@ void FDTreeElement::AddFunctionalDependency(model::Bitset<FDTreeElement::kMaxAtt
     FDTreeElement* current_node = this;
     this->AddRhsAttribute(attr_num);
 
-    for (size_t i = lhs._Find_first(); i != kMaxAttrNum; i = lhs._Find_next(i)) {
+    for (size_t i = model::FindFirst(lhs); i != kMaxAttrNum; i = model::FindNext(lhs, i)) {
         if (current_node->children_[i - 1] == nullptr) {
             current_node->children_[i - 1] =
                     std::make_unique<FDTreeElement>(this->max_attribute_number_);
@@ -210,8 +210,8 @@ void FDTreeElement::TransformTreeFdCollection(
     for (size_t attr = 1; attr <= this->max_attribute_number_; ++attr) {
         if (this->is_fd_[attr - 1]) {
             boost::dynamic_bitset<> lhs_bitset(kMaxAttrNum);
-            for (size_t i = active_path._Find_first(); i != kMaxAttrNum;
-                 i = active_path._Find_next(i)) {
+            for (size_t i = model::FindFirst(active_path); i != kMaxAttrNum;
+                 i = model::FindNext(active_path, i)) {
                 if (i > 0) {
                     lhs_bitset.set(i - 1);
                 }

--- a/src/core/algorithms/fd/fdep/fdep.cpp
+++ b/src/core/algorithms/fd/fdep/fdep.cpp
@@ -74,8 +74,8 @@ void FDep::AddViolatedFDs(std::vector<size_t> const& t1, std::vector<size_t> con
     }
 
     equal_attr &= (~diff_attr);
-    for (size_t attr = diff_attr._Find_first(); attr != FDTreeElement::kMaxAttrNum;
-         attr = diff_attr._Find_next(attr)) {
+    for (size_t attr = model::FindFirst(diff_attr); attr != FDTreeElement::kMaxAttrNum;
+         attr = model::FindNext(diff_attr, attr)) {
         this->neg_cover_tree_->AddFunctionalDependency(equal_attr, attr);
     }
 }

--- a/src/core/algorithms/od/fastod/model/attribute_set.h
+++ b/src/core/algorithms/od/fastod/model/attribute_set.h
@@ -52,7 +52,7 @@ public:
     static AttributeSet FromVector(std::vector<int> const& indices) {
         model::Bitset<kBitsNum> bs;
         for (int idx : indices) {
-            bs._Unchecked_set(static_cast<std::size_t>(idx));
+            bs.set(static_cast<std::size_t>(idx));
         }
         return AttributeSet(std::move(bs));
     }

--- a/src/core/algorithms/od/fastod/model/attribute_set.h
+++ b/src/core/algorithms/od/fastod/model/attribute_set.h
@@ -112,11 +112,11 @@ public:
     }
 
     model::ColumnIndex FindFirst() const noexcept {
-        return bitset_._Find_first();
+        return model::FindFirst(bitset_);
     }
 
     model::ColumnIndex FindNext(model::ColumnIndex pos) const noexcept {
-        return bitset_._Find_next(pos);
+        return model::FindNext(bitset_, pos);
     }
 
     std::string ToString() const;

--- a/src/core/model/types/bitset.h
+++ b/src/core/model/types/bitset.h
@@ -533,7 +533,7 @@ public:
     }
 
     // Here's the only place where users of zero-length bitsets are penalized
-    // This function is unreachable until _Unchecked methods are used
+    // This function is unreachable until Unchecked methods are used
     [[noreturn]] WordT& GetWord([[maybe_unused]] size_t) noexcept {
         // Originally, here is `throw` statement, but it violates `noexcept` specification
         // throw std::out_of_range("BaseBitset::GetWord");
@@ -782,12 +782,12 @@ public:
     }
 
     // These methods starting with underscore are SGI extensions
-    BitsetImpl<NumBits>& _Unchecked_set(size_t pos) noexcept {
+    BitsetImpl<NumBits>& Unchecked_set(size_t pos) noexcept {
         this->GetWord(pos) |= Base::MaskBit(pos);
         return *this;
     }
 
-    BitsetImpl<NumBits>& _Unchecked_set(size_t pos, int val) noexcept {
+    BitsetImpl<NumBits>& Unchecked_set(size_t pos, int val) noexcept {
         if (val) {
             this->GetWord(pos) |= Base::MaskBit(pos);
         } else {
@@ -796,17 +796,17 @@ public:
         return *this;
     }
 
-    BitsetImpl<NumBits>& _Unchecked_reset(size_t pos) noexcept {
+    BitsetImpl<NumBits>& Unchecked_reset(size_t pos) noexcept {
         this->GetWord(pos) &= ~Base::MaskBit(pos);
         return *this;
     }
 
-    BitsetImpl<NumBits>& _Unchecked_flip(size_t pos) noexcept {
+    BitsetImpl<NumBits>& Unchecked_flip(size_t pos) noexcept {
         this->GetWord(pos) ^= Base::MaskBit(pos);
         return *this;
     }
 
-    constexpr bool _Unchecked_test(size_t pos) const noexcept {
+    constexpr bool Unchecked_test(size_t pos) const noexcept {
         return ((this->GetWord(pos) & Base::MaskBit(pos)) != static_cast<WordT>(0));
     }
 
@@ -818,7 +818,7 @@ public:
 
     BitsetImpl<NumBits>& set(size_t position, bool val = true) {
         this->Check(position, "BitsetImpl::set");
-        return _Unchecked_set(position, val);
+        return Unchecked_set(position, val);
     }
 
     BitsetImpl<NumBits>& reset() noexcept {
@@ -828,7 +828,7 @@ public:
 
     BitsetImpl<NumBits>& reset(size_t position) {
         this->Check(position, "BitsetImpl::reset");
-        return _Unchecked_reset(position);
+        return Unchecked_reset(position);
     }
 
     BitsetImpl<NumBits>& flip() noexcept {
@@ -839,7 +839,7 @@ public:
 
     BitsetImpl<NumBits>& flip(size_t position) {
         this->Check(position, "BitsetImpl::flip");
-        return _Unchecked_flip(position);
+        return Unchecked_flip(position);
     }
 
     BitsetImpl<NumBits> operator~() const noexcept {
@@ -851,7 +851,7 @@ public:
     }
 
     constexpr bool operator[](size_t position) const {
-        return _Unchecked_test(position);
+        return Unchecked_test(position);
     }
 
     unsigned long to_ulong() const {
@@ -920,7 +920,7 @@ public:
 
     bool test(size_t position) const {
         this->Check(position, "BitsetImpl::test");
-        return _Unchecked_test(position);
+        return Unchecked_test(position);
     }
 
     bool all() const noexcept {
@@ -943,11 +943,11 @@ public:
         return BitsetImpl<NumBits>(*this) >>= position;
     }
 
-    size_t _Find_first() const noexcept {
+    size_t FindFirst() const noexcept {
         return this->DoFindFirst(NumBits);
     }
 
-    size_t _Find_next(size_t prev) const noexcept {
+    size_t FindNext(size_t prev) const noexcept {
         return this->DoFindNext(prev, NumBits);
     }
 
@@ -1020,7 +1020,7 @@ void BitsetImpl<NumBits>::CopyFromPtr(CharT const* s, size_t len, size_t pos, si
         if (Traits::eq(c, zero)) {
             // Here's already zero
         } else if (Traits::eq(c, one)) {
-            _Unchecked_set(i - 1);
+            Unchecked_set(i - 1);
         } else {
             throw std::invalid_argument("BitsetImpl::CopyFromPtr");
         }
@@ -1032,10 +1032,10 @@ template <typename CharT, typename Traits, typename Alloc>
 void BitsetImpl<NumBits>::CopyToString(std::basic_string<CharT, Traits, Alloc>& s, CharT zero,
                                        CharT one) const {
     s.assign(NumBits, zero);
-    size_t n = this->_Find_first();
+    size_t n = this->FindFirst();
     while (n < NumBits) {
         s[NumBits - n - 1] = one;
-        n = _Find_next(n);
+        n = FindNext(n);
     }
 }
 
@@ -1169,6 +1169,26 @@ struct BitsetSelector<S> {
 
 template <size_t S>
 using Bitset = typename bitset_impl::BitsetSelector<S>::Type;
+
+template <size_t S>
+size_t FindFirst(std::bitset<S> const& bitset) noexcept {
+    return bitset._Find_first();
+}
+
+template <size_t S>
+size_t FindFirst(bitset_impl::BitsetImpl<S> const& bitset) noexcept {
+    return bitset.FindFirst();
+}
+
+template <size_t S>
+size_t FindNext(std::bitset<S> const& bitset, size_t n) noexcept {
+    return bitset._Find_next(n);
+}
+
+template <size_t S>
+size_t FindNext(bitset_impl::BitsetImpl<S> const& bitset, size_t n) noexcept {
+    return bitset.FindNext(n);
+}
 
 }  // namespace model
 

--- a/src/tests/unit/test_bitset.cpp
+++ b/src/tests/unit/test_bitset.cpp
@@ -430,7 +430,7 @@ TYPED_TEST_P(BitsetTest, FindFirst_libstdcxxExtensions) {
     typename TypeParam::Custom c{kVal1};
     typename TypeParam::STL s{kVal1};
 
-    EXPECT_EQ(c._Find_first(), s._Find_first());
+    EXPECT_EQ(model::FindFirst(c), model::FindFirst(s));
 #else
     GTEST_SKIP() << "SGI extensions unavailable";
 #endif
@@ -441,7 +441,7 @@ TYPED_TEST_P(BitsetTest, FindNext_libstdcxxExtensions) {
     typename TypeParam::Custom c{kVal1};
     typename TypeParam::STL s{kVal1};
 
-    EXPECT_EQ(c._Find_next(2), s._Find_next(2));
+    EXPECT_EQ(model::FindNext(c, 2), model::FindNext(s, 2));
 #else
     GTEST_SKIP() << "SGI extensions unavailable";
 #endif


### PR DESCRIPTION
Rename _Find_first and _Find_next functions to FindFirst and FindNext (along with some other functions) in a "self-hosted" copy of GCC bitset as names like `_Xx` are "reserved by implementation for any use" (see [lex.name](https://timsong-cpp.github.io/cppwp/std23/lex.name#3.1))