### PR TITLE
fix ind CMakeLists.txt

### DIFF
--- a/src/core/algorithms/ind/mind/CMakeLists.txt
+++ b/src/core/algorithms/ind/mind/CMakeLists.txt
@@ -3,5 +3,5 @@ desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE mind.cpp)
 target_link_libraries(
     ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::config ${DESBORDANTE_PREFIX}::util
-                    spdlog::spdlog_header_only Boost::headers
+                    ${DESBORDANTE_PREFIX}::ind::spider spdlog::spdlog_header_only Boost::headers
 )

--- a/src/core/algorithms/ind/spider/CMakeLists.txt
+++ b/src/core/algorithms/ind/spider/CMakeLists.txt
@@ -1,4 +1,6 @@
 set(NAME ind.spider)
 desbordante_add_lib(NAME)
 target_sources(${NAME} PRIVATE spider.cpp attribute.cpp)
-target_link_libraries(${NAME} PRIVATE ${DESBORDANTE_PREFIX}::util Boost::headers)
+target_link_libraries(
+    ${NAME} PRIVATE ${DESBORDANTE_PREFIX}::util ${DESBORDANTE_PREFIX}::model::table Boost::headers
+)


### PR DESCRIPTION
**Error:** Linking `Desbordante.benchmark` fails with undefined reference to `algos::Spider::Spider()` from `mind.cpp.o`. 
```bash
[524/526] Linking CXX executable target/Desbordante.benchmark
FAILED: [code=1] target/Desbordante.benchmark 
: && /opt/gcc-16/bin/g++ -O3 -O3 -DNDEBUG  src/tests/common/CMakeFiles/Desbordante.testlib.common.dir/all_csv_configs.cpp.o src/tests/common/CMakeFiles/Desbordante.testlib.common.dir/all_sequence_paths.cpp.o src/core/algorithms/ind/CMakeFiles/Desbordante.ind.dir/ind.cpp.o src/core/algorithms/ind/CMakeFiles/Desbordante.ind.dir/ind_algorithm.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/indexes/dictionary_compressor.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/indexes/keyed_position_list_index.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/indexes/records_info.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/indexes/similarity_index.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/preprocessing/column_matches/jaccard.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/preprocessing/column_matches/lcs.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/preprocessing/column_matches/levenshtein.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/preprocessing/column_matches/monge_elkan.cpp.o src/core/algorithms/md/hymd/CMakeFiles/Desbordante.md.hy.preprocessing.dir/preprocessing/column_matches/smith_waterman_gotoh.cpp.o src/tests/benchmark/CMakeFiles/Desbordante.benchmark.dir/main.cpp.o src/tests/benchmark/CMakeFiles/Desbordante.benchmark.dir/benchmark_cli.cpp.o src/tests/benchmark/CMakeFiles/Desbordante.benchmark.dir/benchmark_comparer.cpp.o -o target/Desbordante.benchmark  src/core/algorithms/dc/FastADC/libDesbordante.dc.fastadc.a  src/core/algorithms/dd/split/libDesbordante.dd.split.a  src/core/algorithms/ind/mind/libDesbordante.ind.mind.a  src/core/algorithms/fd/hyfd/libDesbordante.fd.hy.a  src/core/algorithms/fd/pyro/libDesbordante.fd.pyro.a  src/core/algorithms/fd/tane/libDesbordante.fd.tane.a  src/core/algorithms/fd/aidfd/libDesbordante.fd.aid.a  src/core/algorithms/md/hymd/libDesbordante.md.hy.a  src/core/algorithms/nar/des/libDesbordante.nar.des.a  /usr/lib/x86_64-linux-gnu/libboost_program_options.so.1.90.0  /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.90.0  /usr/lib/x86_64-linux-gnu/libboost_atomic.so.1.90.0  /usr/lib/x86_64-linux-gnu/libboost_chrono.so.1.90.0  /usr/lib/x86_64-linux-gnu/libboost_date_time.so.1.90.0  src/core/algorithms/libDesbordante.algos.a  /usr/lib/x86_64-linux-gnu/libboost_container.so.1.90.0 && :
/usr/bin/x86_64-linux-gnu-ld.bfd: src/core/algorithms/ind/mind/libDesbordante.ind.mind.a(mind.cpp.o): in function `algos::Mind::MakeLoadOptsAvailable()':
mind.cpp:(.text+0x137a): undefined reference to `algos::Spider::Spider()'
/usr/bin/x86_64-linux-gnu-ld.bfd: src/core/algorithms/ind/mind/libDesbordante.ind.mind.a(mind.cpp.o): in function `algos::Mind::Mind()':
mind.cpp:(.text+0x86f1): undefined reference to `algos::Spider::Spider()'
collect2: error: ld returned 1 exit status
[525/526] Building CXX object src/python_bindings/CMakeFiles/Desbordante.bind.sd.dir/sd/bind_sd_verification.cpp.o
ninja: build stopped: subcommand failed.
```
**Build:** `./build.sh -p -b -j4 -f`  
**Compiler:** g++ (GCC) 16.1.0  