### PR TITLE
Optimize custom metrics by using a type holder

### DIFF
--- a/src/core/config/custom_metric/custom_metric/option.cpp
+++ b/src/core/config/custom_metric/custom_metric/option.cpp
@@ -6,16 +6,17 @@
 namespace config {
 
 namespace {
-void Normalize(CustomMetricType& value) {
+void Normalize(CustomMetricOptionType& value) {
     if (!value) {
         value = std::make_shared<util::DefaultCustomMetric>();
     }
 }
 }  // namespace
 
-Option<CustomMetricType> MetricOption(CustomMetricType* value_ptr, std::string_view name,
-                                      std::string_view description) {
-    Option<CustomMetricType> option{value_ptr, name, description, CustomMetricType{nullptr}};
+Option<CustomMetricOptionType> MetricOption(CustomMetricOptionType* value_ptr,
+                                            std::string_view name, std::string_view description) {
+    Option<CustomMetricOptionType> option{value_ptr, name, description,
+                                          CustomMetricOptionType{nullptr}};
     option.SetNormalizeFunc(&Normalize);
     return option;
 }

--- a/src/core/config/custom_metric/custom_metric/option.h
+++ b/src/core/config/custom_metric/custom_metric/option.h
@@ -8,7 +8,7 @@
 #include "core/config/option.h"
 
 namespace config {
-Option<CustomMetricType> MetricOption(CustomMetricType* value_ptr,
-                                      std::string_view name = names::kCustomMetric,
-                                      std::string_view description = descriptions::kDCustomMetric);
+Option<CustomMetricOptionType> MetricOption(
+        CustomMetricOptionType* value_ptr, std::string_view name = names::kCustomMetric,
+        std::string_view description = descriptions::kDCustomMetric);
 }  // namespace config

--- a/src/core/config/custom_metric/custom_metric/type.h
+++ b/src/core/config/custom_metric/custom_metric/type.h
@@ -5,5 +5,6 @@
 #include "core/util/custom_metric/custom_metric.h"
 
 namespace config {
-using CustomMetricType = std::shared_ptr<util::ICustomMetric>;
+using CustomMetricOptionType = std::shared_ptr<util::ICustomMetric>;
+using CustomMetricType = std::unique_ptr<util::ICustomMetric::ITypedMetric>;
 }  // namespace config

--- a/src/core/config/custom_metric/custom_metrics/option.cpp
+++ b/src/core/config/custom_metric/custom_metrics/option.cpp
@@ -7,12 +7,12 @@
 #include "core/config/option.h"
 
 namespace config {
-Option<CustomMetricsType> MetricsOption::operator()(
-        CustomMetricsType* value_ptr, std::function<IndexType()> get_col_count) const {
+Option<CustomMetricsOptionType> MetricsOption::operator()(
+        CustomMetricsOptionType* value_ptr, std::function<IndexType()> get_col_count) const {
     assert(get_col_count);
     auto make_default = [get_col_count]() { return MakeDefaultMetrics(get_col_count()); };
-    auto option = Option<CustomMetricsType>(value_ptr, name_, description_, make_default);
-    option.SetValueCheck([get_col_count](CustomMetricsType const& value) {
+    auto option = Option<CustomMetricsOptionType>(value_ptr, name_, description_, make_default);
+    option.SetValueCheck([get_col_count](CustomMetricsOptionType const& value) {
         return CheckMetrics(value, get_col_count());
     });
     option.SetNormalizeFunc(NormalizeMetrics);

--- a/src/core/config/custom_metric/custom_metrics/option.h
+++ b/src/core/config/custom_metric/custom_metrics/option.h
@@ -21,11 +21,11 @@ private:
     std::string_view name_;
     std::string_view description_;
 
-    static CustomMetricsType MakeDefaultMetrics(std::size_t indices_count) {
-        return CustomMetricsType(indices_count, nullptr);
+    static CustomMetricsOptionType MakeDefaultMetrics(std::size_t indices_count) {
+        return CustomMetricsOptionType(indices_count, nullptr);
     }
 
-    static void CheckMetrics(CustomMetricsType const& value, std::size_t indices_count) {
+    static void CheckMetrics(CustomMetricsOptionType const& value, std::size_t indices_count) {
         if (value.size() != indices_count) {
             std::ostringstream msg;
             msg << "Expected " << indices_count << " user-defined metrics, got " << value.size();
@@ -34,7 +34,7 @@ private:
     }
 
     /// User can pass @c nullptr to use the default metric explicitly
-    static void NormalizeMetrics(CustomMetricsType& value) {
+    static void NormalizeMetrics(CustomMetricsOptionType& value) {
         auto default_metric = std::make_shared<util::DefaultCustomMetric>();
 
         std::ranges::replace_if(value, std::logical_not{}, default_metric);
@@ -47,7 +47,7 @@ public:
 
     // NOTE: This option should depend on indices option (see @c SetConditionalOpts)
     // to properly get column count
-    [[nodiscard]] Option<CustomMetricsType> operator()(
-            CustomMetricsType* value_ptr, std::function<IndexType()> get_col_count) const;
+    [[nodiscard]] Option<CustomMetricsOptionType> operator()(
+            CustomMetricsOptionType* value_ptr, std::function<IndexType()> get_col_count) const;
 };
 }  // namespace config

--- a/src/core/config/custom_metric/custom_metrics/type.h
+++ b/src/core/config/custom_metric/custom_metrics/type.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 
-#include "core/util/custom_metric/custom_metric.h"
+#include "core/config/custom_metric/custom_metric/type.h"
 
 namespace config {
-using CustomMetricsType = std::vector<std::shared_ptr<util::ICustomMetric>>;
+using CustomMetricsOptionType = std::vector<CustomMetricOptionType>;
+using CustomMetricsType = std::vector<CustomMetricType>;
 }  // namespace config

--- a/src/core/config/custom_metric/custom_vector_metric/option.cpp
+++ b/src/core/config/custom_metric/custom_vector_metric/option.cpp
@@ -3,18 +3,18 @@
 namespace config {
 
 namespace {
-void Normalize(CustomVectorMetricType& value) {
+void Normalize(CustomVectorMetricOptionType& value) {
     if (!value) {
         value = std::make_shared<util::DefaultCustomVectorMetric>();
     }
 }
 }  // namespace
 
-Option<CustomVectorMetricType> VectorMetricOption(CustomVectorMetricType* value_ptr,
-                                                  std::string_view name,
-                                                  std::string_view description) {
-    Option<CustomVectorMetricType> option{value_ptr, name, description,
-                                          CustomVectorMetricType{nullptr}};
+Option<CustomVectorMetricOptionType> VectorMetricOption(CustomVectorMetricOptionType* value_ptr,
+                                                        std::string_view name,
+                                                        std::string_view description) {
+    Option<CustomVectorMetricOptionType> option{value_ptr, name, description,
+                                                CustomVectorMetricOptionType{nullptr}};
     option.SetNormalizeFunc(&Normalize);
     return option;
 }

--- a/src/core/config/custom_metric/custom_vector_metric/option.h
+++ b/src/core/config/custom_metric/custom_vector_metric/option.h
@@ -8,7 +8,7 @@
 #include "core/config/option.h"
 
 namespace config {
-Option<CustomVectorMetricType> VectorMetricOption(
-        CustomVectorMetricType* value_ptr, std::string_view name = names::kCustomMetric,
+Option<CustomVectorMetricOptionType> VectorMetricOption(
+        CustomVectorMetricOptionType* value_ptr, std::string_view name = names::kCustomMetric,
         std::string_view description = descriptions::kDCustomMetric);
 }  // namespace config

--- a/src/core/config/custom_metric/custom_vector_metric/type.h
+++ b/src/core/config/custom_metric/custom_vector_metric/type.h
@@ -5,5 +5,6 @@
 #include "core/util/custom_metric/custom_vector_metric.h"
 
 namespace config {
-using CustomVectorMetricType = std::shared_ptr<util::ICustomVectorMetric>;
+using CustomVectorMetricOptionType = std::shared_ptr<util::ICustomVectorMetric>;
+using CustomVectorMetricType = std::unique_ptr<util::ICustomVectorMetric::ITypedMetric>;
 }  // namespace config

--- a/src/core/util/custom_metric/custom_metric.h
+++ b/src/core/util/custom_metric/custom_metric.h
@@ -122,7 +122,7 @@ public:
             type_ = dynamic_cast<model::IMetrizableType const*>(type);
             if (!type_) {
                 std::ostringstream msg;
-                msg << "Cannot use default metric, because column " << "type " << type->ToString();
+                msg << "Cannot use default metric, because column type " << type->ToString();
                 if (!column_name.empty()) {
                     msg << " for column " << column_name;
                 }

--- a/src/core/util/custom_metric/custom_metric.h
+++ b/src/core/util/custom_metric/custom_metric.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <functional>
+#include <memory>
 #include <optional>
 #include <sstream>
+#include <string>
 #include <utility>
 
 #include "core/config/exceptions.h"
@@ -21,10 +24,22 @@ namespace util {
 /// WARN: NULL value is represented by nullptr
 class DESBORDANTE_EXPORT ICustomMetric {
 public:
+    /// @brief A user-defined metric populated with type
+    /// Even though interface doesn't bind TypedMetric to a column, it is highly recommended to use
+    /// a dedicated TypedMetric for each column to avoid unexpected results (because this type is
+    /// generally user-defined)
+    class DESBORDANTE_EXPORT ITypedMetric {
+    public:
+        virtual ~ITypedMetric() = default;
+        virtual double operator()(std::byte const* a, std::byte const* b) const = 0;
+    };
+
     virtual ~ICustomMetric() = default;
 
-    virtual double Dist(model::Type const* type, std::byte const* first,
-                        std::byte const* second) const = 0;
+    // NOTE: column_name should be used only to emit more informative error messages.
+    // Do not try to reconstruct any column info depending on it
+    virtual std::unique_ptr<ITypedMetric> SetType(model::Type const* type,
+                                                  std::string const& column_name = "") const = 0;
 };
 
 /// @brief Provides a convenient way to define custom metric, when column type is known in advance
@@ -45,11 +60,22 @@ private:
     }
 
 public:
+    class TypedMetric : public ITypedMetric {
+    private:
+        Metric metric_;
+
+    public:
+        explicit TypedMetric(Metric metric) : metric_(std::move(metric)) {}
+
+        double operator()(std::byte const* a, std::byte const* b) const override {
+            return metric_(GetValue(a), GetValue(b));
+        }
+    };
+
     explicit StaticCustomMetric(Metric metric) : metric_(std::move(metric)) {}
 
-    double Dist(model::Type const*, std::byte const* first,
-                std::byte const* second) const override {
-        return metric_(GetValue(first), GetValue(second));
+    std::unique_ptr<ITypedMetric> SetType(model::Type const*, std::string const&) const {
+        return std::make_unique<TypedMetric>(metric_);
     }
 };
 
@@ -61,36 +87,61 @@ private:
     Metric metric_;
 
 public:
+    class TypedMetric : public ITypedMetric {
+    private:
+        Metric metric_;
+        model::Type const* type_;
+
+    public:
+        TypedMetric(Metric metric, model::Type const* type)
+            : metric_(std::move(metric)), type_(type) {}
+
+        double operator()(std::byte const* a, std::byte const* b) const override {
+            return metric_(type_, a, b);
+        }
+    };
+
     explicit DynamicCustomMetric(Metric metric) : metric_(std::move(metric)) {}
 
-    double Dist(model::Type const* type, std::byte const* first,
-                std::byte const* second) const override {
-        return metric_(type, first, second);
+    std::unique_ptr<ITypedMetric> SetType(model::Type const* type,
+                                          std::string const&) const override {
+        return std::make_unique<TypedMetric>(metric_, type);
     }
 };
 
 /// @brief A default value for custom metric option
 /// Uses default metric for the type. Works only with metrizable types
 class DefaultCustomMetric : public ICustomMetric {
-private:
-    static model::IMetrizableType const* ConvertType(model::Type const* type) {
-        auto const* metr_type = dynamic_cast<model::IMetrizableType const*>(type);
-        if (!metr_type) {
-            std::ostringstream msg;
-            msg << "Cannot use default metric, because column type " << type->ToString()
-                << " is not metrizable. Consider defining custom metric";
-            throw config::ConfigurationError(msg.str());
-        }
-        return metr_type;
-    }
-
 public:
-    double Dist(model::Type const* type, std::byte const* first,
-                std::byte const* second) const override {
-        if (!first || !second) {
-            return 0;
+    class TypedMetric : public ITypedMetric {
+    private:
+        model::IMetrizableType const* type_;
+
+    public:
+        explicit TypedMetric(model::Type const* type, std::string const& column_name = "") {
+            type_ = dynamic_cast<model::IMetrizableType const*>(type);
+            if (!type_) {
+                std::ostringstream msg;
+                msg << "Cannot use default metric, because column " << "type " << type->ToString();
+                if (!column_name.empty()) {
+                    msg << " for column " << column_name;
+                }
+                msg << " is not metrizable. Consider defining custom metric";
+                throw config::ConfigurationError(msg.str());
+            }
         }
-        return ConvertType(type)->Dist(first, second);
+
+        double operator()(std::byte const* a, std::byte const* b) const override {
+            if (!a || !b) {
+                return 0;
+            }
+            return type_->Dist(a, b);
+        }
+    };
+
+    std::unique_ptr<ITypedMetric> SetType(model::Type const* type,
+                                          std::string const& column_name) const override {
+        return std::make_unique<TypedMetric>(type, column_name);
     }
 };
 }  // namespace util

--- a/src/core/util/custom_metric/custom_vector_metric.h
+++ b/src/core/util/custom_metric/custom_vector_metric.h
@@ -12,6 +12,8 @@
 #include "core/model/types/type.h"
 #include "core/util/export.h"
 
+// TODO: vector metrics
+
 namespace util {
 /// @brief User-defined metric on a set of columns, that treats values as tuples (vectors)
 /// Together with @c PyCustomVectorMetric and @c CustomVectorMetric provides

--- a/src/core/util/custom_metric/custom_vector_metric.h
+++ b/src/core/util/custom_metric/custom_vector_metric.h
@@ -4,6 +4,9 @@
 #include <cmath>
 #include <cstddef>
 #include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -27,9 +30,22 @@ protected:
     using Values = std::vector<std::byte const*>;
 
 public:
+    /// @brief A user-defined metric populated with type
+    /// Even though interface doesn't bind TypedMetric to a column, it is highly recommended to use
+    /// a dedicated TypedMetric for each column to avoid unexpected results (because this type is
+    /// generally user-defined)
+    class DESBORDANTE_EXPORT ITypedMetric {
+    public:
+        virtual ~ITypedMetric() = default;
+        virtual double operator()(Values const& a, Values const& b) const = 0;
+    };
+
     virtual ~ICustomVectorMetric() = default;
 
-    virtual double Dist(Types const& types, Values const& first, Values const& second) const = 0;
+    // NOTE: column_name should be used only to emit more informative error messages.
+    // Do not try to reconstruct any column info depending on it
+    virtual std::unique_ptr<ITypedMetric> SetTypes(
+            Types const& types, std::vector<std::string> const& column_names = {}) const = 0;
 };
 
 /// @brief A custom vector metric, which uses real column types
@@ -40,10 +56,25 @@ private:
     Metric metric_;
 
 public:
+    class TypedMetric : public ITypedMetric {
+    private:
+        Metric metric_;
+        Types types_;
+
+    public:
+        TypedMetric(Metric metric, Types types)
+            : metric_(std::move(metric)), types_(std::move(types)) {}
+
+        double operator()(Values const& a, Values const& b) const override {
+            return metric_(types_, a, b);
+        }
+    };
+
     explicit CustomVectorMetric(Metric metric) : metric_(std::move(metric)) {}
 
-    double Dist(Types const& types, Values const& first, Values const& second) const override {
-        return metric_(types, first, second);
+    std::unique_ptr<ITypedMetric> SetTypes(Types const& types,
+                                           std::vector<std::string> const&) const {
+        return std::make_unique<TypedMetric>(metric_, types);
     }
 };
 
@@ -64,17 +95,48 @@ private:
     }
 
 public:
-    double Dist(Types const& types, Values const& first, Values const& second) const override {
-        assert(types.size() == first.size() && types.size() == second.size());
+    class TypedMetric : public ITypedMetric {
+    private:
+        std::vector<model::IMetrizableType const*> types_;
 
-        double result = 0;
-        for (std::size_t i = 0; i < types.size(); ++i) {
-            if (first[i] && second[i]) {
-                double dist = ConvertType(types[i])->Dist(first[i], second[i]);
-                result += dist * dist;
+    public:
+        TypedMetric(Types const& types, std::vector<std::string> const& column_names) {
+            assert(column_names.empty() || types.size() == column_names.size());
+
+            types_.reserve(types.size());
+            for (std::size_t i = 0; i < types.size(); ++i) {
+                auto metr_type = dynamic_cast<model::IMetrizableType const*>(types[i]);
+                if (!metr_type) {
+                    std::ostringstream msg;
+                    msg << "Cannot use default metric, because column type "
+                        << types[i]->ToString();
+                    if (!column_names.empty()) {
+                        msg << " for column " << column_names[i];
+                    }
+                    msg << " is not metrizable. Consider using custom metric";
+                    throw config::ConfigurationError(msg.str());
+                }
+                types_.push_back(metr_type);
             }
         }
-        return std::sqrt(result);
+
+        double operator()(Values const& a, Values const& b) const override {
+            assert(types_.size() == a.size() && types_.size() == b.size());
+
+            double result = 0;
+            for (std::size_t i = 0; i < types_.size(); ++i) {
+                if (a[i] && b[i]) {
+                    double dist = ConvertType(types_[i])->Dist(a[i], b[i]);
+                    result += dist * dist;
+                }
+            }
+            return std::sqrt(result);
+        }
+    };
+
+    std::unique_ptr<ITypedMetric> SetTypes(
+            Types const& types, std::vector<std::string> const& column_names = {}) const override {
+        return std::make_unique<TypedMetric>(types, column_names);
     }
 };
 }  // namespace util

--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -145,8 +145,9 @@ py::tuple GetPyType(std::type_index type_index) {
             kPyTypePair<std::vector<double>, &PyList_Type, &PyFloat_Type>,
             {typeid(std::shared_ptr<pac::model::IDomain>),
              []() { return MakeTypeTuple(py::type::of<pac::model::IDomain>()); }},
-            kPyTypePair<config::CustomMetricType, &PyFunction_Type>,
-            kPyTypePair<config::CustomMetricsType, &PyList_Type, &PyFunction_Type>,
+            kPyTypePair<config::CustomMetricOptionType, &PyFunction_Type>,
+            kPyTypePair<config::CustomMetricsOptionType, &PyList_Type, &PyFunction_Type>,
+            // TODO: CustomVectorMetricOptionType
             kPyTypePair<config::CustomVectorMetricType, &PyFunction_Type>,
             {typeid(algos::cfd::RawCFD),
              [] { return MakeTypeTuple(py::type::of<algos::cfd::RawCFD>()); }},

--- a/src/python_bindings/py_util/get_py_type.cpp
+++ b/src/python_bindings/py_util/get_py_type.cpp
@@ -147,8 +147,7 @@ py::tuple GetPyType(std::type_index type_index) {
              []() { return MakeTypeTuple(py::type::of<pac::model::IDomain>()); }},
             kPyTypePair<config::CustomMetricOptionType, &PyFunction_Type>,
             kPyTypePair<config::CustomMetricsOptionType, &PyList_Type, &PyFunction_Type>,
-            // TODO: CustomVectorMetricOptionType
-            kPyTypePair<config::CustomVectorMetricType, &PyFunction_Type>,
+            kPyTypePair<config::CustomVectorMetricOptionType, &PyFunction_Type>,
             {typeid(algos::cfd::RawCFD),
              [] { return MakeTypeTuple(py::type::of<algos::cfd::RawCFD>()); }},
     };

--- a/src/python_bindings/py_util/opt_to_py.cpp
+++ b/src/python_bindings/py_util/opt_to_py.cpp
@@ -64,8 +64,7 @@ std::unordered_map<std::type_index, ConvFunction> const kConverters{
         kNormalConvPair<std::shared_ptr<pac::model::IDomain>>,
         kNormalConvPair<config::CustomMetricOptionType>,
         kNormalConvPair<config::CustomMetricsOptionType>,
-        // TODO: CustomVectorMetricType
-        kNormalConvPair<config::CustomVectorMetricType>,
+        kNormalConvPair<config::CustomVectorMetricOptionType>,
         kEnumConvPair<algos::metric::MetricAlgo>,
         kEnumConvPair<algos::metric::Metric>,
         kEnumConvPair<model::InputFormatType>,

--- a/src/python_bindings/py_util/opt_to_py.cpp
+++ b/src/python_bindings/py_util/opt_to_py.cpp
@@ -62,8 +62,9 @@ std::unordered_map<std::type_index, ConvFunction> const kConverters{
         kNormalConvPair<model::Gdd>,
         kNormalConvPair<algos::cfd::RawCFD>,
         kNormalConvPair<std::shared_ptr<pac::model::IDomain>>,
-        kNormalConvPair<config::CustomMetricType>,
-        kNormalConvPair<config::CustomMetricsType>,
+        kNormalConvPair<config::CustomMetricOptionType>,
+        kNormalConvPair<config::CustomMetricsOptionType>,
+        // TODO: CustomVectorMetricType
         kNormalConvPair<config::CustomVectorMetricType>,
         kEnumConvPair<algos::metric::MetricAlgo>,
         kEnumConvPair<algos::metric::Metric>,

--- a/src/python_bindings/py_util/py_custom_metrics.h
+++ b/src/python_bindings/py_util/py_custom_metrics.h
@@ -42,16 +42,30 @@ public:
     }
 };
 
-// TODO: py custom vector metric
 class PyCustomVectorMetric : public util::ICustomVectorMetric {
 private:
     pybind11::object metric_;
 
 public:
+    class TypedMetric : public ITypedMetric {
+    private:
+        pybind11::object metric_;
+        Types types_;
+
+    public:
+        TypedMetric(pybind11::object metric, Types const& types)
+            : metric_(std::move(metric)), types_(types) {}
+
+        double operator()(Values const& a, Values const& b) const override {
+            return pybind11::cast<double>(metric_(ValuesToPy(types_, a), ValuesToPy(types_, b)));
+        }
+    };
+
     explicit PyCustomVectorMetric(pybind11::object&& metric) : metric_(std::move(metric)) {}
 
-    double Dist(Types const& types, Values const& first, Values const& second) const override {
-        return pybind11::cast<double>(metric_(ValuesToPy(types, first), ValuesToPy(types, second)));
+    std::unique_ptr<ITypedMetric> SetTypes(Types const& types,
+                                           std::vector<std::string> const&) const override {
+        return std::make_unique<TypedMetric>(metric_, types);
     }
 };
 

--- a/src/python_bindings/py_util/py_custom_metrics.h
+++ b/src/python_bindings/py_util/py_custom_metrics.h
@@ -3,6 +3,8 @@
 #include <pybind11/pybind11.h>
 
 #include <cstddef>
+#include <memory>
+#include <string>
 #include <utility>
 
 #include <pybind11/pytypes.h>
@@ -18,14 +20,29 @@ private:
     pybind11::object metric_;
 
 public:
+    class TypedMetric : public ITypedMetric {
+    private:
+        pybind11::object metric_;
+        model::Type const* type_;
+
+    public:
+        TypedMetric(pybind11::object metric, model::Type const* type)
+            : metric_(std::move(metric)), type_(type) {}
+
+        double operator()(std::byte const* a, std::byte const* b) const override {
+            return pybind11::cast<double>(metric_(ValueToPy(type_, a), ValueToPy(type_, b)));
+        }
+    };
+
     explicit PyCustomMetric(pybind11::object&& metric) : metric_(std::move(metric)) {}
 
-    double Dist(model::Type const* type, std::byte const* first,
-                std::byte const* second) const override {
-        return pybind11::cast<double>(metric_(ValueToPy(type, first), ValueToPy(type, second)));
+    std::unique_ptr<ITypedMetric> SetType(model::Type const* type,
+                                          std::string const&) const override {
+        return std::make_unique<TypedMetric>(metric_, type);
     }
 };
 
+// TODO: py custom vector metric
 class PyCustomVectorMetric : public util::ICustomVectorMetric {
 private:
     pybind11::object metric_;

--- a/src/python_bindings/py_util/py_to_any.cpp
+++ b/src/python_bindings/py_util/py_to_any.cpp
@@ -201,15 +201,15 @@ boost::any StringVectorToAny(std::string_view option_name, py::handle obj) {
 }
 
 boost::any CustomMetricToAny(std::string_view, py::handle obj) {
-    return config::CustomMetricType{
+    return config::CustomMetricOptionType{
             new python_bindings::PyCustomMetric(py::reinterpret_borrow<py::object>(obj))};
 }
 
 boost::any CustomMetricsToAny(std::string_view option_name, py::handle obj) {
     auto metric_handles = CastAndReplaceCastError<std::vector<py::handle>>(option_name, obj);
-    config::CustomMetricsType result(metric_handles.size());
+    config::CustomMetricsOptionType result(metric_handles.size());
     std::ranges::transform(metric_handles, result.begin(),
-                           [](py::handle handle) -> config::CustomMetricType {
+                           [](py::handle handle) -> config::CustomMetricOptionType {
                                if (handle.is_none()) {
                                    return nullptr;
                                }
@@ -220,6 +220,7 @@ boost::any CustomMetricsToAny(std::string_view option_name, py::handle obj) {
 }
 
 boost::any CustomVectorMetricToAny(std::string_view, py::handle obj) {
+    // TODO: CustomVectorMetricOptionType
     return config::CustomVectorMetricType{
             new python_bindings::PyCustomVectorMetric(py::reinterpret_borrow<py::object>(obj))};
 }

--- a/src/python_bindings/py_util/py_to_any.cpp
+++ b/src/python_bindings/py_util/py_to_any.cpp
@@ -220,8 +220,7 @@ boost::any CustomMetricsToAny(std::string_view option_name, py::handle obj) {
 }
 
 boost::any CustomVectorMetricToAny(std::string_view, py::handle obj) {
-    // TODO: CustomVectorMetricOptionType
-    return config::CustomVectorMetricType{
+    return config::CustomVectorMetricOptionType{
             new python_bindings::PyCustomVectorMetric(py::reinterpret_borrow<py::object>(obj))};
 }
 


### PR DESCRIPTION
Trying to get rid of lots of `dynamic_cast`s in custom metrics
Some measurements on Iowa datasets (default metrics, PACs of low arities), FD PAC verifier:
- Flamegraph before: 
<img width="1200" height="470" alt="flamegraph-before" src="https://github.com/user-attachments/assets/af780db7-8066-41eb-b55c-6b02b788b8b4" />
- Flamegraph after:
<img width="1200" height="678" alt="flamegraph-metrizer" src="https://github.com/user-attachments/assets/1f7f4a4e-b6e3-4016-8243-550d972e5418" />
- Execution time before:
[baseline-fd-pac-iowas-low-arities.pdf](https://github.com/user-attachments/files/31847308/baseline-fd-pac-iowas-low-arities.pdf)
- Execution time after:
[metrizer-fd-pac-iowas-low-arities.pdf](https://github.com/user-attachments/files/31847316/metrizer-fd-pac-iowas-low-arities.pdf)

You can find usage examples in https://github.com/p-senichenkov/Desbordante/pull/12 and https://github.com/p-senichenkov/Desbordante/pull/14